### PR TITLE
fix(dashboard): UX/a11y/perf/correctness pass

### DIFF
--- a/clients/dashboard/src/components/auth/demo-accounts-dialog.tsx
+++ b/clients/dashboard/src/components/auth/demo-accounts-dialog.tsx
@@ -149,7 +149,7 @@ function TenantRail({
                 "font-display text-[15px] font-semibold tabular-nums",
                 "transition-all duration-300",
                 isActive
-                  ? "bg-primary text-white shadow-[0_4px_14px_color-mix(in_srgb,var(--primary)_35%,transparent)]"
+                  ? "bg-primary text-primary-foreground shadow-[0_4px_14px_color-mix(in_srgb,var(--primary)_35%,transparent)]"
                   : "border border-border/80 bg-background text-muted-foreground/70 group-hover:border-primary/30 group-hover:text-primary",
               ].join(" ")}
             >
@@ -235,7 +235,7 @@ function UserRow({
       />
 
       {/* Initial monogram */}
-      <span className="relative flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background font-mono text-[10.5px] font-semibold text-muted-foreground/80 transition-all duration-300 group-hover:border-primary group-hover:bg-primary group-hover:text-white group-hover:shadow-[0_0_0_3px_color-mix(in_srgb,var(--primary)_18%,transparent)]">
+      <span className="relative flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background font-mono text-[10.5px] font-semibold text-muted-foreground/80 transition-all duration-300 group-hover:border-primary group-hover:bg-primary group-hover:text-primary-foreground group-hover:shadow-[0_0_0_3px_color-mix(in_srgb,var(--primary)_18%,transparent)]">
         {initials || "?"}
       </span>
 

--- a/clients/dashboard/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/dashboard/src/components/command-palette/command-palette-dialog.tsx
@@ -425,7 +425,7 @@ export function CommandPaletteDialog({
               placeholder="Type a command or search…"
               aria-label="Search commands"
               className={cn(
-                "h-7 flex-1 bg-transparent text-[14px] tracking-tight placeholder:text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]",
+                "h-7 flex-1 bg-transparent text-[14px] tracking-tight placeholder:text-[var(--color-muted-foreground)]",
                 "focus:outline-none focus-visible:outline-none focus-visible:shadow-none",
               )}
               autoFocus

--- a/clients/dashboard/src/components/file/file-dropzone.tsx
+++ b/clients/dashboard/src/components/file/file-dropzone.tsx
@@ -236,7 +236,14 @@ function detailFor(
 function ProgressBar({ percent, loaded, total }: { percent: number; loaded: number; total: number }) {
   return (
     <div className="w-full max-w-sm space-y-1.5">
-      <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-muted)]">
+      <div
+        role="progressbar"
+        aria-label="Upload progress"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="relative h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-muted)]"
+      >
         <span
           aria-hidden
           className="absolute inset-y-0 left-0 rounded-full bg-[var(--color-primary)] transition-[width] duration-200"

--- a/clients/dashboard/src/components/file/product-image-manager.tsx
+++ b/clients/dashboard/src/components/file/product-image-manager.tsx
@@ -221,7 +221,7 @@ function ImageTile({
             disabled={busy}
             title="Set as cover"
             aria-label="Set as cover"
-            className="bg-[oklch(0_0_0/0.45)] text-white hover:bg-[oklch(0_0_0/0.65)]"
+            className="bg-[var(--color-overlay)] text-[var(--color-overlay-foreground)] hover:bg-[oklch(0_0_0/0.65)]"
           >
             <StarOff className="h-4 w-4" />
           </Button>
@@ -237,7 +237,7 @@ function ImageTile({
           disabled={busy}
           title="Remove image"
           aria-label="Remove image"
-          className="bg-[oklch(0_0_0/0.45)] text-white hover:bg-[var(--color-destructive)]"
+          className="bg-[var(--color-overlay)] text-[var(--color-overlay-foreground)] hover:bg-[var(--color-destructive)]"
         >
           <Trash2 className="h-4 w-4" />
         </Button>

--- a/clients/dashboard/src/components/layout/mobile-nav.tsx
+++ b/clients/dashboard/src/components/layout/mobile-nav.tsx
@@ -9,7 +9,12 @@ import {
 } from "react";
 import { useLocation } from "react-router-dom";
 import { Menu } from "lucide-react";
-import { Sheet, SheetContent } from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { SidebarNavBody } from "@/components/layout/sidebar";
 import { findSectionForPath } from "@/components/layout/nav-data";
 import { cn } from "@/lib/cn";
@@ -79,11 +84,13 @@ export function MobileNavRoot() {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetContent
-        side="left"
-        aria-label="Primary navigation"
-        className="flex flex-col p-0"
-      >
+      <SheetContent side="left" className="flex flex-col p-0">
+        {/* Radix Dialog requires a Title for the accessible name; keep it
+            visually hidden so the drawer chrome is unchanged. */}
+        <DialogTitle className="sr-only">Primary navigation</DialogTitle>
+        <DialogDescription className="sr-only">
+          Site sections and account links.
+        </DialogDescription>
         {/* Brand row — matches Topbar height so the drawer top aligns
             with the rest of the chrome. */}
         <div className="flex h-14 shrink-0 items-center gap-2.5 border-b border-[var(--color-border)] px-4">

--- a/clients/dashboard/src/components/layout/sidebar.tsx
+++ b/clients/dashboard/src/components/layout/sidebar.tsx
@@ -391,6 +391,9 @@ function NavItemLink({
       to={item.to}
       end={item.to === "/"}
       title={collapsed ? item.label : undefined}
+      // When collapsed the text label is hidden, so the icon-only link needs
+      // an explicit accessible name (title alone is the weakest AT signal).
+      aria-label={collapsed ? item.label : undefined}
       onClick={onNavigate}
       className={({ isActive }) =>
         cn(

--- a/clients/dashboard/src/components/list/combobox.tsx
+++ b/clients/dashboard/src/components/list/combobox.tsx
@@ -43,7 +43,6 @@ export function Combobox({
   variant = "field",
   align = "start",
   disabled,
-  required,
   id,
   className,
 }: {
@@ -59,6 +58,7 @@ export function Combobox({
   variant?: Variant;
   align?: "start" | "end" | "center";
   disabled?: boolean;
+  /** Accepted for API symmetry; the required indicator is rendered by the wrapping <Field>. */
   required?: boolean;
   id?: string;
   className?: string;
@@ -85,10 +85,12 @@ export function Combobox({
   const selected = options.find((o) => o.value === value) ?? null;
   const hasValue = value !== null && value !== "";
 
+  const showFieldClear = clearable && hasValue && !disabled;
+
   return (
     <DropdownMenu open={open} onOpenChange={(o) => !disabled && setOpen(o)}>
-      <DropdownMenuTrigger asChild disabled={disabled}>
-        {variant === "filter" ? (
+      {variant === "filter" ? (
+        <DropdownMenuTrigger asChild disabled={disabled}>
           <FilterTrigger
             label={label}
             selected={selected}
@@ -98,20 +100,35 @@ export function Combobox({
             disabled={disabled}
             className={className}
           />
-        ) : (
-          <FieldTrigger
-            id={id}
-            placeholder={placeholder ?? `Select ${label.toLowerCase()}…`}
-            selected={selected}
-            hasValue={hasValue}
-            clearable={clearable}
-            onClear={() => onChange(null)}
-            disabled={disabled}
-            required={required}
-            className={className}
-          />
-        )}
-      </DropdownMenuTrigger>
+        </DropdownMenuTrigger>
+      ) : (
+        // The clear control is a sibling of the trigger (not nested inside it):
+        // an interactive element inside another interactive element is invalid
+        // and unreliable for keyboard/AT.
+        <div className="relative">
+          <DropdownMenuTrigger asChild disabled={disabled}>
+            <FieldTrigger
+              id={id}
+              placeholder={placeholder ?? `Select ${label.toLowerCase()}…`}
+              selected={selected}
+              hasValue={hasValue}
+              hasClear={showFieldClear}
+              disabled={disabled}
+              className={className}
+            />
+          </DropdownMenuTrigger>
+          {showFieldClear && (
+            <button
+              type="button"
+              aria-label={`Clear ${label.toLowerCase()}`}
+              onClick={() => onChange(null)}
+              className="absolute right-8 top-1/2 grid h-5 w-5 -translate-y-1/2 cursor-pointer place-items-center rounded text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      )}
 
       <DropdownMenuContent
         align={align}
@@ -136,7 +153,7 @@ export function Combobox({
               }}
               className={cn(
                 "h-6 w-full bg-transparent text-sm",
-                "placeholder:text-[var(--color-muted-foreground)]/70",
+                "placeholder:text-[var(--color-muted-foreground)]",
                 // The popover row is already a contained visual context — skip
                 // the global :focus-visible halo so it doesn't draw a hard
                 // rectangle + 6px outer bloom around the search input.
@@ -160,7 +177,7 @@ export function Combobox({
           </DropdownMenuRow>
         )}
 
-        <ul className="max-h-[300px] overflow-y-auto py-1">
+        <ul role="none" className="max-h-[300px] overflow-y-auto py-1">
           {emptyOptionLabel && (!filter || emptyOptionLabel.toLowerCase().includes(filter.toLowerCase())) && (
             <Option
               selected={value === null || value === ""}
@@ -215,12 +232,12 @@ function Option({
   children: React.ReactNode;
 }) {
   return (
-    <li>
+    <li role="none">
       <button
         type="button"
         onClick={onPick}
-        role="option"
-        aria-selected={selected}
+        role="menuitemradio"
+        aria-checked={selected}
         className={cn(
           "group/opt flex w-full cursor-pointer items-center gap-2.5 px-3 py-1.5 text-left text-sm",
           "transition-colors duration-[var(--duration-fast)]",
@@ -309,10 +326,8 @@ const FieldTrigger = ({
   placeholder,
   selected,
   hasValue,
-  clearable,
-  onClear,
+  hasClear,
   disabled,
-  required,
   className,
   ...props
 }: {
@@ -320,23 +335,20 @@ const FieldTrigger = ({
   placeholder: string;
   selected: ComboboxOption | null;
   hasValue: boolean;
-  clearable: boolean;
-  onClear: () => void;
+  /** Reserve a slot for the sibling clear button so the label doesn't underlap it. */
+  hasClear?: boolean;
   disabled?: boolean;
-  required?: boolean;
   className?: string;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
+    // A plain menu-button: Radix's DropdownMenuTrigger forwards
+    // aria-haspopup="menu" + aria-expanded via asChild, so no explicit
+    // role is needed (and role="combobox" without aria-controls/-expanded
+    // would be an invalid name/role/value pairing). `required` is conveyed
+    // by the wrapping <Field> label, not aria-required (unsupported on a button).
     <button
       id={id}
       type="button"
-      // role="combobox" requires aria-controls + aria-expanded. This
-      // component is intended as a Radix Popover.Trigger child via
-      // asChild, which sets both at runtime via prop forwarding —
-      // ESLint can't see that statically.
-      // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-      role="combobox"
-      aria-required={required}
       disabled={disabled}
       className={cn(
         "group/field relative flex h-9 w-full cursor-pointer items-center justify-between gap-2",
@@ -365,27 +377,8 @@ const FieldTrigger = ({
         </span>
       </span>
       <span className="flex shrink-0 items-center gap-1">
-        {clearable && hasValue && (
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label="Clear"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClear();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                e.stopPropagation();
-                onClear();
-              }
-            }}
-            className="grid h-5 w-5 cursor-pointer place-items-center rounded text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
-          >
-            <X className="h-3 w-3" />
-          </span>
-        )}
+        {/* Reserve room for the sibling clear button so the label can't run under it. */}
+        {hasClear && <span aria-hidden className="h-5 w-5" />}
         <ChevronDown
           aria-hidden
           className={cn(

--- a/clients/dashboard/src/components/list/entity-shell.tsx
+++ b/clients/dashboard/src/components/list/entity-shell.tsx
@@ -81,13 +81,14 @@ export function EntitySearch({
       <input
         type="text"
         placeholder={placeholder}
+        aria-label={placeholder ?? "Search"}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         autoFocus={autoFocus}
         className={cn(
           "h-[46px] w-full rounded-xl border border-[var(--color-border)] bg-[var(--color-card)]",
           "pl-12 pr-4 text-[14px] font-normal text-[var(--color-foreground)] outline-none",
-          "placeholder:text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]",
+          "placeholder:text-[var(--color-muted-foreground)]",
           "shadow-xs",
           "transition-all duration-200",
           "focus:border-[oklch(from_var(--color-ring)_l_c_h_/_0.30)] focus:ring-2 focus:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.10)]",
@@ -96,7 +97,8 @@ export function EntitySearch({
       {value && (
         <button
           onClick={() => onChange("")}
-          className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer text-[11px] font-medium text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)] transition-colors hover:text-[var(--color-muted-foreground)]"
+          aria-label="Clear search"
+          className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer text-[11px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
           type="button"
         >
           Clear
@@ -221,9 +223,9 @@ export function EntityEmpty({
       <div className="mb-4 grid size-14 place-items-center rounded-2xl bg-[var(--color-muted)]">
         <Icon className="size-6 text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.4)]" />
       </div>
-      <h3 className="mb-1.5 font-display text-[17px] font-semibold text-[var(--color-foreground)]">
+      <h2 className="mb-1.5 font-display text-[17px] font-semibold text-[var(--color-foreground)]">
         {title}
-      </h3>
+      </h2>
       {body && (
         <p className="mb-6 max-w-[320px] text-[13px] text-[var(--color-muted-foreground)]">
           {body}
@@ -477,7 +479,8 @@ export function EntityListLoading({
   mobile?: boolean;
 }) {
   return (
-    <div>
+    <div role="status" aria-busy="true">
+      <span className="sr-only">Loading…</span>
       {mobile && (
         <div className="space-y-2 md:hidden">
           {Array.from({ length: rows }).map((_, i) => (

--- a/clients/dashboard/src/components/notifications/notification-bell.tsx
+++ b/clients/dashboard/src/components/notifications/notification-bell.tsx
@@ -89,6 +89,7 @@ export function NotificationBell() {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
+          data-notification-bell
           aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ""}`}
           title="Notifications"
           className={cn(

--- a/clients/dashboard/src/components/theme/theme-provider.tsx
+++ b/clients/dashboard/src/components/theme/theme-provider.tsx
@@ -42,10 +42,14 @@ type ThemeContextValue = {
   setCustomAccent: (spec: CustomAccentSpec) => void;
   density: DensityMode;
   setDensity: (next: DensityMode) => void;
+  /** When true, forces reduced motion regardless of the OS setting. */
+  reducedMotion: boolean;
+  setReducedMotion: (next: boolean) => void;
 };
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 const THEME_STORAGE_KEY = "fsh.theme";
+const REDUCED_MOTION_STORAGE_KEY = "fsh.reduce-motion";
 const ACCENT_CLASS_PREFIX = "accent-";
 const FALLBACK_TRANSITION_MS = 280;
 
@@ -204,6 +208,20 @@ function applyDensity(value: DensityMode) {
   document.documentElement.classList.toggle("density-compact", value === "compact");
 }
 
+function readStoredReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(REDUCED_MOTION_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function applyReducedMotion(value: boolean) {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("reduce-motion", value);
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [mode, setModeState] = useState<ThemeMode>(() => readStoredMode());
   const [resolved, setResolved] = useState<ResolvedTheme>(() =>
@@ -228,6 +246,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const stored = readStoredString(DENSITY_STORAGE_KEY, DEFAULT_DENSITY);
     return stored === "compact" ? "compact" : DEFAULT_DENSITY;
   });
+  const [reducedMotion, setReducedMotionState] = useState<boolean>(() =>
+    readStoredReducedMotion(),
+  );
 
   // Apply font / accent / density — covers initial render and any
   // subsequent change. The dark class is owned by withThemeTransition
@@ -237,6 +258,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => applyFont(font), [font]);
   useEffect(() => applyAccent(accent, customAccent), [accent, customAccent]);
   useEffect(() => applyDensity(density), [density]);
+  useEffect(() => applyReducedMotion(reducedMotion), [reducedMotion]);
 
   // Subscribe to system preference while in "system" mode. Future OS
   // changes route through withThemeTransition so they crossfade too.
@@ -318,6 +340,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const setReducedMotion = useCallback((next: boolean) => {
+    setReducedMotionState(next);
+    try {
+      window.localStorage.setItem(REDUCED_MOTION_STORAGE_KEY, String(next));
+    } catch {
+      /* storage unavailable */
+    }
+  }, []);
+
   const value = useMemo<ThemeContextValue>(
     () => ({
       mode, resolved, setMode,
@@ -325,6 +356,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       accent, setAccent,
       customAccent, setCustomAccent,
       density, setDensity,
+      reducedMotion, setReducedMotion,
     }),
     [
       mode, resolved, setMode,
@@ -332,6 +364,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       accent, setAccent,
       customAccent, setCustomAccent,
       density, setDensity,
+      reducedMotion, setReducedMotion,
     ],
   );
 

--- a/clients/dashboard/src/components/ui/dialog.tsx
+++ b/clients/dashboard/src/components/ui/dialog.tsx
@@ -33,7 +33,7 @@ export const DialogOverlay = React.forwardRef<
     ref={ref}
     data-slot="dialog-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/40 backdrop-blur-[6px]",
+      "fixed inset-0 z-50 bg-[oklch(0_0_0_/_0.4)] backdrop-blur-[6px]",
       "data-[state=open]:animate-fsh-overlay-in data-[state=closed]:animate-fsh-overlay-out",
       className,
     )}

--- a/clients/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/clients/dashboard/src/components/ui/dropdown-menu.tsx
@@ -77,10 +77,14 @@ export const DropdownMenuLinkItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     href: string;
   }
->(({ href, children, onClick, ...props }, ref) => {
+>(({ href, children, ...props }, ref) => {
   return (
-    <DropdownMenuItem ref={ref} onClick={onClick} {...props}>
-      <a href={href} className="flex w-full items-center gap-2.5">
+    // `asChild` makes the anchor itself the menuitem (keyboard-reachable,
+    // single role) rather than nesting an <a> inside a role="menuitem".
+    // Radix's Slot merges the Item's handlers (onClick/onSelect) onto the
+    // anchor, so they ride through `...props`.
+    <DropdownMenuItem ref={ref} asChild {...props}>
+      <a href={href} className="w-full">
         {children}
         <ChevronRight className="ml-auto h-3.5 w-3.5 text-[var(--color-muted-foreground)]" aria-hidden />
       </a>

--- a/clients/dashboard/src/components/ui/input.tsx
+++ b/clients/dashboard/src/components/ui/input.tsx
@@ -22,7 +22,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           "transition-[color,box-shadow,border-color,background-color] duration-[var(--duration-fast)] ease-[var(--ease-out-cubic)]",
           "selection:bg-[var(--color-primary)] selection:text-[var(--color-primary-foreground)]",
           "file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-[var(--color-foreground)]",
-          "placeholder:text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.6)]",
+          "placeholder:text-[var(--color-muted-foreground)]",
           "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
           "md:text-sm",
           "dark:bg-[oklch(from_var(--color-input)_l_c_h_/_0.3)]",

--- a/clients/dashboard/src/components/ui/switch.tsx
+++ b/clients/dashboard/src/components/ui/switch.tsx
@@ -39,7 +39,7 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         <span
           aria-hidden
           className={cn(
-            "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-[0_1px_2px_oklch(0_0_0_/_0.20)]",
+            "pointer-events-none inline-block h-4 w-4 rounded-full bg-[var(--color-overlay-foreground)] shadow-[0_1px_2px_oklch(0_0_0_/_0.20)]",
             "transition-transform duration-[var(--duration-default)] ease-[var(--ease-out-cubic)]",
             checked ? "translate-x-[18px]" : "translate-x-0.5",
           )}

--- a/clients/dashboard/src/pages/catalog/brands.tsx
+++ b/clients/dashboard/src/pages/catalog/brands.tsx
@@ -423,7 +423,7 @@ function BrandEditorDialog({
       description: brand?.description ?? "",
       logoUrl: brand?.logoUrl ?? "",
     }),
-    [brand?.id, brand?.name, brand?.description, brand?.logoUrl],
+    [brand?.name, brand?.description, brand?.logoUrl],
   );
 
   const [name, setName] = useState(initial.name);

--- a/clients/dashboard/src/pages/catalog/categories.tsx
+++ b/clients/dashboard/src/pages/catalog/categories.tsx
@@ -472,12 +472,7 @@ function CategoryEditorDialog({
       description: category?.description ?? "",
       parentCategoryId: category?.parentCategoryId ?? "",
     }),
-    [
-      category?.id,
-      category?.name,
-      category?.description,
-      category?.parentCategoryId,
-    ],
+    [category?.name, category?.description, category?.parentCategoryId],
   );
 
   const [name, setName] = useState(initial.name);

--- a/clients/dashboard/src/pages/chat/channel-settings.tsx
+++ b/clients/dashboard/src/pages/chat/channel-settings.tsx
@@ -360,7 +360,7 @@ function MemberRow({
           aria-label={`Remove ${display.name}`}
           className={cn(
             "grid h-8 w-8 cursor-pointer place-items-center rounded-md",
-            "text-[var(--color-muted-foreground)] hover:bg-[var(--color-destructive)] hover:text-white",
+            "text-[var(--color-muted-foreground)] hover:bg-[var(--color-destructive)] hover:text-[var(--color-destructive-foreground)]",
             "transition-colors duration-[var(--duration-fast)] ease-[var(--ease-out-cubic)]",
             "disabled:opacity-50",
           )}

--- a/clients/dashboard/src/pages/chat/chat-page.tsx
+++ b/clients/dashboard/src/pages/chat/chat-page.tsx
@@ -60,7 +60,7 @@ export function ChatPage() {
     staleTime: 30_000,
   });
 
-  const channels = channelsQuery.data ?? [];
+  const channels = useMemo(() => channelsQuery.data ?? [], [channelsQuery.data]);
 
   // Auto-pick the first channel when no channelId is in the route.
   useEffect(() => {

--- a/clients/dashboard/src/pages/chat/chat-search.tsx
+++ b/clients/dashboard/src/pages/chat/chat-search.tsx
@@ -228,10 +228,12 @@ function ResultPlaceholder({ label }: { label: string; mono?: boolean }) {
 function highlight(body: string, term: string): React.ReactNode {
   if (term.length === 0) return body;
   const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`(${escaped})`, "ig");
-  const parts = body.split(re);
+  const parts = body.split(new RegExp(`(${escaped})`, "ig"));
+  // split() with a capturing group emits the matched term as the odd-index
+  // segments; a case-insensitive equality is enough to pick them out (and
+  // avoids a stateful `/g` RegExp.test whose lastIndex drifts across calls).
   return parts.map((part, i) =>
-    re.test(part) && part.toLowerCase() === term.toLowerCase() ? (
+    part.toLowerCase() === term.toLowerCase() ? (
       <mark
         key={i}
         className="rounded-sm bg-[var(--color-primary-soft)] px-0.5 text-[var(--color-primary)]"

--- a/clients/dashboard/src/pages/chat/composer.tsx
+++ b/clients/dashboard/src/pages/chat/composer.tsx
@@ -607,8 +607,17 @@ function UploadingChip({
       </div>
       {/* Inline progress strip, hidden on error. */}
       {!isError && (
-        <div className="relative h-1 w-16 overflow-hidden rounded-full bg-[var(--color-card)]">
+        <div
+          role="progressbar"
+          aria-label="Upload progress"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={label}
+          className="relative h-1 w-16 overflow-hidden rounded-full bg-[var(--color-card)]"
+        >
           <span
+            aria-hidden
             className="absolute inset-y-0 left-0 bg-[var(--color-primary)] transition-[width] duration-[var(--duration-fast)]"
             style={{ width: `${Math.max(4, percent)}%` }}
           />

--- a/clients/dashboard/src/pages/chat/message-list.tsx
+++ b/clients/dashboard/src/pages/chat/message-list.tsx
@@ -567,13 +567,21 @@ export const MessageList = forwardRef<
         aria-relevant="additions"
         aria-label="Channel messages"
       >
+        {/* aria-hidden so these status rows aren't announced as new messages
+            by the role="log" live region (it only relays additions). */}
         {loadingOlder && (
-          <div className="flex h-9 items-center justify-center text-[11px] text-[var(--color-muted-foreground)]">
+          <div
+            aria-hidden
+            className="flex h-9 items-center justify-center text-[11px] text-[var(--color-muted-foreground)]"
+          >
             Loading older…
           </div>
         )}
         {!hasMoreOlder && messages.length >= 100 && (
-          <div className="flex h-9 items-center justify-center text-[11px] text-[var(--color-muted-foreground)]">
+          <div
+            aria-hidden
+            className="flex h-9 items-center justify-center text-[11px] text-[var(--color-muted-foreground)]"
+          >
             Beginning of the conversation
           </div>
         )}

--- a/clients/dashboard/src/pages/chat/message.tsx
+++ b/clients/dashboard/src/pages/chat/message.tsx
@@ -463,7 +463,7 @@ function AttachmentTile({ attachment }: { attachment: MessageAttachmentDto }) {
           className={cn(
             "pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between gap-2 px-2.5 py-1.5",
             "bg-gradient-to-t from-[oklch(0_0_0_/_0.55)] to-transparent",
-            "text-[11px] font-medium text-white",
+            "text-[11px] font-medium text-[var(--color-overlay-foreground)]",
             "opacity-0 transition-opacity duration-[var(--duration-fast)] group-hover/att:opacity-100",
           )}
         >
@@ -679,6 +679,8 @@ function ReactionChip({
       data-mine={mine || undefined}
       onClick={() => mutation.mutate()}
       disabled={mutation.isPending}
+      aria-pressed={mine}
+      aria-label={`${mine ? "Remove your" : "Add"} ${emoji} reaction, ${count} so far`}
       className="chat-reaction-chip"
     >
       <span aria-hidden>{emoji}</span>
@@ -793,6 +795,7 @@ function MessageActions({
             <button
               key={emoji}
               type="button"
+              aria-label={`React with ${emoji}`}
               onClick={() => {
                 reactMutation.mutate(emoji);
                 setPickerOpen(false);

--- a/clients/dashboard/src/pages/files/my-files.tsx
+++ b/clients/dashboard/src/pages/files/my-files.tsx
@@ -143,7 +143,10 @@ export function MyFilesPage() {
     void queryClient.invalidateQueries({ queryKey: SHARED_FILES_KEY });
   };
 
-  const allFiles = tab === "mine" ? myFilesQuery.data ?? [] : sharedFilesQuery.data ?? [];
+  const allFiles = useMemo(
+    () => (tab === "mine" ? myFilesQuery.data ?? [] : sharedFilesQuery.data ?? []),
+    [tab, myFilesQuery.data, sharedFilesQuery.data],
+  );
   const activeQuery = tab === "mine" ? myFilesQuery : sharedFilesQuery;
 
   // Type-bucket counts run against the unfiltered list so the chips show

--- a/clients/dashboard/src/pages/identity/roles.tsx
+++ b/clients/dashboard/src/pages/identity/roles.tsx
@@ -66,7 +66,7 @@ export function RolesPage() {
     queryFn: listRoles,
   });
 
-  const roles = query.data ?? [];
+  const roles = useMemo(() => query.data ?? [], [query.data]);
 
   const filtered = useMemo(() => {
     if (!debounced) return roles;

--- a/clients/dashboard/src/pages/identity/user-detail.tsx
+++ b/clients/dashboard/src/pages/identity/user-detail.tsx
@@ -22,7 +22,6 @@ import {
   Trash2,
   User as UserIcon,
   UserCog,
-  Users as UsersIcon,
   XCircle,
 } from "lucide-react";
 import {
@@ -106,12 +105,15 @@ export function UserDetailPage() {
   });
 
   const user = userQuery.data;
-  const roles = rolesQuery.data ?? [];
+  const roles = useMemo(() => rolesQuery.data ?? [], [rolesQuery.data]);
 
-  // Reset pending changes when fresh data arrives
+  // Clear staged toggles only when navigating to a different user — NOT on
+  // every `roles` array identity change. `roles` is `rolesQuery.data ?? []`,
+  // so an incidental background refetch would otherwise wipe unsaved edits.
+  // The deterministic post-save clear lives in saveRoles.onSuccess.
   useEffect(() => {
     setPending(new Map());
-  }, [roles]);
+  }, [userId]);
 
   const effective = (role: UserRoleDto) => {
     if (!role.roleId) return role.enabled;
@@ -155,6 +157,7 @@ export function UserDetailPage() {
       toast.success("Roles updated", {
         description: `${dirtyIds.length} role${dirtyIds.length === 1 ? "" : "s"} changed.`,
       });
+      setPending(new Map());
       void queryClient.invalidateQueries({
         queryKey: ["identity", "users", userId, "roles"],
       });
@@ -838,7 +841,3 @@ function SessionsCard({
     </EntityDetailSection>
   );
 }
-
-// Suppress unused-import warning for UsersIcon if we ever drop it; keep
-// because tooltips and future actions may reuse it.
-void UsersIcon;

--- a/clients/dashboard/src/pages/invoices.tsx
+++ b/clients/dashboard/src/pages/invoices.tsx
@@ -78,7 +78,7 @@ export function InvoicesPage() {
 
   const [search, setSearch] = useState("");
 
-  const invoices = query.data ?? [];
+  const invoices = useMemo(() => query.data ?? [], [query.data]);
 
   const sorted = useMemo(
     () =>

--- a/clients/dashboard/src/pages/settings/appearance.tsx
+++ b/clients/dashboard/src/pages/settings/appearance.tsx
@@ -49,8 +49,8 @@ export function AppearanceSettings() {
     accent, setAccent,
     customAccent, setCustomAccent,
     density, setDensity,
+    reducedMotion, setReducedMotion,
   } = useTheme();
-  const [reducedMotion, setReducedMotion] = useState(false);
   const [customOpen, setCustomOpen] = useState(false);
 
   // Fetch the nine lazy-loaded selectable font families the first time
@@ -461,7 +461,7 @@ function CustomAccentDialog({
                 step={1}
                 value={Math.round(draft.h)}
                 onChange={(e) => setDraft((d) => ({ ...d, h: Number(e.target.value) }))}
-                className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-1.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-[oklch(0_0_0_/_0.4)] [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_2px_6px_-2px_oklch(0_0_0_/_0.4)] [&::-moz-range-thumb]:h-7 [&::-moz-range-thumb]:w-1.5 [&::-moz-range-thumb]:rounded-sm [&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-[oklch(0_0_0_/_0.4)] [&::-moz-range-thumb]:bg-white"
+                className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-1.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-[oklch(0_0_0_/_0.4)] [&::-webkit-slider-thumb]:bg-[var(--color-overlay-foreground)] [&::-webkit-slider-thumb]:shadow-[0_2px_6px_-2px_oklch(0_0_0_/_0.4)] [&::-moz-range-thumb]:h-7 [&::-moz-range-thumb]:w-1.5 [&::-moz-range-thumb]:rounded-sm [&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-[oklch(0_0_0_/_0.4)] [&::-moz-range-thumb]:bg-[var(--color-overlay-foreground)]"
                 aria-label="Hue"
               />
             </div>

--- a/clients/dashboard/src/pages/settings/notifications.tsx
+++ b/clients/dashboard/src/pages/settings/notifications.tsx
@@ -21,9 +21,9 @@ export function NotificationsSettings() {
           <div className="mb-4 grid size-14 place-items-center rounded-2xl bg-[var(--color-muted)]">
             <Bell className="size-6 text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.4)]" />
           </div>
-          <h3 className="mb-1.5 font-display text-[17px] font-semibold text-[var(--color-foreground)]">
+          <h2 className="mb-1.5 font-display text-[17px] font-semibold text-[var(--color-foreground)]">
             Per-event preferences aren't tunable yet.
-          </h3>
+          </h2>
           <p className="mb-6 max-w-[380px] text-[13px] text-[var(--color-muted-foreground)]">
             In-app notifications are already delivered to your bell — open it from
             the top bar to see them. Granular per-event email opt-ins are on the

--- a/clients/dashboard/src/pages/settings/profile.tsx
+++ b/clients/dashboard/src/pages/settings/profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Camera, Fingerprint, UserCircle2 } from "lucide-react";
 import { toast } from "sonner";
@@ -23,22 +23,28 @@ export function ProfileSettings() {
   });
 
   const profile = profileQuery.data;
+  const loading = profileQuery.isLoading;
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [phone, setPhone] = useState("");
 
-  // Seed form state from the fetched profile (falls back to the JWT-derived
-  // user while the query is in flight so the form isn't empty on first paint).
+  // Seed the form from the fetched profile exactly once. The JWT-derived
+  // `user` provides an immediate non-empty paint; the authoritative profile
+  // then seeds and locks. Seeding once means a later background refetch
+  // can't clobber edits the user has already made.
+  const seededRef = useRef(false);
   useEffect(() => {
+    if (seededRef.current) return;
     if (profile) {
       setFirstName(profile.firstName ?? "");
       setLastName(profile.lastName ?? "");
       setPhone(profile.phoneNumber ?? "");
-    } else if (user) {
+      seededRef.current = true;
+    } else if (user && loading) {
       setFirstName(user.name?.split(" ")[0] ?? "");
       setLastName(user.name?.split(" ").slice(1).join(" ") ?? "");
     }
-  }, [profile, user]);
+  }, [profile, user, loading]);
 
   const saveMutation = useMutation({
     mutationFn: () =>
@@ -96,6 +102,17 @@ export function ProfileSettings() {
 
   return (
     <form onSubmit={onSubmit} className="space-y-5 fsh-enter">
+      {profileQuery.isError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-[oklch(from_var(--color-destructive)_l_c_h_/_0.30)] bg-[oklch(from_var(--color-destructive)_l_c_h_/_0.06)] px-3 py-2 text-[13px] text-[var(--color-destructive)]"
+        >
+          <span>
+            Couldn't load your profile. Showing details from your session;
+            saved changes may not reflect the latest server state.
+          </span>
+        </div>
+      )}
       <SettingsSection
         title="Photo"
         icon={Camera}
@@ -138,6 +155,7 @@ export function ProfileSettings() {
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
               autoComplete="given-name"
+              disabled={loading}
               className="h-10 text-[13px]"
             />
           </Field>
@@ -147,6 +165,7 @@ export function ProfileSettings() {
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
               autoComplete="family-name"
+              disabled={loading}
               className="h-10 text-[13px]"
             />
           </Field>
@@ -171,6 +190,7 @@ export function ProfileSettings() {
               onChange={(e) => setPhone(e.target.value)}
               autoComplete="tel"
               placeholder="+1 (555) 123-4567"
+              disabled={loading}
               className="h-10 text-[13px]"
             />
           </Field>

--- a/clients/dashboard/src/pages/settings/settings-layout.tsx
+++ b/clients/dashboard/src/pages/settings/settings-layout.tsx
@@ -216,12 +216,12 @@ export function SettingsSection({
     >
       {title && (
         <div className="border-b border-[oklch(from_var(--color-border)_l_c_h_/_0.5)] px-5 py-3">
-          <h3 className="flex items-center gap-2 text-[13px] font-semibold text-[var(--color-foreground)]">
+          <h2 className="flex items-center gap-2 text-[13px] font-semibold text-[var(--color-foreground)]">
             {Icon && (
               <Icon className="size-3.5 text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]" />
             )}
             {title}
-          </h3>
+          </h2>
           {description && (
             <p className="mt-1 text-[12px] text-[var(--color-muted-foreground)]">
               {description}

--- a/clients/dashboard/src/pages/system/sessions.tsx
+++ b/clients/dashboard/src/pages/system/sessions.tsx
@@ -6,7 +6,6 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import {
-  AlertCircle,
   AlertTriangle,
   Globe,
   LogOut,
@@ -83,7 +82,7 @@ export function SessionsPage() {
     refetchInterval: 30_000, // light auto-refresh — sessions move fast
   });
 
-  const items = query.data?.items ?? [];
+  const items = useMemo(() => query.data?.items ?? [], [query.data]);
 
   const stats = useMemo(() => {
     const active = items.filter((s) => s.isActive).length;
@@ -489,6 +488,3 @@ function SessionDesktopRow({
     </EntityListRow>
   );
 }
-
-// AlertCircle reserved for a future stale-session callout.
-void AlertCircle;

--- a/clients/dashboard/src/pages/system/trash.tsx
+++ b/clients/dashboard/src/pages/system/trash.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Boxes,
   FileText,
   FolderTree,
   Package,
@@ -375,6 +375,7 @@ function TrashShell<T>({
   setPageNumber: (n: number) => void;
   mapRow: (item: T) => RowVm;
 }) {
+  const navigate = useNavigate();
   const items = query.data?.items ?? [];
   const total = query.data?.totalCount ?? 0;
   const rows = items.map(mapRow);
@@ -403,9 +404,7 @@ function TrashShell<T>({
         action={
           <Button
             variant="outline"
-            onClick={() => {
-              window.location.href = `/${tabPath(label)}`;
-            }}
+            onClick={() => navigate(`/${tabPath(label)}`)}
             className="h-9 rounded-lg px-4 text-[13px]"
           >
             Back to {label.toLowerCase()}
@@ -570,6 +569,3 @@ function TrashDesktopRow({ row, isLast }: { row: RowVm; isLast: boolean }) {
     </EntityListRow>
   );
 }
-
-// Suppress unused warnings for shared icons when bundling per-tab views.
-void Boxes;

--- a/clients/dashboard/src/realtime/realtime-context.tsx
+++ b/clients/dashboard/src/realtime/realtime-context.tsx
@@ -130,13 +130,17 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
         "ChatMessageCreated",
         "ChatMessageEdited",
         "ChatMessageDeleted",
+        "ChatMessagePinned",
+        "ChatMessageUnpinned",
         "ChatChannelMemberAdded",
         "ChatChannelMemberRemoved",
+        "ChatChannelMemberRead",
         "ChatChannelAdded",
         "ChatChannelRemoved",
         "ChatChannelRead",
         "ChatReactionChanged",
         "ChatTypingStarted",
+        "PresenceChanged",
         "NotificationCreated",
       ]) {
         wire(event);

--- a/clients/dashboard/src/realtime/use-presence.ts
+++ b/clients/dashboard/src/realtime/use-presence.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getPresence } from "@/api/chat";
 import { useRealtimeEvent } from "@/realtime/realtime-context";
@@ -41,14 +40,6 @@ export function usePresence(userId: string | null | undefined): boolean {
     },
     [userId, queryClient],
   );
-
-  // Belt: when the userId changes mid-component, invalidate the previous
-  // entry so a stale "offline" doesn't linger when switching DM partners.
-  useEffect(() => {
-    return () => {
-      // No-op cleanup; the queryClient handles staleness on its own.
-    };
-  }, [userId]);
 
   return userId ? (query.data ?? false) : false;
 }

--- a/clients/dashboard/src/routes.tsx
+++ b/clients/dashboard/src/routes.tsx
@@ -102,7 +102,8 @@ const ChatPage = lazyNamed(() => import("@/pages/chat/chat-page"), "ChatPage");
  */
 function RouteFallback() {
   return (
-    <div className={cn("space-y-6 fsh-enter")} aria-busy>
+    <div className={cn("space-y-6 fsh-enter")} role="status" aria-busy="true">
+      <span className="sr-only">Loading…</span>
       <div className="space-y-2">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-8 w-64" />

--- a/clients/dashboard/src/styles/globals.css
+++ b/clients/dashboard/src/styles/globals.css
@@ -88,6 +88,13 @@
   --primary-hover:              var(--brand-700);
   --primary-soft:               oklch(from var(--brand-600) l c h / 0.10);
 
+  /* Theme-independent. For content that sits on top of imagery or a dark
+     scrim (caption text, overlay action icons) and for the thumb of a
+     filled control — white stays legible in both light and dark, so these
+     are intentionally NOT flipped in the .dark block. */
+  --overlay:                    oklch(0 0 0 / 0.55);
+  --overlay-foreground:         oklch(1 0 0);
+
   --secondary:                  var(--neutral-100);
   --secondary-foreground:       var(--neutral-900);
 
@@ -375,6 +382,8 @@
   --color-primary-foreground:     var(--primary-foreground);
   --color-primary-hover:          var(--primary-hover);
   --color-primary-soft:           var(--primary-soft);
+  --color-overlay:                var(--overlay);
+  --color-overlay-foreground:     var(--overlay-foreground);
   --color-secondary:              var(--secondary);
   --color-secondary-foreground:   var(--secondary-foreground);
   --color-muted:                  var(--muted);
@@ -1128,6 +1137,18 @@
   }
   body { background-image: none; }
 }
+
+/* App-level override: the Appearance > "Reduce motion" toggle adds
+   `.reduce-motion` on :root to force the same reductions regardless of the
+   OS setting. Mirrors the media query above. */
+.reduce-motion *,
+.reduce-motion *::before,
+.reduce-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-delay: 0ms !important;
+  transition-duration: 0.01ms !important;
+}
+.reduce-motion body { background-image: none; }
 
 /* CHAT-ONLY page chrome (.chat-typing-dot, .chat-unread-divider,
    .chat-day-rule, .chat-reaction-chip, .chat-channel-header,

--- a/clients/dashboard/tests/identity/groups.spec.ts
+++ b/clients/dashboard/tests/identity/groups.spec.ts
@@ -62,7 +62,7 @@ test.describe("identity/groups — list", () => {
     await page.goto("/identity/groups");
 
     await expect(
-      page.getByRole("heading", { name: "No groups yet", level: 3 }),
+      page.getByRole("heading", { name: "No groups yet", level: 2 }),
     ).toBeVisible();
     await expect(
       page.getByText(/create the first group to bundle members and roles/i),

--- a/clients/dashboard/tests/identity/roles.spec.ts
+++ b/clients/dashboard/tests/identity/roles.spec.ts
@@ -74,7 +74,7 @@ test.describe("identity/roles — list", () => {
     await page.getByPlaceholder("Search by name or description…").fill("zzzznope");
 
     await expect(
-      page.getByRole("heading", { name: "No roles found", level: 3 }),
+      page.getByRole("heading", { name: "No roles found", level: 2 }),
     ).toBeVisible();
     await expect(page.getByText(/nothing matches "zzzznope"/i)).toBeVisible();
   });

--- a/clients/dashboard/tests/identity/users.spec.ts
+++ b/clients/dashboard/tests/identity/users.spec.ts
@@ -62,7 +62,7 @@ test.describe("identity/users — list", () => {
 
     // No search/filter active → "No users yet" empty headline.
     await expect(
-      page.getByRole("heading", { name: "No users yet", level: 3 }),
+      page.getByRole("heading", { name: "No users yet", level: 2 }),
     ).toBeVisible();
     await expect(
       page.getByText(/register the first member to seed this tenant/i),


### PR DESCRIPTION
## What

A focused UX / accessibility / performance / correctness pass over the **tenant dashboard** (`clients/dashboard`), driven by a four-dimension audit. No backend or `src/BuildingBlocks` changes.

## Why

The dashboard was already mature, so this targets the things lint can't catch: silent realtime bugs, invalid ARIA, contrast gaps, and a few dead-code / footgun spots.

## Highlights

### Functional bugs
- **4 hub events subscribed but never wired** in `realtime-context.tsx` (`PresenceChanged`, `ChatMessagePinned`, `ChatMessageUnpinned`, `ChatChannelMemberRead`) — live presence dots, pin/unpin, and read-receipts silently never updated. The backend broadcasts all four.
- **chat-search highlight**: a `/g` `RegExp.test()` in a `.map()` drifted `lastIndex` and mis-wrapped matches.
- **user-detail**: the staged-role reset was keyed on `roles = data ?? []`, so a background refetch could wipe unsaved edits — re-keyed on `userId` with a deterministic post-save clear.

### Accessibility
- **Combobox**: invalid `role="option"` inside a `role="menu"` and `role="combobox"` without `aria-expanded`/`controls` → valid `menuitemradio`; nested interactive clear button lifted to a sibling.
- Accessible names: reaction chips, quick-react emoji, `EntitySearch` (every list page), collapsed sidebar items.
- `role="status"`/sr-only on skeletons, `role="progressbar"` on upload bars, `DialogTitle` on the mobile nav Sheet, anchor-as-menuitem (`asChild`) for link menu items, h1→h2 heading hierarchy, chat status rows hidden from the `role="log"` region.
- Placeholder contrast raised to AA (removed sub-AA alpha multipliers).

### UX / correctness
- Retired hardcoded `text-white`/`bg-white`/`bg-black` via a new theme-independent `--color-overlay-foreground` / `--color-overlay` token + semantic foregrounds.
- **Profile form**: surfaces load errors, gates inputs while loading, seeds once (no clobber on refetch).
- Wired the previously **no-op "Reduce motion" toggle** through the theme provider (persisted + `.reduce-motion` class + CSS); fixed the notifications "open bell" selector.

### Cleanup
- Removed 3 `void X` dead-import hacks + a dead effect, swapped a full-page `window.location` reload for router `navigate()`, and resolved all 10 `exhaustive-deps` lint warnings via `useMemo`.

## Deliberately deferred
- Global token-syntax normalization and `products.tsx` primitive de-dup (render identically — churn without a defect).
- Server-side pagination for roles/groups at scale and a batched presence endpoint (need API changes).
- The 12 remaining lint warnings are all pre-existing `react-refresh/only-export-components` (dev-only HMR ergonomics).

## Verification
- `tsc -b` clean
- `eslint` 0 errors, **12 warnings (down from 22)**
- `vite build` succeeds
- **Playwright 121/121 pass** (updated 3 identity empty-state heading-level assertions to match the corrected h2)

> Note (golden rule #10): the now-working reduce-motion toggle and live-presence fix are user-facing — a changelog entry in the separate docs repo should accompany this before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
