### PR TITLE
fix(cli): template detection in doctor/info + drop obsolete Aspire workload check

### DIFF
--- a/src/Tools/CLI/Commands/DoctorCommand.cs
+++ b/src/Tools/CLI/Commands/DoctorCommand.cs
@@ -22,7 +22,6 @@ public sealed class DoctorCommand : AsyncCommand
                 checks.Add(await CheckDotNetSdkAsync(cancellationToken).ConfigureAwait(false));
                 checks.Add(await CheckGitAsync(cancellationToken).ConfigureAwait(false));
                 checks.Add(await CheckDockerAsync(cancellationToken).ConfigureAwait(false));
-                checks.Add(await CheckAspireWorkloadAsync(cancellationToken).ConfigureAwait(false));
                 checks.Add(await CheckFshTemplateAsync(cancellationToken).ConfigureAwait(false));
                 checks.Add(CheckPorts());
             }).ConfigureAwait(false);
@@ -107,25 +106,17 @@ public sealed class DoctorCommand : AsyncCommand
         return new("Docker", CheckStatus.Pass, version.Split('\n')[0]);
     }
 
-    private static async Task<DoctorCheck> CheckAspireWorkloadAsync(CancellationToken cancellationToken)
-    {
-        (bool ok, string output) = await ProcessRunner.CaptureAsync("dotnet", "workload list", cancellationToken)
-            .ConfigureAwait(false);
-
-        bool installed = ok && output.Contains("aspire", StringComparison.OrdinalIgnoreCase);
-        return new("Aspire Workload", installed ? CheckStatus.Pass : CheckStatus.Warn,
-            installed ? "Installed" : "Run: dotnet workload install aspire");
-    }
-
     private static async Task<DoctorCheck> CheckFshTemplateAsync(CancellationToken cancellationToken)
     {
         string? version = await NuGetClient.GetInstalledTemplateVersionAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return new("FSH Template", version is not null ? CheckStatus.Pass : CheckStatus.Warn,
-            version is not null
-                ? $"v{version}"
-                : $"Not installed. Run: dotnet new install {FshConstants.TemplatePackageId}");
+        if (version is null)
+            return new("FSH Template", CheckStatus.Warn,
+                $"Not installed. Run: dotnet new install {FshConstants.TemplatePackageId}");
+
+        string detail = char.IsDigit(version[0]) ? $"v{version}" : version;
+        return new("FSH Template", CheckStatus.Pass, detail);
     }
 
     private static DoctorCheck CheckPorts()

--- a/src/Tools/CLI/Commands/InfoCommand.cs
+++ b/src/Tools/CLI/Commands/InfoCommand.cs
@@ -52,9 +52,12 @@ public sealed class InfoCommand : AsyncCommand
         }
 
         // Template version
-        table.AddRow("Template", templateVersion is not null
-            ? $"v{templateVersion}"
-            : $"[{FshConstants.DimColor}]not installed[/]");
+        string templateDisplay;
+        if (templateVersion is null)
+            templateDisplay = $"[{FshConstants.DimColor}]not installed[/]";
+        else
+            templateDisplay = char.IsDigit(templateVersion[0]) ? $"v{templateVersion}" : templateVersion;
+        table.AddRow("Template", templateDisplay);
 
         if (latestTemplate is not null)
         {

--- a/src/Tools/CLI/Infrastructure/NuGetClient.cs
+++ b/src/Tools/CLI/Infrastructure/NuGetClient.cs
@@ -59,36 +59,43 @@ internal static class NuGetClient
     }
 
     /// <summary>
-    /// Gets the installed version of the FSH dotnet new template, or null.
+    /// Gets the installed version of the FSH dotnet new template, or null if it is not
+    /// installed. Returns "local" when installed from a folder (no package version).
     /// </summary>
     internal static async Task<string?> GetInstalledTemplateVersionAsync(
         CancellationToken cancellationToken = default)
     {
-        // dotnet new list outputs a table. We use --columns to get a parseable format.
+        // `dotnet new list` has no version column, so we read `dotnet new uninstall`
+        // (no args), which lists installed template packages with their versions:
+        //    FullStackHero.NET.StarterKit
+        //       Version: 10.0.0
         (bool ok, string output) = await ProcessRunner.CaptureAsync(
-            "dotnet", $"new list {FshConstants.TemplateShortName}",
-            cancellationToken).ConfigureAwait(false);
+            "dotnet", "new uninstall", cancellationToken).ConfigureAwait(false);
 
         if (!ok) return null;
 
-        foreach (string line in output.Split('\n'))
+        string[] lines = output.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
         {
-            if (!line.Contains(FshConstants.TemplateShortName, StringComparison.OrdinalIgnoreCase)
-                || !line.Contains("FullStackHero", StringComparison.OrdinalIgnoreCase))
+            // Match the package-block header: the package id on its own (indented) line.
+            if (!string.Equals(lines[i].Trim(), FshConstants.TemplatePackageId, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            // Version appears as a column in the dotnet new list table output.
-            // Columns are separated by 2+ spaces. Find the segment that looks like a version.
-            string[] segments = line.Split("  ", StringSplitOptions.RemoveEmptyEntries);
-            foreach (string segment in segments)
+            // The next indented line is "Version: x.y.z" for NuGet-installed packages.
+            for (int j = i + 1; j < Math.Min(i + 3, lines.Length); j++)
             {
-                string trimmed = segment.Trim();
-                if (trimmed.Length > 0 && char.IsDigit(trimmed[0]) && trimmed.Contains('.', StringComparison.Ordinal))
-                {
-                    return trimmed;
-                }
+                int idx = lines[j].IndexOf("Version:", StringComparison.OrdinalIgnoreCase);
+                if (idx >= 0)
+                    return lines[j][(idx + "Version:".Length)..].Trim();
             }
+
+            return "local"; // installed, but no package version reported
         }
+
+        // A folder install lists a path rather than the package id — detect via the template entry.
+        if (output.Contains("FullStackHero", StringComparison.OrdinalIgnoreCase)
+            && output.Contains($"({FshConstants.TemplateShortName})", StringComparison.OrdinalIgnoreCase))
+            return "local";
 
         return null;
     }


### PR DESCRIPTION
Two cosmetic CLI bugs found during pre-release verification (the first thing devs see when they run `fsh doctor`/`fsh info`):

1. **"Template: not installed" false negative** — detection parsed `dotnet new list fsh`, which has no version column, so it always returned null. Now reads `dotnet new uninstall` (lists the package id + `Version:`), with a folder-install fallback.
2. **Obsolete Aspire workload check** — `fsh doctor` ran `dotnet workload list` and told users to `dotnet workload install aspire`, but Aspire has been a NuGet SDK (no workload) since .NET 9. Removed the check.

### Before / after `fsh doctor`
- Before: `Aspire Workload  WARN  Run: dotnet workload install aspire` + `FSH Template  WARN  Not installed`
- After: (no Aspire row) + `FSH Template  PASS  v10.0.0`

Builds clean with `-warnaserror`; verified `doctor` + `info` against an installed template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
