### PR TITLE
fix: Add missing validators to Identity module commands

### DIFF
--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Groups.AddUsersToGroup;
+
+namespace FSH.Modules.Identity.Features.v1.Groups.AddUsersToGroup;
+
+public sealed class AddUsersToGroupCommandValidator : AbstractValidator<AddUsersToGroupCommand>
+{
+    public AddUsersToGroupCommandValidator()
+    {
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Group ID is required.");
+
+        RuleFor(x => x.UserIds)
+            .NotEmpty().WithMessage("At least one user ID is required.")
+            .Must(ids => ids.All(id => !string.IsNullOrWhiteSpace(id)))
+            .WithMessage("User IDs cannot be empty or whitespace.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Groups.DeleteGroup;
+
+namespace FSH.Modules.Identity.Features.v1.Groups.DeleteGroup;
+
+public sealed class DeleteGroupCommandValidator : AbstractValidator<DeleteGroupCommand>
+{
+    public DeleteGroupCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Group ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Groups.RemoveUserFromGroup;
+
+namespace FSH.Modules.Identity.Features.v1.Groups.RemoveUserFromGroup;
+
+public sealed class RemoveUserFromGroupCommandValidator : AbstractValidator<RemoveUserFromGroupCommand>
+{
+    public RemoveUserFromGroupCommandValidator()
+    {
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Group ID is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Roles.DeleteRole;
+
+namespace FSH.Modules.Identity.Features.v1.Roles.DeleteRole;
+
+public sealed class DeleteRoleCommandValidator : AbstractValidator<DeleteRoleCommand>
+{
+    public DeleteRoleCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Role ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeAllSessions/AdminRevokeAllSessionsCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeAllSessions/AdminRevokeAllSessionsCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Sessions.AdminRevokeAllSessions;
+
+namespace FSH.Modules.Identity.Features.v1.Sessions.AdminRevokeAllSessions;
+
+public sealed class AdminRevokeAllSessionsCommandValidator : AbstractValidator<AdminRevokeAllSessionsCommand>
+{
+    public AdminRevokeAllSessionsCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500).WithMessage("Reason must not exceed 500 characters.")
+            .When(x => x.Reason is not null);
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeSession/AdminRevokeSessionCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeSession/AdminRevokeSessionCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Sessions.AdminRevokeSession;
+
+namespace FSH.Modules.Identity.Features.v1.Sessions.AdminRevokeSession;
+
+public sealed class AdminRevokeSessionCommandValidator : AbstractValidator<AdminRevokeSessionCommand>
+{
+    public AdminRevokeSessionCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+
+        RuleFor(x => x.SessionId)
+            .NotEmpty().WithMessage("Session ID is required.");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500).WithMessage("Reason must not exceed 500 characters.")
+            .When(x => x.Reason is not null);
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeAllSessions/RevokeAllSessionsCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeAllSessions/RevokeAllSessionsCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Sessions.RevokeAllSessions;
+
+namespace FSH.Modules.Identity.Features.v1.Sessions.RevokeAllSessions;
+
+public sealed class RevokeAllSessionsCommandValidator : AbstractValidator<RevokeAllSessionsCommand>
+{
+    public RevokeAllSessionsCommandValidator()
+    {
+        // ExceptSessionId is optional - no validation required
+        // This validator exists for consistency and potential future validation rules
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeSession/RevokeSessionCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeSession/RevokeSessionCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Sessions.RevokeSession;
+
+namespace FSH.Modules.Identity.Features.v1.Sessions.RevokeSession;
+
+public sealed class RevokeSessionCommandValidator : AbstractValidator<RevokeSessionCommand>
+{
+    public RevokeSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty().WithMessage("Session ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.AssignUserRoles;
+
+namespace FSH.Modules.Identity.Features.v1.Users.AssignUserRoles;
+
+public sealed class AssignUserRolesCommandValidator : AbstractValidator<AssignUserRolesCommand>
+{
+    public AssignUserRolesCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+
+        RuleFor(x => x.UserRoles)
+            .NotNull().WithMessage("User roles list is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ConfirmEmail/ConfirmEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ConfirmEmail/ConfirmEmailCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.ConfirmEmail;
+
+namespace FSH.Modules.Identity.Features.v1.Users.ConfirmEmail;
+
+public sealed class ConfirmEmailCommandValidator : AbstractValidator<ConfirmEmailCommand>
+{
+    public ConfirmEmailCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+
+        RuleFor(x => x.Code)
+            .NotEmpty().WithMessage("Confirmation code is required.");
+
+        RuleFor(x => x.Tenant)
+            .NotEmpty().WithMessage("Tenant is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/DeleteUser/DeleteUserCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/DeleteUser/DeleteUserCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.DeleteUser;
+
+namespace FSH.Modules.Identity.Features.v1.Users.DeleteUser;
+
+public sealed class DeleteUserCommandValidator : AbstractValidator<DeleteUserCommand>
+{
+    public DeleteUserCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/RegisterUser/RegisterUserCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/RegisterUser/RegisterUserCommandValidator.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.RegisterUser;
+
+namespace FSH.Modules.Identity.Features.v1.Users.RegisterUser;
+
+public sealed class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage("First name is required.")
+            .MaximumLength(100).WithMessage("First name must not exceed 100 characters.");
+
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage("Last name is required.")
+            .MaximumLength(100).WithMessage("Last name must not exceed 100 characters.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("A valid email address is required.");
+
+        RuleFor(x => x.UserName)
+            .NotEmpty().WithMessage("Username is required.")
+            .MinimumLength(3).WithMessage("Username must be at least 3 characters.")
+            .MaximumLength(50).WithMessage("Username must not exceed 50 characters.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(6).WithMessage("Password must be at least 6 characters.");
+
+        RuleFor(x => x.ConfirmPassword)
+            .NotEmpty().WithMessage("Password confirmation is required.")
+            .Equal(x => x.Password).WithMessage("Passwords do not match.");
+
+        RuleFor(x => x.PhoneNumber)
+            .MaximumLength(20).WithMessage("Phone number must not exceed 20 characters.")
+            .When(x => x.PhoneNumber is not null);
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ToggleUserStatus/ToggleUserStatusCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ToggleUserStatus/ToggleUserStatusCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.ToggleUserStatus;
+
+namespace FSH.Modules.Identity.Features.v1.Users.ToggleUserStatus;
+
+public sealed class ToggleUserStatusCommandValidator : AbstractValidator<ToggleUserStatusCommand>
+{
+    public ToggleUserStatusCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}


### PR DESCRIPTION
## Summary
Added FluentValidation validators for 13 commands that were missing them in the Identity module.

## Changes

### Groups
- `AddUsersToGroupCommandValidator` - Validates GroupId and UserIds
- `DeleteGroupCommandValidator` - Validates Id
- `RemoveUserFromGroupCommandValidator` - Validates GroupId and UserId

### Roles
- `DeleteRoleCommandValidator` - Validates Id

### Sessions
- `AdminRevokeAllSessionsCommandValidator` - Validates UserId, optional Reason max length
- `AdminRevokeSessionCommandValidator` - Validates UserId, SessionId, optional Reason max length
- `RevokeAllSessionsCommandValidator` - Placeholder for future rules (all fields optional)
- `RevokeSessionCommandValidator` - Validates SessionId

### Users
- `AssignUserRolesCommandValidator` - Validates UserId and UserRoles not null
- `ConfirmEmailCommandValidator` - Validates UserId, Code, and Tenant
- `DeleteUserCommandValidator` - Validates Id
- `RegisterUserCommandValidator` - Full validation for registration fields including email format, password matching, and field lengths
- `ToggleUserStatusCommandValidator` - Validates UserId

## Testing
All validators follow the established FSH pattern using `AbstractValidator<TCommand>` with appropriate validation rules.