### PR TITLE
fix(template): correct Dockerfile packaging + nested IDE-cache excludes

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -134,9 +134,9 @@
             "target": "./",
             "exclude": [
                 ".template.config/**",
-                ".idea/**",
-                ".vscode/**",
-                ".vs/**",
+                "**/.idea/**",
+                "**/.vscode/**",
+                "**/.vs/**",
                 ".github/**",
                 ".agents/**",
                 ".claude/**",

--- a/templates/FullStackHero.NET.StarterKit.csproj
+++ b/templates/FullStackHero.NET.StarterKit.csproj
@@ -46,9 +46,9 @@
       nested .template.config that would otherwise collide on `dotnet new install`.
     -->
     <Content Include="..\**\*"
-             Exclude="..\**\bin\**;..\**\obj\**;..\.git\**;..\.github\**;..\.claude\**;..\.agents\**;..\.vs\**;..\.idea\**;..\.vscode\**;..\.devcontainer\**;..\**\node_modules\**;..\**\dist\**;..\**\build\**;..\**\TestResults\**;..\**\playwright-report\**;..\**\test-results\**;..\coverage-report\**;..\nupkgs\**;..\nupkgs-test\**;..\docs\**;..\templates\**;..\**\*.user"
+             Exclude="..\**\bin\**;..\**\obj\**;..\.git\**;..\.github\**;..\.claude\**;..\.agents\**;..\**\.vs\**;..\**\.idea\**;..\**\.vscode\**;..\.devcontainer\**;..\**\node_modules\**;..\**\dist\**;..\**\build\**;..\**\TestResults\**;..\**\playwright-report\**;..\**\test-results\**;..\coverage-report\**;..\nupkgs\**;..\nupkgs-test\**;..\docs\**;..\templates\**;..\**\*.user"
              Pack="true"
-             PackagePath="content\%(RecursiveDir)%(Filename)%(Extension)" />
+             PackagePath="content" />
     <Compile Remove="**\*" />
   </ItemGroup>
 


### PR DESCRIPTION
Found while verifying the `dotnet new` / `fsh` CLI flow before the NuGet release. Two template **packing** bugs that CI never caught (CI packs from clean checkouts):

### 1. Dockerfiles broken in scaffolded output (user-facing)
Extensionless files were duplicated to a nested path in the package — e.g. `content/src/Host/FSH.Starter.Api/Dockerfile/src/Host/FSH.Starter.Api/Dockerfile`. NuGet treats an extensionless computed `PackagePath` as a *directory* and re-appends `%(RecursiveDir)%(Filename)%(Extension)`. Result: every scaffolded project got a **`Dockerfile` directory instead of a file**, breaking `deploy/docker/docker-compose.yml` (`docker compose up --build`).
**Fix:** `PackagePath="content"` — NuGet appends the recursive path uniformly, so every file (including extensionless Dockerfiles) lands at a correct single path.

### 2. `dotnet pack` fails / bundles IDE junk on dev machines
`.vs`/`.idea`/`.vscode` excludes were root-anchored, so a nested `src/.vs/` (VS's per-solution cache, since the solution lives in `src/`) was not excluded. Packing locally fails on a locked `.vsidx`, and otherwise bundles IDE cache into the shipped template. **Fix:** made them recursive (`..\**\.vs\**` etc.), matching the existing `bin`/`obj` pattern, in both the csproj glob and `template.json`.

### Verification (local, end-to-end)
- `dotnet pack` → no `.vs`/`bin`/`obj` junk; all files at single paths; 4 Dockerfiles correct.
- `dotnet new install` → `dotnet new fsh` **and** `fsh new`: scaffold builds with `-warnaserror`, both React apps `npm ci && npm run build` pass, and the full test suite passes (unit + Testcontainers integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
