### PR TITLE
fix(persistence): add AuditableEntitySaveChangesInterceptor with async-safe recursion guard

### DIFF
--- a/src/BuildingBlocks/Persistence/Inteceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/BuildingBlocks/Persistence/Inteceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -1,0 +1,115 @@
+using FSH.Framework.Core.Context;
+using FSH.Framework.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace FSH.Framework.Persistence.Inteceptors;
+
+/// <summary>
+/// Interceptor that automatically populates audit metadata for entities implementing <see cref="IAuditableEntity"/>
+/// and handles soft delete for entities implementing <see cref="ISoftDeletable"/>.
+/// Uses an <see cref="AsyncLocal{T}"/> recursion guard to prevent StackOverflowException from nested SaveChanges calls.
+/// </summary>
+public sealed class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
+{
+    private readonly ICurrentUser _currentUser;
+    private readonly TimeProvider _timeProvider;
+
+    private static readonly AsyncLocal<bool> _isSaving = new();
+
+    public AuditableEntitySaveChangesInterceptor(ICurrentUser currentUser, TimeProvider timeProvider)
+    {
+        _currentUser = currentUser;
+        _timeProvider = timeProvider;
+    }
+
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(eventData);
+
+        if (_isSaving.Value)
+        {
+            return await base.SavingChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            _isSaving.Value = true;
+            UpdateAuditEntities(eventData.Context);
+            return await base.SavingChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _isSaving.Value = false;
+        }
+    }
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        ArgumentNullException.ThrowIfNull(eventData);
+
+        if (_isSaving.Value)
+        {
+            return base.SavingChanges(eventData, result);
+        }
+
+        try
+        {
+            _isSaving.Value = true;
+            UpdateAuditEntities(eventData.Context);
+            return base.SavingChanges(eventData, result);
+        }
+        finally
+        {
+            _isSaving.Value = false;
+        }
+    }
+
+    private void UpdateAuditEntities(DbContext? context)
+    {
+        if (context is null) return;
+
+        var userId = _currentUser.IsAuthenticated() ? _currentUser.GetUserId().ToString() : null;
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var entry in context.ChangeTracker.Entries())
+        {
+            if (entry.Entity is IAuditableEntity)
+            {
+                if (entry.State == EntityState.Added)
+                {
+                    entry.Property(nameof(IAuditableEntity.CreatedOnUtc)).CurrentValue = now;
+                    entry.Property(nameof(IAuditableEntity.CreatedBy)).CurrentValue = userId;
+                }
+                else if (entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
+                {
+                    entry.Property(nameof(IAuditableEntity.LastModifiedOnUtc)).CurrentValue = now;
+                    entry.Property(nameof(IAuditableEntity.LastModifiedBy)).CurrentValue = userId;
+                }
+            }
+
+            if (entry.Entity is ISoftDeletable && entry.State == EntityState.Deleted)
+            {
+                entry.State = EntityState.Modified;
+                entry.Property(nameof(ISoftDeletable.IsDeleted)).CurrentValue = true;
+                entry.Property(nameof(ISoftDeletable.DeletedOnUtc)).CurrentValue = now;
+                entry.Property(nameof(ISoftDeletable.DeletedBy)).CurrentValue = userId;
+            }
+        }
+    }
+}
+
+internal static class EntityEntryExtensions
+{
+    public static bool HasChangedOwnedEntities(this EntityEntry entry) =>
+        entry.References.Any(r =>
+            r.TargetEntry is not null &&
+            r.TargetEntry.Metadata.IsOwned() &&
+            (r.TargetEntry.State == EntityState.Added || r.TargetEntry.State == EntityState.Modified));
+}

--- a/src/BuildingBlocks/Persistence/PersistenceExtensions.cs
+++ b/src/BuildingBlocks/Persistence/PersistenceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FSH.Framework.Persistence.Inteceptors;
+using FSH.Framework.Persistence.Inteceptors;
 using FSH.Framework.Shared.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -31,6 +31,8 @@ public static class PersistenceExtensions
             .Validate(o => !string.IsNullOrWhiteSpace(o.Provider), "DatabaseOptions.Provider is required.")
             .ValidateOnStart();
         services.AddHostedService<DatabaseOptionsStartupLogger>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddScoped<ISaveChangesInterceptor, AuditableEntitySaveChangesInterceptor>();
         services.AddScoped<ISaveChangesInterceptor, DomainEventsInterceptor>();
         return services;
     }


### PR DESCRIPTION
## Summary

Supersedes #1223 — rebased onto latest `develop` with critical bug fixes applied.

- **AuditableEntitySaveChangesInterceptor**: Automatically populates `IAuditableEntity` audit metadata and converts `ISoftDeletable` deletes into soft-delete updates
- **Async-safe recursion guard**: Uses `AsyncLocal<bool>` (not `[ThreadStatic]`) to prevent `StackOverflowException` from nested `SaveChanges` calls
- **Global registration**: Interceptor registered via `AddHeroDatabaseOptions` alongside `DomainEventsInterceptor`

## Changes from original PR (#1223)

| Fix | Detail |
|-----|--------|
| `[ThreadStatic]` → `AsyncLocal<bool>` | Original guard was broken for async code — after `await`, execution can resume on a different thread |
| `Extensions` → `EntityEntryExtensions` | Renamed to `internal static class` to avoid namespace pollution |
| Added `.ConfigureAwait(false)` | On all `await` calls per project conventions |
| Added `ArgumentNullException.ThrowIfNull` | Guard clauses on `eventData` to fix CA1062 warnings |
| `TryAddSingleton` for `TimeProvider` | Prevents duplicate registration |
| Merge conflict resolved | `PersistenceExtensions.cs` merged cleanly with existing `DomainEventsInterceptor` registration |

## Test plan

- [x] `dotnet build src/FSH.Framework.slnx` — 0 errors, 0 new warnings
- [ ] Verify audit fields are populated on entity create/update
- [ ] Verify soft-delete converts DELETE → UPDATE with metadata
- [ ] Verify no StackOverflow on nested SaveChanges scenarios

Credit: @cesarcastrocuba (original implementation in #1223)

🤖 Generated with [Claude Code](https://claude.com/claude-code)