### PR TITLE
feat(identity): wire up domain events for user lifecycle

### DIFF
--- a/src/Modules/Identity/Modules.Identity/Domain/FshUser.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/FshUser.cs
@@ -1,9 +1,13 @@
+using FSH.Framework.Core.Domain;
+using FSH.Modules.Identity.Domain.Events;
 using Microsoft.AspNetCore.Identity;
 
 namespace FSH.Modules.Identity.Domain;
 
-public class FshUser : IdentityUser
+public class FshUser : IdentityUser, IHasDomainEvents
 {
+    private readonly List<IDomainEvent> _domainEvents = [];
+
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public Uri? ImageUrl { get; set; }
@@ -18,4 +22,63 @@ public class FshUser : IdentityUser
 
     // Navigation property for password history
     public virtual ICollection<PasswordHistory> PasswordHistories { get; set; } = new List<PasswordHistory>();
+
+    // IHasDomainEvents implementation
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+    public void ClearDomainEvents() => _domainEvents.Clear();
+    private void AddDomainEvent(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
+
+    /// <summary>Records UserRegisteredEvent. Call after user creation.</summary>
+    public void RecordRegistered(string? tenantId = null)
+    {
+        AddDomainEvent(UserRegisteredEvent.Create(
+            userId: Id,
+            email: Email ?? string.Empty,
+            firstName: FirstName,
+            lastName: LastName,
+            tenantId: tenantId));
+    }
+
+    /// <summary>Records PasswordChangedEvent. Call after password change.</summary>
+    public void RecordPasswordChanged(bool wasReset = false, string? tenantId = null)
+    {
+        AddDomainEvent(PasswordChangedEvent.Create(
+            userId: Id,
+            wasReset: wasReset,
+            tenantId: tenantId));
+    }
+
+    /// <summary>Sets user to active and records UserActivatedEvent.</summary>
+    public void Activate(string? activatedBy = null, string? tenantId = null)
+    {
+        if (IsActive) return;
+        IsActive = true;
+        AddDomainEvent(UserActivatedEvent.Create(
+            userId: Id,
+            activatedBy: activatedBy,
+            tenantId: tenantId));
+    }
+
+    /// <summary>Sets user to inactive and records UserDeactivatedEvent.</summary>
+    public void Deactivate(string? deactivatedBy = null, string? reason = null, string? tenantId = null)
+    {
+        if (!IsActive) return;
+        IsActive = false;
+        AddDomainEvent(UserDeactivatedEvent.Create(
+            userId: Id,
+            deactivatedBy: deactivatedBy,
+            reason: reason,
+            tenantId: tenantId));
+    }
+
+    /// <summary>Records UserRoleAssignedEvent. Call after roles are assigned.</summary>
+    public void RecordRolesAssigned(IEnumerable<string> assignedRoles, string? tenantId = null)
+    {
+        var rolesList = assignedRoles.ToList();
+        if (rolesList.Count == 0) return;
+        AddDomainEvent(UserRoleAssignedEvent.Create(
+            userId: Id,
+            assignedRoles: rolesList,
+            tenantId: tenantId));
+    }
 }

--- a/src/Modules/Identity/Modules.Identity/Services/SessionService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/SessionService.cs
@@ -145,7 +145,8 @@ public sealed class SessionService : ISessionService
             throw new UnauthorizedAccessException("Cannot revoke session for another user");
         }
 
-        session.Revoke(revokedBy, reason ?? "User requested");
+        var tenantId = _multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id;
+        session.Revoke(revokedBy, reason ?? "User requested", tenantId);
 
         await _db.SaveChangesAsync(cancellationToken);
 
@@ -179,9 +180,10 @@ public sealed class SessionService : ISessionService
 
         var sessions = await query.ToListAsync(cancellationToken);
 
+        var tenantId = _multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id;
         foreach (var session in sessions)
         {
-            session.Revoke(revokedBy, reason ?? "User requested logout from all devices");
+            session.Revoke(revokedBy, reason ?? "User requested logout from all devices", tenantId);
         }
 
         await _db.SaveChangesAsync(cancellationToken);
@@ -203,9 +205,10 @@ public sealed class SessionService : ISessionService
             .Where(s => s.UserId == userId && !s.IsRevoked)
             .ToListAsync(cancellationToken);
 
+        var tenantId = _multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id;
         foreach (var session in sessions)
         {
-            session.Revoke(revokedBy, reason ?? "Admin requested");
+            session.Revoke(revokedBy, reason ?? "Admin requested", tenantId);
         }
 
         await _db.SaveChangesAsync(cancellationToken);
@@ -232,7 +235,8 @@ public sealed class SessionService : ISessionService
             return false;
         }
 
-        session.Revoke(revokedBy, reason ?? "Admin requested");
+        var tenantId = _multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id;
+        session.Revoke(revokedBy, reason ?? "Admin requested", tenantId);
 
         await _db.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Wire up domain events in the Identity module so that user lifecycle operations automatically raise domain events that can be consumed by handlers.

## Changes

### FshUser Entity
- Implements `IHasDomainEvents` interface
- Added domain event methods:
  - `RecordRegistered()` - raises `UserRegisteredEvent`
  - `RecordPasswordChanged()` - raises `PasswordChangedEvent`
  - `Activate()` / `Deactivate()` - sets status and raises `UserActivatedEvent` / `UserDeactivatedEvent`
  - `RecordRolesAssigned()` - raises `UserRoleAssignedEvent`

### UserSession Entity
- Implements `IHasDomainEvents` interface
- `Revoke()` method now raises `SessionRevokedEvent`

### UserService
- `RegisterAsync` and `GetOrCreateFromPrincipalAsync` raise `UserRegisteredEvent`
- `ToggleStatusAsync` uses `Activate()`/`Deactivate()` methods for proper event raising
- `AssignRolesAsync` raises `UserRoleAssignedEvent` for newly assigned roles
- `ChangePasswordAsync`/`ResetPasswordAsync` raise `PasswordChangedEvent`

### SessionService
- All revoke methods now pass tenantId to `Revoke()` for proper event context

## How It Works

The existing `DomainEventsInterceptor` in the Persistence layer automatically:
1. Collects domain events from entities implementing `IHasDomainEvents` after SaveChanges
2. Publishes each event via MediatR
3. Clears the events from entities

This allows handlers to be created for any of these domain events to implement cross-cutting concerns like audit logging, notifications, cache invalidation, etc.

## Testing

- ✅ Build succeeds with 0 errors, 0 warnings
