### PR TITLE
chore(deps): update Aspire to 13.3.5 + bump outdated packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,9 +9,9 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -41,18 +41,18 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
-    <PackageVersion Include="Finbuckle.MultiTenant" Version="10.0.8" />
-    <PackageVersion Include="Finbuckle.MultiTenant.AspNetCore" Version="10.0.8" />
-    <PackageVersion Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Finbuckle.MultiTenant.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Finbuckle.MultiTenant.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Finbuckle.MultiTenant" Version="10.1.0" />
+    <PackageVersion Include="Finbuckle.MultiTenant.AspNetCore" Version="10.1.0" />
+    <PackageVersion Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.1.0" />
+    <PackageVersion Include="Finbuckle.MultiTenant.Abstractions" Version="10.1.0" />
+    <PackageVersion Include="Finbuckle.MultiTenant.Identity.EntityFrameworkCore" Version="10.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Hangfire" Version="1.8.23" />
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.2" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
-    <PackageVersion Include="MailKit" Version="4.16.0" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
@@ -83,17 +83,17 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
-    <PackageVersion Include="MimeKit" Version="4.16.0" />
+    <PackageVersion Include="MimeKit" Version="4.17.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.11" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageVersion Include="Serilog" Version="4.3.2-dev-02419" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
     <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
     <PackageVersion Include="UAParser" Version="3.1.47" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
@@ -109,7 +109,7 @@
   </ItemGroup>
 
   <ItemGroup Label="AWS">
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.23.1" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.23.4" />
   </ItemGroup>
   <ItemGroup Label="Messaging">
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />

--- a/src/Host/FSH.Starter.AppHost/FSH.Starter.AppHost.csproj
+++ b/src/Host/FSH.Starter.AppHost/FSH.Starter.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Brings all outdated NuGet packages to latest for the v10 release.

| Package | From → To |
|---|---|
| Aspire.Hosting.{JavaScript,PostgreSQL,Redis} + AppHost SDK | 13.3.3 → **13.3.5** |
| Finbuckle.MultiTenant family (all 5) | 10.0.8 → 10.1.0 |
| SonarAnalyzer.CSharp | 10.25.0 → 10.27.0 |
| MailKit / MimeKit | 4.16.0 → 4.17.0 |
| AWSSDK.S3 | 4.0.23.1 → 4.0.23.4 |
| Scalar.AspNetCore | 2.14.11 → 2.14.14 |

`OpenTelemetry.Instrumentation.{EntityFrameworkCore,StackExchangeRedis}` stay on `1.15.0-beta.1` (no newer published).

### Verified locally
- `dotnet build -warnaserror`: **0 warnings / 0 errors** (SonarAnalyzer 10.27 added no new diagnostics).
- Full test suite: **1,611 passed / 2 skipped / 0 failed** (incl. Testcontainers integration — 668).
- Full **Aspire 13.3.5** stack boots and serves: API + `/openapi/v1.json` + `/scalar` + both React clients (`:5173`/`:5174`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
