### PR TITLE
fix(scaffold): per-app volumes, init main, seed root admin on Aspire launch

### DIFF
--- a/src/Host/FSH.Starter.AppHost/AppHost.cs
+++ b/src/Host/FSH.Starter.AppHost/AppHost.cs
@@ -101,17 +101,23 @@ var minioInit = builder.AddContainer("minio-init", "minio/mc")
 var minioApiEndpoint = minio.GetEndpoint("api");
 
 // Database migrator — runs once on each AppHost launch, applies pending
-// migrations across the tenant catalog + every tenant's per-module
-// databases, then exits. The API depends on its completion below, so
-// the API never starts against an unmigrated database. Production
-// deployments use this same project as an explicit deploy step.
+// migrations across the tenant catalog + every tenant's per-module databases,
+// then seeds the root tenant's admin user, then exits. The API depends on its
+// completion below, so the API never starts against an unmigrated/unseeded
+// database. Production deployments use this same project as an explicit step.
+//
+// `--seed` runs SeedTenantAsync so the root admin (admin@root.com) exists out of
+// the box — without it the app comes up with an empty Users table and nobody can
+// log in. The seed password is a dev-only default that mirrors the API's
+// appsettings.Development.json; override it for non-dev use.
 var migrator = builder.AddProject<Projects.FSH_Starter_DbMigrator>("fsh-db-migrator")
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithEnvironment("DatabaseOptions__Provider", "POSTGRESQL")
     .WithEnvironment("DatabaseOptions__ConnectionString", postgres.Resource.ConnectionStringExpression)
     .WithEnvironment("DatabaseOptions__MigrationsAssembly", "FSH.Starter.Migrations.PostgreSQL")
-    .WithArgs("apply");
+    .WithEnvironment("Seed__DefaultAdminPassword", "123Pa$$word!")
+    .WithArgs("apply", "--seed");
 
 // API Service
 var api = builder.AddProject<Projects.FSH_Starter_Api>("fsh-api")

--- a/src/Host/FSH.Starter.AppHost/AppHost.cs
+++ b/src/Host/FSH.Starter.AppHost/AppHost.cs
@@ -2,6 +2,16 @@ using Aspire.Hosting.ApplicationModel;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Per-app prefix for Docker volume names, derived from the AppHost assembly name,
+// so two FSH-based apps (or this repo + a scaffolded app) on one machine get
+// isolated data volumes instead of clashing on shared "postgres-data"/etc. names.
+#pragma warning disable CA1308 // Docker volume names are conventionally lowercase
+var volumePrefix = builder.Environment.ApplicationName
+    .Replace(".AppHost", string.Empty, StringComparison.OrdinalIgnoreCase)
+    .Replace('.', '-')
+    .ToLowerInvariant();
+#pragma warning restore CA1308
+
 // Infrastructure
 //
 // pgAdmin sidecar attaches to the same Postgres server resource. Aspire
@@ -10,7 +20,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 // us authoring a `servers.json` by hand. Persistent so the saved query
 // state and folder layout survive `dotnet run` restarts.
 var postgresServer = builder.AddPostgres("postgres")
-    .WithDataVolume("postgres-data")
+    .WithDataVolume($"{volumePrefix}-postgres-data")
     .WithLifetime(ContainerLifetime.Persistent)
     .WithPgAdmin(pa => pa
         .WithHostPort(5050)
@@ -25,7 +35,7 @@ var postgres = postgresServer.AddDatabase("fsh-db");
 // Resource name stays "redis" so connection strings / config keys don't churn.
 var redis = builder.AddRedis("redis")
     .WithImage("valkey/valkey", "8")
-    .WithDataVolume("fsh-redis-data")
+    .WithDataVolume($"{volumePrefix}-redis-data")
     .WithLifetime(ContainerLifetime.Persistent)
     // RedisInsight cache browser — Aspire auto-wires it to the resource above,
     // so it connects to Valkey with no manual config. It's SSPL (source-available),
@@ -62,7 +72,7 @@ var minio = builder.AddContainer("minio", "minio/minio")
     .WithEnvironment("MINIO_ROOT_USER", minioUser)
     .WithEnvironment("MINIO_ROOT_PASSWORD", minioPassword)
     .WithEnvironment("MINIO_API_CORS_ALLOW_ORIGIN", $"{AdminOrigin},{DashboardOrigin}")
-    .WithVolume("fsh-minio-data", "/data")
+    .WithVolume($"{volumePrefix}-minio-data", "/data")
     .WithLifetime(ContainerLifetime.Persistent);
 
 // Init container: just bucket bootstrap (creation + public-read policy). CORS

--- a/src/Tools/CLI/Commands/NewCommand.cs
+++ b/src/Tools/CLI/Commands/NewCommand.cs
@@ -281,6 +281,11 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             {
                 await ProcessRunner.RunAsync("git", "init", output, showOutput: false, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
+                // Default the initial branch to `main` regardless of the user's git
+                // `init.defaultBranch` (older git defaults to `master`). symbolic-ref on
+                // the unborn HEAD works on every git version, unlike `git init -b`.
+                await ProcessRunner.RunAsync("git", "symbolic-ref HEAD refs/heads/main", output, showOutput: false, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
                 await ProcessRunner.RunAsync("git", "add -A", output, showOutput: false, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
                 await ProcessRunner.RunAsync("git", "commit -m \"Initial project from FullStackHero .NET Starter Kit\"", output, showOutput: false, cancellationToken: cancellationToken)


### PR DESCRIPTION
Three scaffolded-app DX fixes found while validating `fsh new` end-to-end (a fresh `DentalOS` scaffold → run → log in → exercise APIs).

### 1. Seed the root admin on Aspire launch (the big one)
The AppHost ran the migrator with bare `apply`, which migrates schema but **never seeds the root admin** — so `dotnet run AppHost` came up with an empty `identity.Users` table and **nobody could log in**. (`deploy/docker` already used `apply --seed`; the Aspire path was inconsistent.) Now runs `apply --seed` + passes the dev-default `Seed__DefaultAdminPassword` (mirrors the API's `appsettings.Development.json`), so `admin@root.com` / `123Pa$$word!` works out of the box.

### 2. Per-app Docker volume names
AppHost data volumes were literal (`postgres-data`, `fsh-redis-data`, `fsh-minio-data`), so every FSH-based app on a machine (and this repo) **shared the same Docker volumes** — one app's DB clobbered another's. Each volume is now prefixed with the AppHost name (e.g. `dentalos-postgres-data`).

### 3. Init git on `main`, not `master`
`fsh new` ran a bare `git init`, so the initial branch followed the user's `init.defaultBranch` (often `master`). Now forces `main` via `symbolic-ref` (works on every git version), matching the kit's single-`main` model.

### Verified end-to-end on a fresh `fsh new DentalOS`
- git branch = `main`; volumes = `dentalos-postgres-data` etc. (no clash with other apps)
- Aspire stack boots, migrator seeds the admin, **login succeeds**
- Major APIs exercised live: tenants, identity users, catalog (brand→category→product full CRUD), audits, `/health/live`+`/health/ready` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
