### PR TITLE
fix(audit): Ignore audit trail attribute

### DIFF
--- a/src/BuildingBlocks/Core/Domain/IgnoreAuditTrailAttribute.cs
+++ b/src/BuildingBlocks/Core/Domain/IgnoreAuditTrailAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace FSH.Framework.Core.Domain;
+
+/// <summary>
+/// Marks an entity class so that changes to it are NOT recorded in the audit trail.
+/// Apply to high-frequency internal entities like outbox messages, inbox messages, or session tokens
+/// that do not require compliance auditing.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class IgnoreAuditTrailAttribute : Attribute { }

--- a/src/BuildingBlocks/Eventing/Inbox/InboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Inbox/InboxMessage.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -6,6 +7,7 @@ namespace FSH.Framework.Eventing.Inbox;
 /// <summary>
 /// Inbox message to track processed integration events per handler for idempotent consumers.
 /// </summary>
+[IgnoreAuditTrail]
 public class InboxMessage
 {
     public Guid Id { get; set; }

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -6,6 +7,7 @@ namespace FSH.Framework.Eventing.Outbox;
 /// <summary>
 /// Outbox message entity used to persist integration events alongside domain changes.
 /// </summary>
+[IgnoreAuditTrail]
 public class OutboxMessage
 {
     public Guid Id { get; set; }

--- a/src/Modules/Auditing/Modules.Auditing/Persistence/AuditingSaveChangesInterceptor.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/AuditingSaveChangesInterceptor.cs
@@ -1,6 +1,7 @@
-﻿using FSH.Modules.Auditing.Contracts;
+using FSH.Modules.Auditing.Contracts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using FSH.Framework.Core.Domain;
 
 namespace FSH.Modules.Auditing.Persistence;
 
@@ -24,6 +25,7 @@ public sealed class AuditingSaveChangesInterceptor : SaveChangesInterceptor
 
         var entries = ctx.ChangeTracker.Entries()
             .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+            .Where(e => !Attribute.IsDefined(e.Entity.GetType(), typeof(IgnoreAuditTrailAttribute)))
             .ToArray();
 
         if (entries.Length == 0) return result;

--- a/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs
@@ -3,6 +3,7 @@ using FSH.Modules.Identity.Domain.Events;
 
 namespace FSH.Modules.Identity.Domain;
 
+[IgnoreAuditTrail]
 public class UserSession : IHasDomainEvents
 {
     private readonly List<IDomainEvent> _domainEvents = [];


### PR DESCRIPTION
# [Fix] Implement IgnoreAuditTrail Attribute for Infrastructure Entities

## Description
This Pull Request implements the `[IgnoreAuditTrail]` attribute to optimize the auditing system. It allows specific high-frequency or technical entities to be excluded from the audit logs, reducing database noise and improving general performance.

## Changes
- **BuildingBlocks.Core**: Created [IgnoreAuditTrailAttribute](cci:2://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Core/Domain/IgnoreAuditTrailAttribute.cs:9:0-10:61) to serve as an opt-out decorator.
- **Modules.Auditing**: Updated [AuditingSaveChangesInterceptor](cci:2://file:///c:/github/dotnet-starter-kit/src/Modules/Auditing/Modules.Auditing/Persistence/AuditingSaveChangesInterceptor.cs:10:0-66:1) to filter and skip any entity decorated with `[IgnoreAuditTrail]` before publishing audit events.
- **Infrastructure Entities**: Applied the attribute to:
    - [OutboxMessage](cci:2://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs:9:0-31:1) (Eventing)
    - [InboxMessage](cci:2://file:///c:/github/dotnet-starter-kit/src/BuildingBlocks/Eventing/Inbox/InboxMessage.cs:9:0-21:1) (Eventing)
    - [UserSession](cci:1://file:///c:/github/dotnet-starter-kit/src/Modules/Identity/Modules.Identity/Domain/UserSession.cs:28:4-28:29) (Identity)

## Verification
- **Build**: Successfully ran `dotnet build src/FSH.Framework.slnx` with 0 errors.
- **Logic**: Verified through temporary `InMemoryDatabase` unit tests (which were deleted after confirmation) that:
    - Tagged entities are correctly ignored by the interceptor.
    - Non-tagged entities continue to be audited as expected.

## Technical Debt
- **Issue #15 Dependency**: Once the central `AuditableEntitySaveChangesInterceptor` is merged into `develop`, it should also be updated to check for this attribute to prevent populating metadata fields (CreatedOn/By, etc.) on ignored entities.
