### PR TITLE
chore(release): set default version to 10.0.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,7 +42,7 @@
 		<!-- Default NuGet metadata -->
 		<Authors>Mukesh Murugan</Authors>
 		<Company>FullStackHero</Company>
-		<Version>10.0.0-rc.1</Version>
+		<Version>10.0.0</Version>
 		<RepositoryUrl>https://github.com/fullstackhero/dotnet-starter-kit</RepositoryUrl>
 		<PackageTags>FSH;FullStackHero;Modular;CQRS;VerticalSlice;DotNet;CleanArchitecture</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Sets the repo-wide `<Version>` from `10.0.0-rc.1` to `10.0.0` so the CLI (`FullStackHero.CLI`) and other packed artifacts default to the GA version, matching the template (which already hardcodes `10.0.0`). Verified: `fsh info` now reports CLI `10.0.0` and Template `v10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)