### PR TITLE
fix: http(s) scheme validation for webhook URLs + cross-platform BuildingBlocks tests

### DIFF
--- a/src/Modules/Webhooks/Modules.Webhooks/Features/v1/CreateWebhookSubscription/CreateWebhookSubscriptionCommandValidator.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Features/v1/CreateWebhookSubscription/CreateWebhookSubscriptionCommandValidator.cs
@@ -7,7 +7,9 @@ public sealed class CreateWebhookSubscriptionCommandValidator : AbstractValidato
 {
     public CreateWebhookSubscriptionCommandValidator()
     {
-        RuleFor(x => x.Url).NotEmpty().Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
+        RuleFor(x => x.Url).NotEmpty()
+            .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
             .WithMessage("A valid absolute URL is required.");
         RuleFor(x => x.Events).NotEmpty().WithMessage("At least one event type is required.");
     }

--- a/src/Tests/Architecture.Tests/BuildingBlocksIndependenceTests.cs
+++ b/src/Tests/Architecture.Tests/BuildingBlocksIndependenceTests.cs
@@ -95,7 +95,7 @@ public class BuildingBlocksIndependenceTests
 
             foreach (string include in references)
             {
-                string referencedName = Path.GetFileNameWithoutExtension(include);
+                string referencedName = GetReferencedProjectName(include);
 
                 // Check if it references a Modules project
                 if (referencedName.StartsWith("Modules.", StringComparison.OrdinalIgnoreCase))
@@ -224,7 +224,7 @@ public class BuildingBlocksIndependenceTests
         var projectReferences = document
             .Descendants("ProjectReference")
             .Select(x => (string?)x.Attribute("Include") ?? string.Empty)
-            .Select(p => Path.GetFileNameWithoutExtension(p))
+            .Select(GetReferencedProjectName)
             .Where(p => !string.IsNullOrEmpty(p))
             .ToArray();
 
@@ -236,4 +236,11 @@ public class BuildingBlocksIndependenceTests
             }
         }
     }
+
+    // ProjectReference Include paths are authored with Windows separators (e.g. ..\Core\Core.csproj).
+    // Path.GetFileNameWithoutExtension only treats '\' as a separator on Windows, so on Linux CI it
+    // returns the whole path minus the extension. Normalize to '/' first to get the bare project name
+    // on every platform.
+    private static string GetReferencedProjectName(string includePath) =>
+        Path.GetFileNameWithoutExtension(includePath.Replace('\\', '/'));
 }


### PR DESCRIPTION
@
## Summary

Two fixes carried on top of the distribution branch:

- **fix(webhooks): require http(s) scheme for subscription URL** — `Uri.TryCreate(UriKind.Absolute)` accepts leading-`/` paths as `file://` on Unix (but not Windows), so the webhook subscription URL validator now also asserts the scheme is `http`/`https`. Fixes a Linux-only CI flake.
- **fix(tests): make BuildingBlocks dependency checks cross-platform** — `BuildingBlocksIndependenceTests` no longer assumes Windows path separators.

## Changes
- `CreateWebhookSubscriptionCommandValidator.cs` — scheme guard on the subscription URL.
- `BuildingBlocksIndependenceTests.cs` — cross-platform path handling.

## Test plan
- [x] `dotnet test src/FSH.Starter.slnx` (architecture + webhook validation suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@