### PR TITLE
ci: make pipelines main-only after retiring develop

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,10 +8,10 @@ name: Backend CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     tags: ['v*']
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
     inputs:
       version:
@@ -37,7 +37,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      # On any non-PR event (push to develop/main, tags, manual release) run the
+      # On any non-PR event (push to main, tags, manual release) run the
       # full pipeline. On PRs, run only when backend-relevant paths changed.
       backend: ${{ github.event_name != 'pull_request' || steps.filter.outputs.backend == 'true' }}
     steps:
@@ -284,7 +284,7 @@ jobs:
   publish-dev-containers:
     name: Publish Dev Containers
     needs: [changes, test, integration-test]
-    if: needs.changes.outputs.backend == 'true' && github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL Analysis
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'src/**'
   schedule:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,9 +8,9 @@ name: Frontend CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -7,7 +7,7 @@ name: Template Smoke Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - '.template.config/**'
       - 'templates/**'
@@ -15,7 +15,7 @@ on:
       - 'src/**'
       - '.github/workflows/template-smoke.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - '.template.config/**'
       - 'templates/**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,10 @@ dotnet run --project src/Host/FSH.Starter.DbMigrator -- list-pending
 
 **Ports:** API 7030 (https)/5030 (http) · admin 5173 · dashboard 5174 · Postgres 5432 · pgAdmin 5050 · Valkey 6379 · MinIO 9000/9001.
 
+## Branching & PRs
+
+Single long-lived branch: **`main`** (the default) — there is **no `develop`**. Branch from and target `main`; stable releases are cut from `v*` tags. CI is split into path-scoped **Backend CI** (`src/**`) and **Frontend CI** (`clients/**`) workflows; branch protection requires only those two gate checks — never the individual jobs, which are skipped on the other side's PRs.
+
 ## Golden rules (do not break)
 
 1. **Module boundaries** — a module references another module only through its `.Contracts` project, never its runtime project. Enforced by `Architecture.Tests`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Client apps live under `clients/admin` and `clients/dashboard` — `npm install 
 
 ## Pull requests
 
-- Branch from and target `develop`, not `main`.
+- Branch from and target `main`.
 - Follow [Conventional Commits](https://www.conventionalcommits.org) — match the existing history (`feat(chat): ...`, `fix(identity): ...`).
 - Add tests. The build runs with `TreatWarningsAsErrors=true`; analyzer warnings must be fixed.
 - Don't touch `src/BuildingBlocks/` without prior discussion — wide blast radius.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-This is a starter kit. Only the current `develop` branch receives security fixes from upstream. Forks, downstream projects, and tagged releases are owned by their maintainers — pull fixes in on your own cadence.
+This is a starter kit. Only the current `main` branch receives security fixes from upstream. Forks, downstream projects, and tagged releases are owned by their maintainers — pull fixes in on your own cadence.
 
 ## Reporting a vulnerability
 
@@ -23,7 +23,7 @@ Please include:
 - Triage decision within 7 days.
 - Coordinated disclosure window of ~90 days from triage, longer for changes that need careful migration paths.
 
-Fixes ship as a patched commit on `develop` plus a GitHub Security Advisory. Reporters are credited with permission.
+Fixes ship as a patched commit on `main` plus a GitHub Security Advisory. Reporters are credited with permission.
 
 ## Scope
 


### PR DESCRIPTION
@
Follow-up to the CI split now that `develop` has been consolidated into `main` and deleted.

## Changes
- Drop `develop` from triggers in `backend.yml`, `frontend.yml`, `codeql.yml`, `template-smoke.yml` (now `main`-only + tags).
- `publish-dev-containers` now runs on push to `main` (was keyed to `develop`).
- `CONTRIBUTING.md`: "Branch from and target `main`".
- `SECURITY.md`: supported branch + fix-shipping now reference `main`.

Releases remain on `v*` tags (plus the manual `workflow_dispatch` on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@