### PR TITLE
feat(identity): add ICurrentUserService and IRequestContextService interfaces

### DIFF
--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/ICurrentUserService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/ICurrentUserService.cs
@@ -1,0 +1,12 @@
+using System.Security.Claims;
+using FSH.Framework.Core.Context;
+
+namespace FSH.Modules.Identity.Contracts.Services;
+
+/// <summary>
+/// Service interface for managing the current user context.
+/// Combines user identity access with initialization capabilities.
+/// </summary>
+public interface ICurrentUserService : ICurrentUser, ICurrentUserInitializer
+{
+}

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IRequestContextService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IRequestContextService.cs
@@ -1,0 +1,11 @@
+using FSH.Framework.Core.Context;
+
+namespace FSH.Modules.Identity.Contracts.Services;
+
+/// <summary>
+/// Service interface for accessing HTTP request context information.
+/// Provides request metadata for auditing, logging, and other cross-cutting concerns.
+/// </summary>
+public interface IRequestContextService : IRequestContext
+{
+}

--- a/src/Modules/Identity/Modules.Identity/IdentityModule.cs
+++ b/src/Modules/Identity/Modules.Identity/IdentityModule.cs
@@ -73,10 +73,12 @@ public class IdentityModule : IModule
         ArgumentNullException.ThrowIfNull(builder);
         var services = builder.Services;
         services.AddSingleton<IAuthorizationMiddlewareResultHandler, PathAwareAuthorizationHandler>();
-        services.AddScoped<ICurrentUser, CurrentUserService>();
-        services.AddScoped<IRequestContext, RequestContextService>();
+        services.AddScoped<ICurrentUserService, CurrentUserService>();
+        services.AddScoped<ICurrentUser>(sp => sp.GetRequiredService<ICurrentUserService>());
+        services.AddScoped<ICurrentUserInitializer>(sp => sp.GetRequiredService<ICurrentUserService>());
+        services.AddScoped<IRequestContextService, RequestContextService>();
+        services.AddScoped<IRequestContext>(sp => sp.GetRequiredService<IRequestContextService>());
         services.AddScoped<ITokenService, TokenService>();
-        services.AddScoped(sp => (ICurrentUserInitializer)sp.GetRequiredService<ICurrentUser>());
 
         // User services - focused single-responsibility services
         services.AddTransient<IUserRegistrationService, UserRegistrationService>();

--- a/src/Modules/Identity/Modules.Identity/Services/CurrentUserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/CurrentUserService.cs
@@ -1,11 +1,12 @@
 ﻿using FSH.Framework.Core.Context;
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Shared.Identity.Claims;
+using FSH.Modules.Identity.Contracts.Services;
 using System.Security.Claims;
 
 namespace FSH.Modules.Identity.Services;
 
-public class CurrentUserService : ICurrentUser, ICurrentUserInitializer
+internal sealed class CurrentUserService : ICurrentUserService
 {
     private ClaimsPrincipal? _user;
 

--- a/src/Modules/Identity/Modules.Identity/Services/RequestContextService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/RequestContextService.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Context;
 using FSH.Framework.Web.Origin;
+using FSH.Modules.Identity.Contracts.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -9,7 +10,7 @@ namespace FSH.Modules.Identity.Services;
 /// Provides HTTP request context information through an abstraction.
 /// This allows handlers to access request metadata without direct ASP.NET Core dependencies.
 /// </summary>
-public sealed class RequestContextService : IRequestContext
+internal sealed class RequestContextService : IRequestContextService
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly Uri? _originUrl;


### PR DESCRIPTION
## Summary
Add interfaces for RequestContextService and CurrentUserService to enable testing and follow dependency inversion principle.

## Changes
- **ICurrentUserService** - New interface in Contracts project combining `ICurrentUser` and `ICurrentUserInitializer`
- **IRequestContextService** - New interface in Contracts project extending `IRequestContext`
- Updated `CurrentUserService` to implement `ICurrentUserService` (internal sealed)
- Updated `RequestContextService` to implement `IRequestContextService` (internal sealed)
- Updated DI registration to use new interfaces while maintaining backward compatibility

## Benefits
- Enables mocking for unit testing
- Follows dependency inversion principle
- Consistent with other service interfaces in the Contracts project

## Testing
- All existing tests pass
- Build succeeds with 0 errors

Closes #1180