### PR TITLE
Update Specification extensions.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,8 +9,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.Specification" Version="8.0.0" />
-    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
+    <PackageVersion Include="Ardalis.Specification" Version="9.0.1" />
+    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.0.1" />
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />

--- a/src/api/framework/Core/Specifications/EntitiesByBaseFilterSpec.cs
+++ b/src/api/framework/Core/Specifications/EntitiesByBaseFilterSpec.cs
@@ -3,13 +3,13 @@ using FSH.Framework.Core.Paging;
 
 namespace FSH.Framework.Core.Specifications;
 
-public class EntitiesByBaseFilterSpec<T, TResult> : Specification<T, TResult>
+public class EntitiesByBaseFilterSpec<T, TResult> : Specification<T, TResult> where T : class
 {
     public EntitiesByBaseFilterSpec(BaseFilter filter) =>
         Query.SearchBy(filter);
 }
 
-public class EntitiesByBaseFilterSpec<T> : Specification<T>
+public class EntitiesByBaseFilterSpec<T> : Specification<T> where T : class
 {
     public EntitiesByBaseFilterSpec(BaseFilter filter) =>
         Query.SearchBy(filter);

--- a/src/api/framework/Core/Specifications/EntitiesByPaginationFilterSpec.cs
+++ b/src/api/framework/Core/Specifications/EntitiesByPaginationFilterSpec.cs
@@ -2,14 +2,14 @@
 
 namespace FSH.Framework.Core.Specifications;
 
-public class EntitiesByPaginationFilterSpec<T, TResult> : EntitiesByBaseFilterSpec<T, TResult>
+public class EntitiesByPaginationFilterSpec<T, TResult> : EntitiesByBaseFilterSpec<T, TResult> where T : class
 {
     public EntitiesByPaginationFilterSpec(PaginationFilter filter)
         : base(filter) =>
         Query.PaginateBy(filter);
 }
 
-public class EntitiesByPaginationFilterSpec<T> : EntitiesByBaseFilterSpec<T>
+public class EntitiesByPaginationFilterSpec<T> : EntitiesByBaseFilterSpec<T> where T : class
 {
     public EntitiesByPaginationFilterSpec(PaginationFilter filter)
         : base(filter) =>


### PR DESCRIPTION
Fixes #1109 

Updated specification extensions and bumped the version to 9.0.1

- There is no need to return `IOrderedSpecificationBuilder` from the extension methods, we should return `ISpecificationBuilder`.
- Avoid relying on the internals and use public behavior. Removed the state casting.
- Other minor fixes.