### PR TITLE
fix(web): return 400 (not 500) for missing required `tenant` header (#1245)

### DIFF
--- a/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
+++ b/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
@@ -67,6 +67,19 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
             problemDetails.Title = "Not Found";
             problemDetails.Detail = exception.Message;
         }
+        else if (exception is BadHttpRequestException badRequest)
+        {
+            // ASP.NET Core throws BadHttpRequestException for malformed requests:
+            // a missing required header/route/query parameter (e.g. the `tenant`
+            // header on tenant-scoped endpoints), an unreadable body, or a body
+            // that exceeds the size limit. These are client errors and the
+            // exception already carries the correct status (usually 400) — honour
+            // it instead of letting it fall through to a generic 500.
+            statusCode = badRequest.StatusCode;
+            problemDetails.Status = statusCode;
+            problemDetails.Title = "Bad Request";
+            problemDetails.Detail = badRequest.Message;
+        }
         else
         {
             statusCode = StatusCodes.Status500InternalServerError;

--- a/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
+++ b/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,64 @@
+using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Web.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net;
+
+namespace Framework.Tests.Web;
+
+public sealed class GlobalExceptionHandlerTests
+{
+    private static async Task<HttpContext> HandleAsync(Exception exception)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/v1/identity/forgot-password";
+        context.Response.Body = new MemoryStream();
+
+        var handler = new GlobalExceptionHandler(NullLogger<GlobalExceptionHandler>.Instance);
+        await handler.TryHandleAsync(context, exception, CancellationToken.None);
+        return context;
+    }
+
+    // Regression for #1245: a missing required `tenant` header surfaces as a
+    // BadHttpRequestException during parameter binding. It must be rendered with
+    // the framework's own status (400), not the generic 500 fallback.
+    [Fact]
+    public async Task TryHandleAsync_Should_Map_BadHttpRequestException_To_ItsStatusCode()
+    {
+        var exception = new BadHttpRequestException(
+            "Required parameter \"string tenant\" was not provided from header.");
+
+        var context = await HandleAsync(exception);
+
+        exception.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_Should_Honour_NonDefault_BadHttpRequestException_StatusCode()
+    {
+        var exception = new BadHttpRequestException(
+            "Request body too large.", StatusCodes.Status413PayloadTooLarge);
+
+        var context = await HandleAsync(exception);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_Should_Map_CustomException_To_ItsStatusCode()
+    {
+        var context = await HandleAsync(
+            new CustomException("conflict", errors: null, HttpStatusCode.Conflict));
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status409Conflict);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_Should_Default_To_500_For_UnknownException()
+    {
+        var context = await HandleAsync(new InvalidOperationException("boom"));
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/Tests/Integration.Tests/Infrastructure/DetailedTestExceptionHandler.cs
+++ b/src/Tests/Integration.Tests/Infrastructure/DetailedTestExceptionHandler.cs
@@ -48,6 +48,14 @@ public sealed class DetailedTestExceptionHandler : IExceptionHandler
                 problemDetails.Extensions["errors"] = customEx.ErrorMessages;
             }
         }
+        else if (exception is BadHttpRequestException badRequest)
+        {
+            // Mirror GlobalExceptionHandler: malformed requests (missing required
+            // header/route/query param, unreadable body) carry their own status.
+            statusCode = badRequest.StatusCode;
+            problemDetails.Title = "Bad Request";
+            problemDetails.Detail = badRequest.Message;
+        }
         else
         {
             problemDetails.Title = exception.GetType().Name;

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/MissingTenantTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/MissingTenantTests.cs
@@ -1,0 +1,63 @@
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Multitenancy;
+
+// Regression for #1245: anonymous, tenant-scoped endpoints bind a required
+// `tenant` header. When it's missing, ASP.NET Core throws BadHttpRequestException
+// (StatusCode 400) during parameter binding. GlobalExceptionHandler used to let
+// that fall through to a generic 500; it must now surface the framework's 400.
+[Collection(FshCollectionDefinition.Name)]
+public sealed class MissingTenantTests
+{
+    private readonly FshWebApplicationFactory _factory;
+
+    public MissingTenantTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ForgotPassword_Should_Return400_When_TenantHeaderMissing()
+    {
+        using var client = _factory.CreateClient(); // anonymous, NO tenant header
+
+        var response = await client.PostAsJsonAsync(
+            $"{TestConstants.IdentityBasePath}/forgot-password",
+            new { email = "nobody@example.com" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ResetPassword_Should_Return400_When_TenantHeaderMissing()
+    {
+        using var client = _factory.CreateClient(); // anonymous, NO tenant header
+
+        var response = await client.PostAsJsonAsync(
+            $"{TestConstants.IdentityBasePath}/reset-password",
+            new { email = "nobody@example.com", token = "x", password = "Test@1234!" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SelfRegister_Should_Return400_When_TenantHeaderMissing()
+    {
+        using var client = _factory.CreateClient(); // anonymous, NO tenant header
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+
+        var response = await client.PostAsJsonAsync(
+            $"{TestConstants.IdentityBasePath}/self-register",
+            new
+            {
+                firstName = "Self",
+                lastName = "Reg",
+                email = $"self-{uniqueId}@example.com",
+                userName = $"selfreg-{uniqueId}",
+                password = "Test@1234!",
+                confirmPassword = "Test@1234!"
+            });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1245 — a tenant-scoped endpoint returned **500 Internal Server Error** when the tenant ID was missing, instead of a proper client error.

## Root cause

The anonymous, tenant-scoped identity endpoints (`forgot-password`, `reset-password`, `self-register`) bind a **required `[FromHeader] tenant` parameter**. When it is missing, ASP.NET Core throws `Microsoft.AspNetCore.Http.BadHttpRequestException` (which carries `StatusCode = 400`) during parameter binding. `GlobalExceptionHandler` did not recognise that type, so it fell through to the generic **500** branch.

Notes from the investigation:
- Authenticated CRUD endpoints do **not** reproduce this — the JWT `tenant` claim resolves the tenant even without the header, so the bug only bites the anonymous endpoints that require the header.
- It is **not** a null-reference in Finbuckle's tenant query filter (the filter is null-safe).

## Fix

- `GlobalExceptionHandler` now maps `BadHttpRequestException` to its own `StatusCode` (400, or 413 for oversized bodies, etc.) with a `ProblemDetails` body. This covers **every** endpoint with a required bound header/route/query param, not just identity.
- Mirrored the mapping in the test-only `DetailedTestExceptionHandler` so tests reflect production behaviour.

## Tests

- 3 integration regression tests: `forgot-password` / `reset-password` / `self-register` without the `tenant` header now return **400** (were 500).
- 4 `GlobalExceptionHandler` unit tests (400, 413, `CustomException` pass-through, 500 default).
- Full integration suite: **668 passed, 2 skipped, 0 failed**. Backend builds clean (0 warnings).

## Docs

Changelog entry: fullstackhero/docs#218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
