### PR TITLE
Fix: Docker Service Running with Unsafe Writable File System in compose/docker-compose.yml

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -174,7 +174,12 @@ services:
       - fullstackhero
 
   node_exporter:
+read_only: true
+    read_only: true
+    tmpfs:
+      - /tmp
     image: quay.io/prometheus/node-exporter:v1.5.0
+    read_only: true
     container_name: node_exporter
     command: "--path.rootfs=/host"
     pid: host


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'node_exporter' is running with a writable root filesystem. This may allow malicious applications to download and run additional payloads, or modify container files. If an application inside a container has to save something temporarily consider using a tmpfs. Add 'read_only: true' to this service to prevent this.
- **Rule ID:** yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service
- **Severity:** HIGH
- **File:** compose/docker-compose.yml
- **Lines Affected:** 176 - 176

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `compose/docker-compose.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.