### PR TITLE
refactor: Add DDD patterns to Identity domain entities

### DIFF
--- a/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
+++ b/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
@@ -109,15 +109,12 @@ internal sealed class IdentityDbInitializer(
 
         if (allUsersGroup is null)
         {
-            allUsersGroup = new Group
-            {
-                Name = allUsersGroupName,
-                Description = "Default group for all users. New users are automatically added to this group.",
-                IsDefault = true,
-                IsSystemGroup = true,
-                CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-                CreatedBy = "System"
-            };
+            allUsersGroup = Group.Create(
+                name: allUsersGroupName,
+                description: "Default group for all users. New users are automatically added to this group.",
+                isDefault: true,
+                isSystemGroup: true,
+                createdBy: "System");
 
             await context.Groups.AddAsync(allUsersGroup);
             logger.LogInformation("Seeding '{GroupName}' system group for '{TenantId}' Tenant.", allUsersGroupName, tenantId);
@@ -130,15 +127,12 @@ internal sealed class IdentityDbInitializer(
 
         if (administratorsGroup is null)
         {
-            administratorsGroup = new Group
-            {
-                Name = administratorsGroupName,
-                Description = "System group for administrators with full administrative privileges.",
-                IsDefault = false,
-                IsSystemGroup = true,
-                CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-                CreatedBy = "System"
-            };
+            administratorsGroup = Group.Create(
+                name: administratorsGroupName,
+                description: "System group for administrators with full administrative privileges.",
+                isDefault: false,
+                isSystemGroup: true,
+                createdBy: "System");
 
             await context.Groups.AddAsync(administratorsGroup);
             logger.LogInformation("Seeding '{GroupName}' system group for '{TenantId}' Tenant.", administratorsGroupName, tenantId);
@@ -155,11 +149,7 @@ internal sealed class IdentityDbInitializer(
 
             if (existingGroupRole is null)
             {
-                context.GroupRoles.Add(new GroupRole
-                {
-                    GroupId = administratorsGroup.Id,
-                    RoleId = adminRole.Id
-                });
+                context.GroupRoles.Add(GroupRole.Create(administratorsGroup.Id, adminRole.Id));
 
                 await context.SaveChangesAsync();
                 logger.LogInformation("Assigned Admin role to '{GroupName}' group for '{TenantId}' Tenant.", administratorsGroupName, tenantId);

--- a/src/Modules/Identity/Modules.Identity/Domain/Group.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/Group.cs
@@ -4,15 +4,15 @@ namespace FSH.Modules.Identity.Domain;
 
 public class Group : ISoftDeletable
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public string Name { get; set; } = default!;
-    public string? Description { get; set; }
-    public bool IsDefault { get; set; }
-    public bool IsSystemGroup { get; set; }
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public string? CreatedBy { get; set; }
-    public DateTime? ModifiedAt { get; set; }
-    public string? ModifiedBy { get; set; }
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public string? Description { get; private set; }
+    public bool IsDefault { get; private set; }
+    public bool IsSystemGroup { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public string? CreatedBy { get; private set; }
+    public DateTime? ModifiedAt { get; private set; }
+    public string? ModifiedBy { get; private set; }
 
     // ISoftDeletable implementation
     public bool IsDeleted { get; set; }
@@ -20,6 +20,37 @@ public class Group : ISoftDeletable
     public string? DeletedBy { get; set; }
 
     // Navigation properties
-    public virtual ICollection<GroupRole> GroupRoles { get; set; } = [];
-    public virtual ICollection<UserGroup> UserGroups { get; set; } = [];
+    public virtual ICollection<GroupRole> GroupRoles { get; private set; } = [];
+    public virtual ICollection<UserGroup> UserGroups { get; private set; } = [];
+
+    private Group() { } // EF Core
+
+    public static Group Create(string name, string? description = null, bool isDefault = false, bool isSystemGroup = false, string? createdBy = null)
+    {
+        return new Group
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Description = description,
+            IsDefault = isDefault,
+            IsSystemGroup = isSystemGroup,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void Update(string name, string? description, string? modifiedBy = null)
+    {
+        Name = name;
+        Description = description;
+        ModifiedAt = DateTime.UtcNow;
+        ModifiedBy = modifiedBy;
+    }
+
+    public void SetAsDefault(bool isDefault, string? modifiedBy = null)
+    {
+        IsDefault = isDefault;
+        ModifiedAt = DateTime.UtcNow;
+        ModifiedBy = modifiedBy;
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Domain/GroupRole.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/GroupRole.cs
@@ -2,10 +2,21 @@ namespace FSH.Modules.Identity.Domain;
 
 public class GroupRole
 {
-    public Guid GroupId { get; set; }
-    public string RoleId { get; set; } = default!;
+    public Guid GroupId { get; private set; }
+    public string RoleId { get; private set; } = default!;
 
     // Navigation properties
-    public virtual Group? Group { get; set; }
-    public virtual FshRole? Role { get; set; }
+    public virtual Group? Group { get; private set; }
+    public virtual FshRole? Role { get; private set; }
+
+    private GroupRole() { } // EF Core
+
+    public static GroupRole Create(Guid groupId, string roleId)
+    {
+        return new GroupRole
+        {
+            GroupId = groupId,
+            RoleId = roleId
+        };
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Domain/PasswordHistory.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/PasswordHistory.cs
@@ -2,11 +2,23 @@ namespace FSH.Modules.Identity.Domain;
 
 public class PasswordHistory
 {
-    public int Id { get; set; }
-    public string UserId { get; set; } = default!;
-    public string PasswordHash { get; set; } = default!;
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public int Id { get; private set; }
+    public string UserId { get; private set; } = default!;
+    public string PasswordHash { get; private set; } = default!;
+    public DateTime CreatedAt { get; private set; }
 
     // Navigation property
-    public virtual FshUser? User { get; set; }
+    public virtual FshUser? User { get; private set; }
+
+    private PasswordHistory() { } // EF Core
+
+    public static PasswordHistory Create(string userId, string passwordHash)
+    {
+        return new PasswordHistory
+        {
+            UserId = userId,
+            PasswordHash = passwordHash,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Domain/UserGroup.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/UserGroup.cs
@@ -2,12 +2,25 @@ namespace FSH.Modules.Identity.Domain;
 
 public class UserGroup
 {
-    public string UserId { get; set; } = default!;
-    public Guid GroupId { get; set; }
-    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
-    public string? AddedBy { get; set; }
+    public string UserId { get; private set; } = default!;
+    public Guid GroupId { get; private set; }
+    public DateTime AddedAt { get; private set; }
+    public string? AddedBy { get; private set; }
 
     // Navigation properties
-    public virtual FshUser? User { get; set; }
-    public virtual Group? Group { get; set; }
+    public virtual FshUser? User { get; private set; }
+    public virtual Group? Group { get; private set; }
+
+    private UserGroup() { } // EF Core
+
+    public static UserGroup Create(string userId, Guid groupId, string? addedBy = null)
+    {
+        return new UserGroup
+        {
+            UserId = userId,
+            GroupId = groupId,
+            AddedAt = DateTime.UtcNow,
+            AddedBy = addedBy
+        };
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
@@ -2,24 +2,76 @@ namespace FSH.Modules.Identity.Domain;
 
 public class UserSession
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public string UserId { get; set; } = default!;
-    public string RefreshTokenHash { get; set; } = default!;
-    public string IpAddress { get; set; } = default!;
-    public string UserAgent { get; set; } = default!;
-    public string? DeviceType { get; set; }
-    public string? Browser { get; set; }
-    public string? BrowserVersion { get; set; }
-    public string? OperatingSystem { get; set; }
-    public string? OsVersion { get; set; }
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public DateTime LastActivityAt { get; set; } = DateTime.UtcNow;
-    public DateTime ExpiresAt { get; set; }
-    public bool IsRevoked { get; set; }
-    public DateTime? RevokedAt { get; set; }
-    public string? RevokedBy { get; set; }
-    public string? RevokedReason { get; set; }
+    public Guid Id { get; private set; }
+    public string UserId { get; private set; } = default!;
+    public string RefreshTokenHash { get; private set; } = default!;
+    public string IpAddress { get; private set; } = default!;
+    public string UserAgent { get; private set; } = default!;
+    public string? DeviceType { get; private set; }
+    public string? Browser { get; private set; }
+    public string? BrowserVersion { get; private set; }
+    public string? OperatingSystem { get; private set; }
+    public string? OsVersion { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime LastActivityAt { get; private set; }
+    public DateTime ExpiresAt { get; private set; }
+    public bool IsRevoked { get; private set; }
+    public DateTime? RevokedAt { get; private set; }
+    public string? RevokedBy { get; private set; }
+    public string? RevokedReason { get; private set; }
 
     // Navigation property
-    public virtual FshUser? User { get; set; }
+    public virtual FshUser? User { get; private set; }
+
+    private UserSession() { } // EF Core
+
+    public static UserSession Create(
+        string userId,
+        string refreshTokenHash,
+        string ipAddress,
+        string userAgent,
+        DateTime expiresAt,
+        string? deviceType = null,
+        string? browser = null,
+        string? browserVersion = null,
+        string? operatingSystem = null,
+        string? osVersion = null)
+    {
+        return new UserSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            RefreshTokenHash = refreshTokenHash,
+            IpAddress = ipAddress,
+            UserAgent = userAgent,
+            DeviceType = deviceType,
+            Browser = browser,
+            BrowserVersion = browserVersion,
+            OperatingSystem = operatingSystem,
+            OsVersion = osVersion,
+            CreatedAt = DateTime.UtcNow,
+            LastActivityAt = DateTime.UtcNow,
+            ExpiresAt = expiresAt
+        };
+    }
+
+    public void UpdateActivity()
+    {
+        LastActivityAt = DateTime.UtcNow;
+    }
+
+    public void UpdateRefreshToken(string refreshTokenHash, DateTime expiresAt)
+    {
+        RefreshTokenHash = refreshTokenHash;
+        ExpiresAt = expiresAt;
+        LastActivityAt = DateTime.UtcNow;
+    }
+
+    public void Revoke(string? revokedBy = null, string? reason = null)
+    {
+        IsRevoked = true;
+        RevokedAt = DateTime.UtcNow;
+        RevokedBy = revokedBy;
+        RevokedReason = reason;
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
@@ -57,12 +57,7 @@ public sealed class AddUsersToGroupCommandHandler : ICommandHandler<AddUsersToGr
         var currentUserId = _currentUser.GetUserId().ToString();
         foreach (var userId in usersToAdd)
         {
-            _dbContext.UserGroups.Add(new UserGroup
-            {
-                UserId = userId,
-                GroupId = command.GroupId,
-                AddedBy = currentUserId
-            });
+            _dbContext.UserGroups.Add(UserGroup.Create(userId, command.GroupId, currentUserId));
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandHandler.cs
@@ -48,21 +48,19 @@ public sealed class CreateGroupCommandHandler : ICommandHandler<CreateGroupComma
             }
         }
 
-        var group = new Group
-        {
-            Name = command.Name,
-            Description = command.Description,
-            IsDefault = command.IsDefault,
-            IsSystemGroup = false,
-            CreatedBy = _currentUser.GetUserId().ToString()
-        };
+        var group = Group.Create(
+            name: command.Name,
+            description: command.Description,
+            isDefault: command.IsDefault,
+            isSystemGroup: false,
+            createdBy: _currentUser.GetUserId().ToString());
 
         // Add role assignments
         if (command.RoleIds is { Count: > 0 })
         {
             foreach (var roleId in command.RoleIds)
             {
-                group.GroupRoles.Add(new GroupRole { GroupId = group.Id, RoleId = roleId });
+                _dbContext.GroupRoles.Add(GroupRole.Create(group.Id, roleId));
             }
         }
 

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
@@ -54,11 +54,8 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
         }
 
         // Update group properties
-        group.Name = command.Name;
-        group.Description = command.Description;
-        group.IsDefault = command.IsDefault;
-        group.ModifiedAt = DateTime.UtcNow;
-        group.ModifiedBy = _currentUser.GetUserId().ToString();
+        group.Update(command.Name, command.Description, _currentUser.GetUserId().ToString());
+        group.SetAsDefault(command.IsDefault, _currentUser.GetUserId().ToString());
 
         // Update role assignments
         var currentRoleIds = group.GroupRoles.Select(gr => gr.RoleId).ToHashSet();
@@ -74,7 +71,7 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
         // Add new role assignments
         foreach (var roleId in newRoleIds.Where(id => !currentRoleIds.Contains(id)))
         {
-            group.GroupRoles.Add(new GroupRole { GroupId = group.Id, RoleId = roleId });
+            group.GroupRoles.Add(GroupRole.Create(group.Id, roleId));
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Identity/Modules.Identity/Services/PasswordHistoryService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/PasswordHistoryService.cs
@@ -73,12 +73,7 @@ internal sealed class PasswordHistoryService : IPasswordHistoryService
             return;
         }
 
-        var passwordHistoryEntry = new PasswordHistory
-        {
-            UserId = userId,
-            PasswordHash = user.PasswordHash,
-            CreatedAt = DateTime.UtcNow
-        };
+        var passwordHistoryEntry = PasswordHistory.Create(userId, user.PasswordHash);
 
         _db.Set<PasswordHistory>().Add(passwordHistoryEntry);
         await _db.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Identity/Modules.Identity/Services/UserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserService.cs
@@ -229,13 +229,7 @@ internal sealed partial class UserService(
 
         foreach (var group in defaultGroups)
         {
-            db.UserGroups.Add(new UserGroup
-            {
-                UserId = user.Id,
-                GroupId = group.Id,
-                AddedAt = DateTime.UtcNow,
-                AddedBy = "ExternalAuth"
-            });
+            db.UserGroups.Add(UserGroup.Create(user.Id, group.Id, "ExternalAuth"));
         }
 
         if (defaultGroups.Count > 0)
@@ -296,13 +290,7 @@ internal sealed partial class UserService(
 
         foreach (var group in defaultGroups)
         {
-            db.UserGroups.Add(new UserGroup
-            {
-                UserId = user.Id,
-                GroupId = group.Id,
-                AddedAt = DateTime.UtcNow,
-                AddedBy = "System"
-            });
+            db.UserGroups.Add(UserGroup.Create(user.Id, group.Id, "System"));
         }
 
         if (defaultGroups.Count > 0)


### PR DESCRIPTION
## Summary
Applied Domain-Driven Design patterns to Identity module entities (excluding FshUser and FshRole which inherit from ASP.NET Identity).

## Changes

### Domain Entities Updated
- **Group.cs**: Private setters, private constructor for EF Core, `Create()` factory method, `Update()` and `SetAsDefault()` domain methods
- **UserGroup.cs**: Private setters, private constructor, `Create()` factory method
- **GroupRole.cs**: Private setters, private constructor, `Create()` factory method
- **UserSession.cs**: Private setters, private constructor, `Create()` factory method, `UpdateActivity()`, `UpdateRefreshToken()`, and `Revoke()` domain methods
- **PasswordHistory.cs**: Private setters, private constructor, `Create()` factory method

### Usages Updated
All existing code that used direct property assignment has been updated to use the new factory methods and domain methods:
- IdentityDbInitializer.cs
- CreateGroupCommandHandler.cs
- UpdateGroupCommandHandler.cs
- AddUsersToGroupCommandHandler.cs
- UserService.cs
- SessionService.cs
- PasswordHistoryService.cs

## Why
Following DDD patterns ensures:
- Entities control their own state transitions
- Object invariants are maintained
- Clear API for entity creation and modification
- Better encapsulation and testability

## Notes
- FshUser and FshRole were intentionally skipped as they inherit from ASP.NET Identity base classes (IdentityUser/IdentityRole) which have their own patterns
- ISoftDeletable properties on Group remain public as required by the framework interface