### PR TITLE
fix: demo logins (acme/globex) on Aspire launch + expired-token session restore

### DIFF
--- a/clients/admin/src/auth/auth-context.tsx
+++ b/clients/admin/src/auth/auth-context.tsx
@@ -1,8 +1,9 @@
 import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { tokenStore } from "@/auth/token-store";
-import { decodeJwt, type JwtClaims } from "@/auth/jwt";
+import { decodeJwt, isTokenExpired, type JwtClaims } from "@/auth/jwt";
 import { issueToken } from "@/auth/api";
+import { refreshAccessToken } from "@/lib/api-client";
 import { getMyPermissions } from "@/api/users";
 
 export type AuthUser = {
@@ -16,6 +17,13 @@ export type AuthUser = {
 export type AuthContextValue = {
   user: AuthUser | null;
   isAuthenticated: boolean;
+  /**
+   * True while the provider resolves a stored session at boot — the access
+   * token was missing/expired but a refresh token was present, so a silent
+   * refresh is in flight. Routes render a loader (not the page, not a redirect)
+   * while this is true, so a stale token never flashes a protected surface.
+   */
+  isInitializing: boolean;
   /**
    * True once permissions have been fetched at least once for the current
    * user (or no user is signed in). Route guards check this before rendering
@@ -43,10 +51,27 @@ function claimsToUser(claims: JwtClaims | null, permissions: string[]): AuthUser
   };
 }
 
+// Read the stored session, treating an EXPIRED access token as "not usable
+// yet": the boot effect attempts a silent refresh before we trust it. A
+// decodable-but-expired token must not flip the app to authenticated, or it
+// renders protected surfaces that 401 in a loop instead of refreshing.
+function readStoredSession(): { claims: JwtClaims | null; usable: boolean } {
+  const claims = decodeJwt(tokenStore.getAccessToken());
+  return { claims, usable: claims !== null && !isTokenExpired(claims) };
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
-  const [user, setUser] = useState<AuthUser | null>(() =>
-    claimsToUser(decodeJwt(tokenStore.getAccessToken()), tokenStore.getPermissions()),
+  const [user, setUser] = useState<AuthUser | null>(() => {
+    const { claims, usable } = readStoredSession();
+    return usable ? claimsToUser(claims, tokenStore.getPermissions()) : null;
+  });
+  // When the stored access token is missing/expired but a refresh token is
+  // present, attempt one silent refresh at boot before rendering — keeps
+  // long-lived sessions alive AND stops a stale token from flashing a doomed
+  // protected surface that fires 401-ing requests.
+  const [isInitializing, setIsInitializing] = useState<boolean>(
+    () => !readStoredSession().usable && tokenStore.getRefreshToken() !== null,
   );
   // Cold-start: if we already have a cached permissions list, treat as hydrated
   // so route guards don't flash 403. Otherwise, wait for the effect.
@@ -55,6 +80,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return tokenStore.getPermissions().length > 0;
   });
   const lastHydratedSubject = useRef<string | null>(user?.id ?? null);
+
+  useEffect(() => {
+    if (!isInitializing) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await refreshAccessToken();
+      } catch {
+        // Refresh token dead (expired, revoked, or DB reseeded) — drop the
+        // stale session so routing falls through to /login cleanly.
+        tokenStore.clear();
+      } finally {
+        if (!cancelled) setIsInitializing(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Boot-only: isInitializing only ever flips false, never back on.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Hydrate (or re-hydrate) the permissions list from the server whenever the
   // signed-in subject changes — covers cold-start, login, and account swap.
@@ -127,12 +173,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     () => ({
       user,
       isAuthenticated: user !== null,
+      isInitializing,
       permissionsHydrated,
       login,
       logout,
       refreshPermissions,
     }),
-    [user, permissionsHydrated, login, logout, refreshPermissions],
+    [user, isInitializing, permissionsHydrated, login, logout, refreshPermissions],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/clients/admin/src/auth/jwt.ts
+++ b/clients/admin/src/auth/jwt.ts
@@ -21,3 +21,18 @@ export function decodeJwt(token: string | null | undefined): JwtClaims | null {
     return null;
   }
 }
+
+/**
+ * True when the token is expired, or within `skewMs` of expiring (so we refresh
+ * proactively rather than send a request the server will reject for an
+ * about-to-die token). A token with no `exp` claim is treated as non-expiring.
+ *
+ * Used at boot to decide whether a stored access token still represents a
+ * usable session: a decodable-but-expired token must NOT count as "signed in",
+ * or the app renders protected surfaces that 401 in a loop instead of
+ * refreshing or routing to /login.
+ */
+export function isTokenExpired(claims: JwtClaims | null, skewMs = 10_000): boolean {
+  if (!claims || typeof claims.exp !== "number") return false;
+  return claims.exp * 1000 <= Date.now() + skewMs;
+}

--- a/clients/admin/src/auth/protected-route.tsx
+++ b/clients/admin/src/auth/protected-route.tsx
@@ -12,8 +12,27 @@ type ProtectedRouteProps = {
 };
 
 export function ProtectedRoute({ permissions = [] }: ProtectedRouteProps) {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, isInitializing, user } = useAuth();
   const location = useLocation();
+
+  // Resolving a stored session (silent token refresh) — hold rendering so we
+  // neither flash a protected surface with a stale/expired token nor bounce to
+  // /login before the refresh has had a chance to restore the session.
+  if (isInitializing) {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center text-sm text-[var(--color-muted-foreground)]"
+        role="status"
+        aria-busy="true"
+      >
+        <span className="sr-only">Restoring your session…</span>
+        <span
+          className="size-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+          aria-hidden
+        />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/clients/admin/src/lib/api-client.ts
+++ b/clients/admin/src/lib/api-client.ts
@@ -27,7 +27,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 let refreshPromise: Promise<void> | null = null;
 
-async function refreshAccessToken() {
+export async function refreshAccessToken() {
   const refreshToken = tokenStore.getRefreshToken();
   const accessToken = tokenStore.getAccessToken();
   if (!refreshToken || !accessToken) {

--- a/clients/admin/tests/auth/session-restore.spec.ts
+++ b/clients/admin/tests/auth/session-restore.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Regression: a stale, EXPIRED access token left in localStorage must NOT make
+// the admin app treat you as signed in. The auth provider attempts ONE silent
+// refresh at boot:
+//   • refresh succeeds → session is restored, no /login bounce.
+//   • refresh fails    → the stale session is dropped and the app routes to
+//                        /login, instead of flashing a protected surface and
+//                        firing requests that 401 in a loop.
+// Before the fix the app rendered as authenticated off the expired token alone
+// (isAuthenticated was gated on token presence, not `exp`).
+
+const ACCESS_KEY = "fsh.admin.accessToken";
+const REFRESH_KEY = "fsh.admin.refreshToken";
+const TENANT_KEY = "fsh.admin.tenant";
+const PERMS_KEY = "fsh.admin.permissions";
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: unknown) =>
+    btoa(JSON.stringify(obj)).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+  return [b64url({ alg: "HS256", typ: "JWT" }), b64url(payload), "sig"].join(".");
+}
+
+const now = () => Math.floor(Date.now() / 1000);
+
+const EXPIRED_TOKEN = fakeJwt({
+  sub: "u-stale-1",
+  email: "admin@root.com",
+  name: "Root Admin",
+  tenant: "root",
+  permissions: [],
+  iat: now() - 7200,
+  exp: now() - 3600, // expired an hour ago
+});
+
+const FRESH_TOKEN = fakeJwt({
+  sub: "u-stale-1",
+  email: "admin@root.com",
+  name: "Root Admin",
+  tenant: "root",
+  permissions: [],
+  iat: now(),
+  exp: now() + 3600,
+});
+
+async function seedExpiredSession(page: Page) {
+  await page.route("**/config.json", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiBase: "", defaultTenant: "root" }),
+    }),
+  );
+  await page.addInitScript(
+    ({ access, accessKey, refreshKey, tenantKey, permsKey }) => {
+      localStorage.setItem(accessKey, access);
+      localStorage.setItem(refreshKey, "stale-refresh-token");
+      localStorage.setItem(tenantKey, "root");
+      localStorage.setItem(permsKey, "[]");
+    },
+    {
+      access: EXPIRED_TOKEN,
+      accessKey: ACCESS_KEY,
+      refreshKey: REFRESH_KEY,
+      tenantKey: TENANT_KEY,
+      permsKey: PERMS_KEY,
+    },
+  );
+}
+
+test.describe("session restore — expired access token at boot", () => {
+  test("routes to /login when the silent refresh fails", async ({ page }) => {
+    await seedExpiredSession(page);
+    await page.route("**/api/v1/identity/token/refresh", (route) =>
+      route.fulfill({
+        status: 401,
+        headers: { "Content-Type": "application/problem+json" },
+        body: JSON.stringify({ title: "Unauthorized", status: 401 }),
+      }),
+    );
+
+    await page.goto("/");
+
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test("silently refreshes and stays signed in when the refresh succeeds", async ({ page }) => {
+    await seedExpiredSession(page);
+    // Catch-all first so any post-auth data fetch (incl. the permissions
+    // hydration) resolves; the refresh route is registered AFTER it so it takes
+    // precedence (Playwright: last route wins).
+    await page.route("**/api/v1/**", (route) =>
+      route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: "[]" }),
+    );
+    await page.route("**/api/v1/identity/token/refresh", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token: FRESH_TOKEN,
+          refreshToken: "rotated-refresh-token",
+          refreshTokenExpiryTime: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+        }),
+      }),
+    );
+
+    await page.goto("/");
+
+    await expect
+      .poll(async () => page.evaluate((k) => localStorage.getItem(k), ACCESS_KEY))
+      .toBe(FRESH_TOKEN);
+    await expect
+      .poll(async () => page.evaluate((k) => localStorage.getItem(k), REFRESH_KEY))
+      .toBe("rotated-refresh-token");
+    await expect(page).not.toHaveURL(/\/login$/);
+  });
+});

--- a/clients/dashboard/src/auth/auth-context.tsx
+++ b/clients/dashboard/src/auth/auth-context.tsx
@@ -1,8 +1,9 @@
 import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { tokenStore } from "@/auth/token-store";
-import { decodeJwt, type JwtClaims } from "@/auth/jwt";
+import { decodeJwt, isTokenExpired, type JwtClaims } from "@/auth/jwt";
 import { issueToken } from "@/auth/api";
+import { refreshAccessToken } from "@/lib/api-client";
 import { endImpersonation, startImpersonation } from "@/api/identity";
 
 export type AuthUser = {
@@ -25,6 +26,13 @@ export type ImpersonationInfo = {
 export type AuthContextValue = {
   user: AuthUser | null;
   isAuthenticated: boolean;
+  /**
+   * True while the provider resolves a stored session at boot — the access
+   * token was missing/expired but a refresh token was present, so a silent
+   * refresh is in flight. Routes render a loader (not the page, not a redirect)
+   * while this is true, so a stale token never flashes a doomed dashboard.
+   */
+  isInitializing: boolean;
   /** Truthy iff the current access token carries act_sub (impersonation mode). */
   impersonation: ImpersonationInfo | null;
   login: (input: { email: string; password: string; tenant: string }) => Promise<void>;
@@ -79,14 +87,53 @@ function pickFirstNonEmpty(...candidates: Array<string | undefined>): string | u
   return undefined;
 }
 
+// Read the stored session, treating an EXPIRED access token as "not usable
+// yet": the boot effect attempts a silent refresh before we trust it. A
+// decodable-but-expired token must not flip the app to authenticated, or it
+// renders protected surfaces that 401 in a loop instead of refreshing.
+function readStoredSession(): { claims: JwtClaims | null; usable: boolean } {
+  const claims = decodeJwt(tokenStore.getAccessToken());
+  return { claims, usable: claims !== null && !isTokenExpired(claims) };
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
-  const [user, setUser] = useState<AuthUser | null>(() =>
-    claimsToUser(decodeJwt(tokenStore.getAccessToken())),
+  const [user, setUser] = useState<AuthUser | null>(() => {
+    const { claims, usable } = readStoredSession();
+    return usable ? claimsToUser(claims) : null;
+  });
+  const [impersonation, setImpersonation] = useState<ImpersonationInfo | null>(() => {
+    const { claims, usable } = readStoredSession();
+    return usable ? claimsToImpersonation(claims) : null;
+  });
+  // When the stored access token is missing/expired but a refresh token is
+  // present, attempt one silent refresh at boot before rendering — this keeps
+  // long-lived sessions alive (45-min access / 7-day refresh) AND stops a stale
+  // token from flashing a doomed dashboard that fires 401-ing requests.
+  const [isInitializing, setIsInitializing] = useState<boolean>(
+    () => !readStoredSession().usable && tokenStore.getRefreshToken() !== null,
   );
-  const [impersonation, setImpersonation] = useState<ImpersonationInfo | null>(() =>
-    claimsToImpersonation(decodeJwt(tokenStore.getAccessToken())),
-  );
+
+  useEffect(() => {
+    if (!isInitializing) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await refreshAccessToken();
+      } catch {
+        // Refresh token dead (expired, revoked, or DB reseeded) — drop the
+        // stale session so routing falls through to /login cleanly.
+        tokenStore.clear();
+      } finally {
+        if (!cancelled) setIsInitializing(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Boot-only: isInitializing only ever flips false, never back on.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const refresh = () => {
@@ -181,13 +228,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     () => ({
       user,
       isAuthenticated: user !== null,
+      isInitializing,
       impersonation,
       login,
       logout,
       beginImpersonation,
       stopImpersonation,
     }),
-    [user, impersonation, login, logout, beginImpersonation, stopImpersonation],
+    [user, isInitializing, impersonation, login, logout, beginImpersonation, stopImpersonation],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/clients/dashboard/src/auth/jwt.ts
+++ b/clients/dashboard/src/auth/jwt.ts
@@ -37,3 +37,18 @@ export function decodeJwt(token: string | null | undefined): JwtClaims | null {
     return null;
   }
 }
+
+/**
+ * True when the token is expired, or within `skewMs` of expiring (so we refresh
+ * proactively rather than send a request the server will reject for an
+ * about-to-die token). A token with no `exp` claim is treated as non-expiring.
+ *
+ * Used at boot to decide whether a stored access token still represents a
+ * usable session: a decodable-but-expired token must NOT count as "signed in",
+ * or the app renders protected surfaces that 401 in a loop instead of
+ * refreshing or routing to /login.
+ */
+export function isTokenExpired(claims: JwtClaims | null, skewMs = 10_000): boolean {
+  if (!claims || typeof claims.exp !== "number") return false;
+  return claims.exp * 1000 <= Date.now() + skewMs;
+}

--- a/clients/dashboard/src/auth/protected-route.tsx
+++ b/clients/dashboard/src/auth/protected-route.tsx
@@ -2,8 +2,27 @@ import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "@/auth/use-auth";
 
 export function ProtectedRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isInitializing } = useAuth();
   const location = useLocation();
+
+  // Resolving a stored session (silent token refresh) — hold rendering so we
+  // neither flash the dashboard with a stale/expired token nor bounce to
+  // /login before the refresh has had a chance to restore the session.
+  if (isInitializing) {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center text-sm text-muted-foreground"
+        role="status"
+        aria-busy="true"
+      >
+        <span className="sr-only">Restoring your session…</span>
+        <span
+          className="size-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+          aria-hidden
+        />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/clients/dashboard/src/lib/api-client.ts
+++ b/clients/dashboard/src/lib/api-client.ts
@@ -62,7 +62,7 @@ function withTimeout(
 
 let refreshPromise: Promise<void> | null = null;
 
-async function refreshAccessToken() {
+export async function refreshAccessToken() {
   const refreshToken = tokenStore.getRefreshToken();
   const accessToken = tokenStore.getAccessToken();
   if (!refreshToken || !accessToken) {

--- a/clients/dashboard/tests/auth/session-restore.spec.ts
+++ b/clients/dashboard/tests/auth/session-restore.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Regression: a stale, EXPIRED access token left in localStorage (e.g. from a
+// session days ago, or before a DB reseed) must NOT make the app treat you as
+// signed in. The auth provider attempts ONE silent refresh at boot:
+//   • refresh succeeds → session is restored, no /login bounce.
+//   • refresh fails    → the stale session is dropped and the app routes to
+//                        /login, instead of flashing the dashboard and firing
+//                        protected requests that 401 in a loop.
+// Before the fix the dashboard rendered as authenticated off the expired token
+// alone (isAuthenticated was gated on token presence, not `exp`).
+
+const ACCESS_KEY = "fsh.dashboard.accessToken";
+const REFRESH_KEY = "fsh.dashboard.refreshToken";
+const TENANT_KEY = "fsh.dashboard.tenant";
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: unknown) =>
+    btoa(JSON.stringify(obj)).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+  return [b64url({ alg: "HS256", typ: "JWT" }), b64url(payload), "sig"].join(".");
+}
+
+const now = () => Math.floor(Date.now() / 1000);
+
+const EXPIRED_TOKEN = fakeJwt({
+  sub: "u-stale-1",
+  email: "alice@acme.com",
+  name: "Alice Nguyen",
+  tenant: "acme",
+  permissions: [],
+  iat: now() - 7200,
+  exp: now() - 3600, // expired an hour ago
+});
+
+const FRESH_TOKEN = fakeJwt({
+  sub: "u-stale-1",
+  email: "alice@acme.com",
+  name: "Alice Nguyen",
+  tenant: "acme",
+  permissions: [],
+  iat: now(),
+  exp: now() + 3600,
+});
+
+async function seedExpiredSession(page: Page) {
+  await page.route("**/config.json", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiBase: "", defaultTenant: "acme", demoMode: true }),
+    }),
+  );
+  await page.addInitScript(
+    ({ access, accessKey, refreshKey, tenantKey }) => {
+      localStorage.setItem(accessKey, access);
+      localStorage.setItem(refreshKey, "stale-refresh-token");
+      localStorage.setItem(tenantKey, "acme");
+    },
+    { access: EXPIRED_TOKEN, accessKey: ACCESS_KEY, refreshKey: REFRESH_KEY, tenantKey: TENANT_KEY },
+  );
+}
+
+test.describe("session restore — expired access token at boot", () => {
+  test("routes to /login when the silent refresh fails", async ({ page }) => {
+    await seedExpiredSession(page);
+    await page.route("**/api/v1/identity/token/refresh", (route) =>
+      route.fulfill({
+        status: 401,
+        headers: { "Content-Type": "application/problem+json" },
+        body: JSON.stringify({ title: "Unauthorized", status: 401 }),
+      }),
+    );
+
+    await page.goto("/");
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
+  });
+
+  test("silently refreshes and stays signed in when the refresh succeeds", async ({ page }) => {
+    await seedExpiredSession(page);
+    // Catch-all first so any post-auth data fetch resolves; the refresh route is
+    // registered AFTER it so it takes precedence (Playwright: last route wins).
+    await page.route("**/api/v1/**", (route) =>
+      route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: "{}" }),
+    );
+    await page.route("**/api/v1/identity/token/refresh", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token: FRESH_TOKEN,
+          refreshToken: "rotated-refresh-token",
+          refreshTokenExpiryTime: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+        }),
+      }),
+    );
+
+    await page.goto("/");
+
+    // The silent refresh persisted the rotated tokens…
+    await expect
+      .poll(async () => page.evaluate((k) => localStorage.getItem(k), ACCESS_KEY))
+      .toBe(FRESH_TOKEN);
+    await expect
+      .poll(async () => page.evaluate((k) => localStorage.getItem(k), REFRESH_KEY))
+      .toBe("rotated-refresh-token");
+    // …and the app did NOT bounce to /login.
+    await expect(page).not.toHaveURL(/\/login$/);
+  });
+});

--- a/src/Host/FSH.Starter.AppHost/AppHost.cs
+++ b/src/Host/FSH.Starter.AppHost/AppHost.cs
@@ -119,6 +119,35 @@ var migrator = builder.AddProject<Projects.FSH_Starter_DbMigrator>("fsh-db-migra
     .WithEnvironment("Seed__DefaultAdminPassword", "123Pa$$word!")
     .WithArgs("apply", "--seed");
 
+// Demo data seeder (dev-only) — provisions the `acme` and `globex` demo
+// tenants plus the users the dashboard's demo-login panel advertises. The base
+// migrator above runs `apply --seed`, which only creates the root tenant +
+// root admin; the demo tenants are created exclusively by the migrator's
+// `seed-demo` verb. Without this step those acme/globex logins fail against a
+// freshly-provisioned database even though the login panel offers them.
+//
+// Chained after the base migration (shares the same Postgres). Idempotent, so
+// re-running on each launch is a no-op once seeded. DOTNET_ENVIRONMENT is pinned
+// to Development and Seed__DemoPassword passed explicitly because seed-demo
+// refuses to run outside Development and requires the demo credential in config
+// (mirrors the dashboard's DEMO_PASSWORD = "Password123!").
+//
+// IMPORTANT: the migrator is a generic-host console app, so its IHostEnvironment
+// reads DOTNET_ENVIRONMENT — NOT ASPNETCORE_ENVIRONMENT (only ASP.NET web hosts
+// honor that). Aspire injects ASPNETCORE_ENVIRONMENT into child projects but not
+// DOTNET_ENVIRONMENT, so without this line the migrator defaults to Production
+// and seed-demo bails with "REFUSING to run".
+var demoSeeder = builder.AddProject<Projects.FSH_Starter_DbMigrator>("fsh-demo-seeder")
+    .WithReference(postgres)
+    .WaitFor(postgres)
+    .WaitForCompletion(migrator)
+    .WithEnvironment("DOTNET_ENVIRONMENT", "Development")
+    .WithEnvironment("DatabaseOptions__Provider", "POSTGRESQL")
+    .WithEnvironment("DatabaseOptions__ConnectionString", postgres.Resource.ConnectionStringExpression)
+    .WithEnvironment("DatabaseOptions__MigrationsAssembly", "FSH.Starter.Migrations.PostgreSQL")
+    .WithEnvironment("Seed__DemoPassword", "Password123!")
+    .WithArgs("seed-demo");
+
 // API Service
 var api = builder.AddProject<Projects.FSH_Starter_Api>("fsh-api")
     .WithReference(postgres)
@@ -127,6 +156,7 @@ var api = builder.AddProject<Projects.FSH_Starter_Api>("fsh-api")
     .WaitFor(redis)
     .WaitForCompletion(minioInit)
     .WaitForCompletion(migrator)
+    .WaitForCompletion(demoSeeder)
     .WithExternalHttpEndpoints()
     .WithEnvironment("DatabaseOptions__Provider", "POSTGRESQL")
     .WithEnvironment("DatabaseOptions__ConnectionString", postgres.Resource.ConnectionStringExpression)

--- a/src/Host/FSH.Starter.DbMigrator/Program.cs
+++ b/src/Host/FSH.Starter.DbMigrator/Program.cs
@@ -49,6 +49,17 @@ if (cli.Help)
 }
 var builder = Host.CreateApplicationBuilder(args);
 
+// The migrator loads every module so DbInitializers/seeders resolve, but runs a
+// deliberately reduced service graph (Mailing, Realtime/SignalR, Jobs disabled
+// via AddHeroPlatform below). The default container's build-time validation —
+// auto-on in Development — walks ALL registered descriptors, including request
+// handlers this process never invokes (Chat handlers needing IHubContext,
+// Identity handlers needing IMailService) and throws at startup. Disable it: the
+// migrator only resolves migration/seed services, so full-graph validation is a
+// false positive here. No-op in Production, where it's already off.
+builder.ConfigureContainer(new DefaultServiceProviderFactory(
+    new ServiceProviderOptions { ValidateOnBuild = false, ValidateScopes = false }));
+
 // In local development (dotnet run), the working directory is the project folder,
 // but appsettings.json is linked and copied to the output directory.
 // We explicitly load it from AppContext.BaseDirectory so IdentityModule's JwtOptions validate.


### PR DESCRIPTION
## Why

On a fresh `dotnet run --project src/Host/FSH.Starter.AppHost`, logging into the dashboard with the advertised demo accounts (`admin@acme.com` / `Password123!`) failed in **every** browser, including incognito. Two independent defects:

1. **Demo tenants were never seeded.** AppHost ran only the migrator's `apply --seed` verb (root tenant/admin only). The `acme`/`globex` demo tenants are created solely by the dev-only `seed-demo` verb, which AppHost never invoked — so the demo-login panel advertised accounts that didn't exist.
2. **A stale/expired token booted the app as "signed in."** Both React apps derived `isAuthenticated` from token presence/decodability without checking `exp`, so a leftover token in `localStorage` rendered the app and fired protected requests that 401'd in a loop (`SecurityTokenExpiredException`) instead of refreshing or routing to `/login`.

## What changed

**Backend / scaffold**
- **AppHost**: new dev-only `fsh-demo-seeder` resource runs `seed-demo` after the base migration; the API waits for it so demo accounts exist before the dashboard is reachable. Idempotent. Pins `DOTNET_ENVIRONMENT=Development` (the generic-host migrator ignores Aspire's injected `ASPNETCORE_ENVIRONMENT`) and passes `Seed__DemoPassword` explicitly.
- **DbMigrator**: disable build-time DI validation. The migrator runs a deliberately reduced service graph (Mailing/SignalR/Jobs off); Development's auto-on `ValidateOnBuild` walked request handlers the migrator never invokes (needing `IHubContext`/`IMailService`) and crashed startup. The migrator only resolves migration/seed services, so this validation was a false positive (no-op in Production).

**Frontend (admin + dashboard, symmetric)**
- `isTokenExpired` added to `jwt.ts`.
- Auth context now does a one-shot **silent refresh at boot** when the access token is missing/expired but a refresh token is present (`isInitializing`), deciding signed-in vs `/login` before rendering. A live session whose access token expires mid-use stays authenticated (reactive 401-refresh), so the 45-min access / 7-day refresh UX is preserved.
- `ProtectedRoute` renders a loader while initializing so no request fires with a dead token.
- Exported `refreshAccessToken` for the boot path.

## Tests
- New `tests/auth/session-restore.spec.ts` in **both** apps: expired token + refresh-fails → routes to `/login`; expired token + refresh-succeeds → session restored, no `/login` bounce. **4/4 pass.**
- `tsc -b` clean for both apps; `eslint` 0 errors; backend `dotnet build` clean.

## Verification
Relaunching Aspire seeds `acme`/`globex` and demo logins succeed; a stale token now silently refreshes or cleanly redirects to `/login` instead of dumping `SecurityTokenExpiredException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
