### PR TITLE
feat: Add domain events to Identity module

### DIFF
--- a/src/Modules/Identity/Modules.Identity/Domain/Events/PasswordChangedEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/PasswordChangedEvent.cs
@@ -1,0 +1,17 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when a user changes their password.</summary>
+public sealed record PasswordChangedEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    bool WasReset,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static PasswordChangedEvent Create(string userId, bool wasReset = false, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, wasReset, correlationId, tenantId);
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/Events/SessionRevokedEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/SessionRevokedEvent.cs
@@ -1,0 +1,19 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when a user session is revoked.</summary>
+public sealed record SessionRevokedEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    Guid SessionId,
+    string? RevokedBy,
+    string? Reason,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static SessionRevokedEvent Create(string userId, Guid sessionId, string? revokedBy = null, string? reason = null, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, sessionId, revokedBy, reason, correlationId, tenantId);
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/Events/UserActivatedEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/UserActivatedEvent.cs
@@ -1,0 +1,17 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when a user account is activated.</summary>
+public sealed record UserActivatedEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    string? ActivatedBy,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static UserActivatedEvent Create(string userId, string? activatedBy = null, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, activatedBy, correlationId, tenantId);
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/Events/UserDeactivatedEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/UserDeactivatedEvent.cs
@@ -1,0 +1,18 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when a user account is deactivated.</summary>
+public sealed record UserDeactivatedEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    string? DeactivatedBy,
+    string? Reason,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static UserDeactivatedEvent Create(string userId, string? deactivatedBy = null, string? reason = null, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, deactivatedBy, reason, correlationId, tenantId);
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/Events/UserRegisteredEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/UserRegisteredEvent.cs
@@ -1,0 +1,19 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when a new user registers in the system.</summary>
+public sealed record UserRegisteredEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    string Email,
+    string? FirstName,
+    string? LastName,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static UserRegisteredEvent Create(string userId, string email, string? firstName = null, string? lastName = null, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, email, firstName, lastName, correlationId, tenantId);
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/Events/UserRoleAssignedEvent.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Events/UserRoleAssignedEvent.cs
@@ -1,0 +1,17 @@
+using FSH.Framework.Core.Domain;
+
+namespace FSH.Modules.Identity.Domain.Events;
+
+/// <summary>Raised when roles are assigned to a user.</summary>
+public sealed record UserRoleAssignedEvent(
+    Guid EventId,
+    DateTimeOffset OccurredOnUtc,
+    string UserId,
+    IReadOnlyList<string> AssignedRoles,
+    string? CorrelationId = null,
+    string? TenantId = null
+) : DomainEvent(EventId, OccurredOnUtc, CorrelationId, TenantId)
+{
+    public static UserRoleAssignedEvent Create(string userId, IEnumerable<string> assignedRoles, string? correlationId = null, string? tenantId = null)
+        => new(Guid.NewGuid(), DateTimeOffset.UtcNow, userId, assignedRoles.ToList().AsReadOnly(), correlationId, tenantId);
+}


### PR DESCRIPTION
## Summary
Add domain events for identity-related operations following FSH patterns.

## Changes
Created domain events in `Modules.Identity/Domain/Events/`:

| Event | Purpose |
|-------|---------|
| `UserRegisteredEvent` | Raised when a new user registers |
| `PasswordChangedEvent` | Raised when a user changes password |
| `UserRoleAssignedEvent` | Raised when roles are assigned to a user |
| `UserActivatedEvent` | Raised when a user account is activated |
| `UserDeactivatedEvent` | Raised when a user account is deactivated |
| `SessionRevokedEvent` | Raised when a user session is revoked |

## Implementation Details
- All events are `sealed record` types inheriting from `DomainEvent` base
- Include `EventId`, `OccurredOnUtc`, `CorrelationId`, `TenantId` from base
- Include domain-specific data (UserId, Email, etc.)
- Provide static `Create` factory methods for convenient instantiation

## Related
Enables publishing domain events for audit trails, notifications, and event sourcing patterns.