### PR TITLE
fix: resolve all build warnings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch API",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Playground/Playground.Api/bin/Debug/net10.0/FSH.Playground.Api.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Playground/Playground.Api",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "dotnet.dotnetPath": "/home/jarvis/.dotnet/dotnet",
+    "omnisharp.dotnetPath": "/home/jarvis/.dotnet",
+    "omnisharp.sdkPath": "/home/jarvis/.dotnet/sdk/10.0.102",
+    "omnisharp.useModernNet": true,
+    "editor.formatOnSave": true,
+    "files.exclude": {
+        "**/bin": true,
+        "**/obj": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,76 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/FSH.Framework.slnx",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test",
+                "${workspaceFolder}/src/FSH.Framework.slnx"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "test"
+        },
+        {
+            "label": "run (Aspire)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/src/Playground/FSH.Playground.AppHost"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "run (API only)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/src/Playground/Playground.Api"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/src/FSH.Framework.slnx"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "restore",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "restore",
+                "${workspaceFolder}/src/FSH.Framework.slnx"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Modules/Identity/Modules.Identity/Domain/GroupRole.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/GroupRole.cs
@@ -5,9 +5,9 @@ public class GroupRole
     public Guid GroupId { get; private set; }
     public string RoleId { get; private set; } = default!;
 
-    // Navigation properties
-    public virtual Group? Group { get; private set; }
-    public virtual FshRole? Role { get; private set; }
+    // Navigation properties (init for EF Core materialization)
+    public virtual Group? Group { get; init; }
+    public virtual FshRole? Role { get; init; }
 
     private GroupRole() { } // EF Core
 

--- a/src/Modules/Identity/Modules.Identity/Domain/PasswordHistory.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/PasswordHistory.cs
@@ -2,13 +2,13 @@ namespace FSH.Modules.Identity.Domain;
 
 public class PasswordHistory
 {
-    public int Id { get; private set; }
+    public int Id { get; init; }
     public string UserId { get; private set; } = default!;
     public string PasswordHash { get; private set; } = default!;
     public DateTime CreatedAt { get; private set; }
 
-    // Navigation property
-    public virtual FshUser? User { get; private set; }
+    // Navigation property (init for EF Core materialization)
+    public virtual FshUser? User { get; init; }
 
     private PasswordHistory() { } // EF Core
 

--- a/src/Modules/Identity/Modules.Identity/Domain/UserGroup.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/UserGroup.cs
@@ -7,9 +7,9 @@ public class UserGroup
     public DateTime AddedAt { get; private set; }
     public string? AddedBy { get; private set; }
 
-    // Navigation properties
-    public virtual FshUser? User { get; private set; }
-    public virtual Group? Group { get; private set; }
+    // Navigation properties (init for EF Core materialization)
+    public virtual FshUser? User { get; init; }
+    public virtual Group? Group { get; init; }
 
     private UserGroup() { } // EF Core
 

--- a/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
@@ -20,8 +20,8 @@ public class UserSession
     public string? RevokedBy { get; private set; }
     public string? RevokedReason { get; private set; }
 
-    // Navigation property
-    public virtual FshUser? User { get; private set; }
+    // Navigation property (init for EF Core materialization)
+    public virtual FshUser? User { get; init; }
 
     private UserSession() { } // EF Core
 

--- a/src/Playground/Playground.Blazor/Components/Layout/PlaygroundLayout.razor
+++ b/src/Playground/Playground.Blazor/Components/Layout/PlaygroundLayout.razor
@@ -182,7 +182,7 @@ else
             _isDarkMode = TenantThemeState.IsDarkMode;
             _logoUrl = _isDarkMode ? TenantThemeState.Current.BrandAssets.LogoDarkUrl : TenantThemeState.Current.BrandAssets.LogoUrl;
 
-            InvokeAsync(StateHasChanged);
+            await InvokeAsync(StateHasChanged);
         }
         else if (wasAuthenticated && !_isAuthenticated)
         {
@@ -192,7 +192,7 @@ else
             _isDarkMode = false;
             _logoUrl = null;
             await ApplyFaviconAsync(); // reset to default
-            InvokeAsync(StateHasChanged);
+            await InvokeAsync(StateHasChanged);
         }
     }
 


### PR DESCRIPTION
## Summary
Resolves all 9 build warnings to achieve a clean build with 0 warnings, 0 errors.

## Changes

### SonarQube S1144 - Unused private setters (7 warnings)
Changed EF Core navigation property setters from `private set` to `init` in Identity domain entities:
- `GroupRole.cs`: Group, Role properties
- `PasswordHistory.cs`: Id, User properties  
- `UserGroup.cs`: User, Group properties
- `UserSession.cs`: User property

Using `init` is EF Core compatible and eliminates the "unused private setter" warning since the setter is now an init accessor.

### CS4014 - Un-awaited async calls (2 warnings)
Added `await` to `InvokeAsync(StateHasChanged)` calls in `PlaygroundLayout.razor` (lines 185, 195).

## Build Verification
```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```