### PR TITLE
fix(auditing): add missing base.OnModelCreating() call in AuditDbContext

### DIFF
--- a/src/Modules/Auditing/Modules.Auditing/Persistence/AuditDbContext.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/AuditDbContext.cs
@@ -20,6 +20,7 @@ public sealed class AuditDbContext : BaseDbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
+        base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AuditDbContext).Assembly);
     }
 }


### PR DESCRIPTION
## Summary

- Adds the missing `base.OnModelCreating(modelBuilder)` call in `AuditDbContext`, ensuring Finbuckle's multi-tenant query filters are properly activated for audit records.
- Without this call, the `.IsMultiTenant()` configuration on `AuditRecord` was never converted into actual EF Core query filters, risking cross-tenant data leakage.
- Aligns with the established pattern used by `IdentityDbContext` and `TenantDbContext`.

> **Note:** The issue also mentions broken soft-delete filtering, but `AuditRecord` does not implement `ISoftDeletable`, so that claim does not apply.

Closes #1226

## Test plan

- [ ] Verify `dotnet build src/FSH.Framework.slnx` succeeds
- [ ] Verify `dotnet test src/FSH.Framework.slnx` passes
- [ ] Confirm audit queries are tenant-isolated with the fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)