### PR TITLE
docs(ai): update claude testing rules to reflect NSubstitute over Moq

### DIFF
--- a/.claude/rules/testing-rules.md
+++ b/.claude/rules/testing-rules.md
@@ -64,7 +64,7 @@ public async Task Handle_ValidCommand_ReturnsId()
 
 - **xUnit** - Test framework
 - **FluentAssertions** - `.Should()` assertions
-- **Moq** - `Mock<T>` for dependencies
+- **NSubstitute** - `Substitute.For<T>()` for dependencies
 
 ## Architecture Tests
 

--- a/.claude/skills/testing-guide/SKILL.md
+++ b/.claude/skills/testing-guide/SKILL.md
@@ -71,19 +71,19 @@ public class ArchitectureTests
 ```csharp
 public class Create{Entity}HandlerTests
 {
-    private readonly Mock<IRepository<{Entity}>> _repositoryMock;
-    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly IRepository<{Entity}> _repositoryMock;
+    private readonly ICurrentUser _currentUserMock;
     private readonly Create{Entity}Handler _handler;
 
     public Create{Entity}HandlerTests()
     {
-        _repositoryMock = new Mock<IRepository<{Entity}>>();
-        _currentUserMock = new Mock<ICurrentUser>();
-        _currentUserMock.Setup(x => x.TenantId).Returns("test-tenant");
+        _repositoryMock = Substitute.For<IRepository<{Entity}>>();
+        _currentUserMock = Substitute.For<ICurrentUser>();
+        _currentUserMock.TenantId.Returns("test-tenant");
 
         _handler = new Create{Entity}Handler(
-            _repositoryMock.Object,
-            _currentUserMock.Object);
+            _repositoryMock,
+            _currentUserMock);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class Create{Entity}HandlerTests
         // Arrange
         var command = new Create{Entity}Command("Test", 99.99m);
         _repositoryMock
-            .Setup(x => x.AddAsync(It.IsAny<{Entity}>(), It.IsAny<CancellationToken>()))
+            .AddAsync(Arg.Any<{Entity}>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
         // Act
@@ -100,9 +100,9 @@ public class Create{Entity}HandlerTests
 
         // Assert
         result.Id.Should().NotBeEmpty();
-        _repositoryMock.Verify(x => x.AddAsync(
-            It.Is<{Entity}>(e => e.Name == "Test" && e.Price == 99.99m),
-            It.IsAny<CancellationToken>()), Times.Once);
+        await _repositoryMock.Received(1).AddAsync(
+            Arg.Is<{Entity}>(e => e.Name == "Test" && e.Price == 99.99m),
+            Arg.Any<CancellationToken>());
     }
 }
 ```
@@ -220,4 +220,4 @@ dotnet test --filter "FullyQualifiedName~Create{Entity}HandlerTests"
 3. **Handlers need tests** - Mock dependencies
 4. **Entities need tests** - Test factory methods and domain logic
 5. **Use FluentAssertions** - `.Should()` syntax
-6. **Use Moq for mocking** - `Mock<T>` pattern
+6. **Use NSubstitute for mocking** - `Substitute.For<T>()` pattern


### PR DESCRIPTION
Updates the AI instruction files to rely on NSubstitute instead of Moq, aligning with the project's testing standards.