### PR TITLE
fix(identity): align JWT claim mapping and add UserId fallbacks

### DIFF
--- a/src/BuildingBlocks/Shared/Identity/Claims/ClaimsPrincipalExtensions.cs
+++ b/src/BuildingBlocks/Shared/Identity/Claims/ClaimsPrincipalExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FSH.Framework.Shared.Constants;
+using FSH.Framework.Shared.Constants;
 using System.Security.Claims;
 
 namespace FSH.Framework.Shared.Identity.Claims;
@@ -31,7 +31,9 @@ public static class ClaimsPrincipalExtensions
 
     // Retrieves the user's ID
     public static string? GetUserId(this ClaimsPrincipal principal) =>
-        principal?.FindFirstValue(ClaimTypes.NameIdentifier);
+        principal?.FindFirstValue("uid")
+        ?? principal?.FindFirstValue("sub")
+        ?? principal?.FindFirstValue(ClaimTypes.NameIdentifier);
 
     // Retrieves the user's image URL as Uri
     public static Uri? GetImageUrl(this ClaimsPrincipal principal)

--- a/src/Modules/Identity/Modules.Identity/Authorization/Jwt/ConfigureJwtBearerOptions.cs
+++ b/src/Modules/Identity/Modules.Identity/Authorization/Jwt/ConfigureJwtBearerOptions.cs
@@ -1,4 +1,4 @@
-﻿using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Core.Exceptions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -41,6 +41,7 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
 
         options.RequireHttpsMetadata = true;
         options.SaveToken = false;
+        options.MapInboundClaims = false;
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,

--- a/src/Tests/Generic.Tests/Identity/ClaimsPrincipalExtensionsTests.cs
+++ b/src/Tests/Generic.Tests/Identity/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using FSH.Framework.Shared.Identity.Claims;
+using Xunit;
+
+namespace Generic.Tests.Identity;
+
+public class ClaimsPrincipalExtensionsTests
+{
+    [Fact]
+    public void GetUserId_Should_ReturnUidClaim_WhenPresent()
+    {
+        // Arrange
+        var claims = new List<Claim> { new Claim("uid", "user-123") };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        var userId = principal.GetUserId();
+
+        // Assert
+        Assert.Equal("user-123", userId);
+    }
+
+    [Fact]
+    public void GetUserId_Should_ReturnSubClaim_WhenUidIsMissing()
+    {
+        // Arrange
+        var claims = new List<Claim> { new Claim("sub", "user-456") };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        var userId = principal.GetUserId();
+
+        // Assert
+        Assert.Equal("user-456", userId);
+    }
+
+    [Fact]
+    public void GetUserId_Should_ReturnNameIdentifier_WhenUidAndSubAreMissing()
+    {
+        // Arrange
+        var claims = new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "user-789") };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        var userId = principal.GetUserId();
+
+        // Assert
+        Assert.Equal("user-789", userId);
+    }
+
+    [Fact]
+    public void GetUserId_Should_PrioritizeUidOverSub()
+    {
+        // Arrange
+        var claims = new List<Claim> 
+        { 
+            new Claim("uid", "priority-uid"),
+            new Claim("sub", "fallback-sub")
+        };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        var userId = principal.GetUserId();
+
+        // Assert
+        Assert.Equal("priority-uid", userId);
+    }
+}


### PR DESCRIPTION
# [fix]: Correct currentUserId in Blazor and API contexts

## Description
This PR resolves an issue where `ICurrentUser.GetUserId()` returned `Guid.Empty` when called from a Blazor client context. The root cause was a mismatch between JWT claim names and the default .NET claim mapping.

### Key Changes:
- **JWT Config**: Set `options.MapInboundClaims = false;` in [ConfigureJwtBearerOptions.cs](cci:7://file:///c:/github/dotnet-starter-kit/src/Modules/Identity/Modules.Identity/Authorization/Jwt/ConfigureJwtBearerOptions.cs:0:0-0:0). This prevents ASP.NET Core from remapping standard short JWT claims (like `sub`, `uid`) to long XML SOAP URIs, ensuring consistency between the raw JWT and the [ClaimsPrincipal](cci:2://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Shared/Identity/Claims/ClaimsPrincipalExtensions.cs:5:0-56:1).
- **Claim Fallbacks**: Updated `ClaimsPrincipalExtensions.GetUserId()` to look for `uid` and `sub` claims before falling back to [NameIdentifier](cci:1://file:///c:/github/dotnet-starter-kit/src/Tests/Generic.Tests/Identity/ClaimsPrincipalExtensionsTests.cs:36:4-48:5). This ensures that existing tokens and Blazor-issued tokens both resolve the User ID correctly.
- **Cross-Component Compatibility**: These changes ensure that both Blazor UI and direct API clients share a unified way of identifying the current user.

## Related Issues
- Fixes incorrect `currentUserId` in Blazor pages.
- Resolves local issue #14.

## Verification
- **Unit Tests**: Added [ClaimsPrincipalExtensionsTests](cci:2://file:///c:/github/dotnet-starter-kit/src/Tests/Generic.Tests/Identity/ClaimsPrincipalExtensionsTests.cs:6:0-67:1) to `Generic.Tests` to verify that [GetUserId()](cci:1://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Shared/Identity/Claims/ClaimsPrincipalExtensions.cs:31:4-35:64) correctly prioritizes `uid` > `sub` > [NameIdentifier](cci:1://file:///c:/github/dotnet-starter-kit/src/Tests/Generic.Tests/Identity/ClaimsPrincipalExtensionsTests.cs:36:4-48:5).
- **Manual Verification**: Confirmed that login works in the Blazor application and [GetUserId()](cci:1://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Shared/Identity/Claims/ClaimsPrincipalExtensions.cs:31:4-35:64) correctly identifies the user after the changes.
- **Build**: Successfully built with 0 errors.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
