### PR TITLE
feat: Add CancellationToken to async methods (#1175)

### DIFF
--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IRoleService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IRoleService.cs
@@ -1,14 +1,13 @@
-﻿using FSH.Modules.Identity.Contracts.DTOs;
+using FSH.Modules.Identity.Contracts.DTOs;
 
 namespace FSH.Modules.Identity.Contracts.Services;
 
 public interface IRoleService
 {
-    Task<IEnumerable<RoleDto>> GetRolesAsync();
-    Task<RoleDto?> GetRoleAsync(string id);
-    Task<RoleDto> CreateOrUpdateRoleAsync(string roleId, string name, string description);
-    Task DeleteRoleAsync(string id);
-    Task<RoleDto> GetWithPermissionsAsync(string id, CancellationToken cancellationToken);
-
-    Task<string> UpdatePermissionsAsync(string roleId, List<string> permissions);
+    Task<IEnumerable<RoleDto>> GetRolesAsync(CancellationToken cancellationToken = default);
+    Task<RoleDto?> GetRoleAsync(string id, CancellationToken cancellationToken = default);
+    Task<RoleDto> CreateOrUpdateRoleAsync(string roleId, string name, string description, CancellationToken cancellationToken = default);
+    Task DeleteRoleAsync(string id, CancellationToken cancellationToken = default);
+    Task<RoleDto> GetWithPermissionsAsync(string id, CancellationToken cancellationToken = default);
+    Task<string> UpdatePermissionsAsync(string roleId, List<string> permissions, CancellationToken cancellationToken = default);
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandHandler.cs
@@ -17,7 +17,7 @@ public sealed class DeleteRoleCommandHandler : ICommandHandler<DeleteRoleCommand
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        await _roleService.DeleteRoleAsync(command.Id).ConfigureAwait(false);
+        await _roleService.DeleteRoleAsync(command.Id, cancellationToken).ConfigureAwait(false);
 
         return Unit.Value;
     }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoleById/GetRoleByIdQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoleById/GetRoleByIdQueryHandler.cs
@@ -17,6 +17,6 @@ public sealed class GetRoleByIdQueryHandler : IQueryHandler<GetRoleQuery, RoleDt
     public async ValueTask<RoleDto?> Handle(GetRoleQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
-        return await _roleService.GetRoleAsync(query.Id).ConfigureAwait(false);
+        return await _roleService.GetRoleAsync(query.Id, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoles/GetRolesQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoles/GetRolesQueryHandler.cs
@@ -16,6 +16,6 @@ public sealed class GetRolesQueryHandler : IQueryHandler<GetRolesQuery, IEnumera
 
     public async ValueTask<IEnumerable<RoleDto>> Handle(GetRolesQuery query, CancellationToken cancellationToken)
     {
-        return await _roleService.GetRolesAsync().ConfigureAwait(false);
+        return await _roleService.GetRolesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpdateRolePermissions/UpdatePermissionsCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpdateRolePermissions/UpdatePermissionsCommandHandler.cs
@@ -16,6 +16,6 @@ public sealed class UpdatePermissionsCommandHandler : ICommandHandler<UpdatePerm
     public async ValueTask<string> Handle(UpdatePermissionsCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
-        return await _roleService.UpdatePermissionsAsync(command.RoleId, command.Permissions).ConfigureAwait(false);
+        return await _roleService.UpdatePermissionsAsync(command.RoleId, command.Permissions, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpsertRole/UpsertRoleCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpsertRole/UpsertRoleCommandHandler.cs
@@ -18,7 +18,7 @@ public sealed class UpsertRoleCommandHandler : ICommandHandler<UpsertRoleCommand
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        return await _roleService.CreateOrUpdateRoleAsync(command.Id, command.Name, command.Description ?? string.Empty)
+        return await _roleService.CreateOrUpdateRoleAsync(command.Id, command.Name, command.Description ?? string.Empty, cancellationToken)
             .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
Adds CancellationToken parameter to async methods that were missing it and propagates the token to all inner async calls.

## Changes

### IdentityDbInitializer.cs
- Added CancellationToken parameter to private methods: `SeedRolesAsync`, `AssignPermissionsToRoleAsync`, `SeedSystemGroupsAsync`, `SeedAdminUserAsync`
- Propagated token from `SeedAsync` to all inner async calls
- Propagated token to EF Core methods: `SingleOrDefaultAsync`, `FirstOrDefaultAsync`, `AddAsync`, `SaveChangesAsync`

### IRoleService.cs & RoleService.cs
- Added CancellationToken parameter to all interface methods
- Updated implementation to accept and propagate the token
- Added `cancellationToken.ThrowIfCancellationRequested()` check in loops

### Command/Query Handlers
- Updated all role-related handlers to pass CancellationToken to service methods:
  - DeleteRoleCommandHandler
  - GetRolesQueryHandler
  - GetRoleByIdQueryHandler
  - UpsertRoleCommandHandler
  - UpdatePermissionsCommandHandler

## Notes
- AuditHttpMiddleware, PathAwareAuthorizationHandler, and RequiredPermissionAuthorizationHandler already use `HttpContext.RequestAborted` correctly
- SessionService already has CancellationToken support on all methods

## Build
✅ Build succeeded with 0 errors, 0 new warnings

Closes #1175