### PR TITLE
Update claims in TokenService and add mobile phone claim

### DIFF
--- a/src/api/framework/Infrastructure/Identity/Tokens/TokenService.cs
+++ b/src/api/framework/Infrastructure/Identity/Tokens/TokenService.cs
@@ -134,9 +134,10 @@ public sealed class TokenService : ITokenService
         new List<Claim>
         {
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new(JwtRegisteredClaimNames.Sub, user.Id),
-            new(JwtRegisteredClaimNames.Email, user.Email!),
-            new(JwtRegisteredClaimNames.Name, user.FirstName ?? string.Empty),
+            new(ClaimTypes.NameIdentifier, user.Id),
+            new(ClaimTypes.Email, user.Email!),
+            new(ClaimTypes.Name, user.FirstName ?? string.Empty),
+            new(ClaimTypes.MobilePhone, user.PhoneNumber ?? string.Empty),
             new(FshClaims.Fullname, $"{user.FirstName} {user.LastName}"),
             new(ClaimTypes.Surname, user.LastName ?? string.Empty),
             new(FshClaims.IpAddress, ipAddress),


### PR DESCRIPTION
Fix for #1049 thanks to @kallievz

I've checked this and it works. I'm simply creating a pull request with a fix from @kallievz 

**Description:**
Replaced JwtRegisteredClaimNames with ClaimTypes for NameIdentifier, Email, and Name in the GetClaims method. Added a new claim for ClaimTypes.MobilePhone to include the user's phone number.