### PR TITLE
fix(scaffold): no-frontend AppHost build + correct advertised health URL

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -40,7 +40,7 @@ Wait until you see something like `[migrator] DbMigrator completed` and the `mig
 ## Verify it's healthy
 
 ```bash
-curl -fsS http://localhost:8080/health        # API
+curl -fsS http://localhost:8080/health/live   # API liveness
 curl -fsSI http://localhost:8081/ | head -1   # admin SPA — HTTP/1.1 200 OK
 curl -fsS  http://localhost:8081/config.json  # admin runtime config — shows FSH_API_URL
 curl -fsSI http://localhost:8082/ | head -1   # dashboard SPA

--- a/src/Host/FSH.Starter.AppHost/AppHost.cs
+++ b/src/Host/FSH.Starter.AppHost/AppHost.cs
@@ -199,6 +199,12 @@ builder.AddJavaScriptApp($"{appPrefix}-dashboard", "../../../clients/dashboard",
     .WithHttpEndpoint(port: 5174, targetPort: 5174, isProxied: false)
     .WithExternalHttpEndpoints()
     .WithEnvironment("VITE_API_BASE_URL", api.GetEndpoint("https"));
+//#else
+// With the React apps excluded, nothing else references the `api` resource
+// handle, which would trip the unused-local analyzer (S1481) under
+// TreatWarningsAsErrors. Discard it explicitly to keep the no-frontend
+// scaffold warning-clean. (In the full template this branch is dropped.)
+_ = api;
 //#endif
 
 await builder.Build().RunAsync();

--- a/src/Tools/CLI/Commands/NewCommand.cs
+++ b/src/Tools/CLI/Commands/NewCommand.cs
@@ -466,7 +466,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             tree.AddNode($"[{FshConstants.WarningColor}]Run 'npm install' in clients/admin and clients/dashboard first.[/]");
 
         tree.AddNode($"[{FshConstants.DimColor}]API docs:[/]         https://localhost:{FshConstants.ApiHttpsPort}/scalar");
-        tree.AddNode($"[{FshConstants.DimColor}]Health check:[/]     https://localhost:{FshConstants.ApiHttpsPort}/health");
+        tree.AddNode($"[{FshConstants.DimColor}]Health check:[/]     https://localhost:{FshConstants.ApiHttpsPort}/health/live");
 
         if (dockerEnvReady)
             tree.AddNode($"[{FshConstants.DimColor}]Self-host:[/]        cd deploy/docker && docker compose up -d --build  [{FshConstants.DimColor}](secrets pre-generated in .env)[/]");


### PR DESCRIPTION
Found while smoke-testing the full template distribution (pack → install → `fsh new` → build → run).

## 1. `--no-frontend` scaffold didn't compile
The AppHost's `api` resource handle is only consumed by the React apps' `.WithReference(api)`. With the frontend excluded, `api` becomes an unused local → **`S1481`** under `TreatWarningsAsErrors`, so `dotnet build` of a `--no-frontend` scaffold failed. Added a `//#else` branch that discards it (`_ = api;`) so the no-frontend render stays warning-clean. The full (frontend) template — and the main repo — are unaffected (verified both build 0/0).

## 2. Advertised health URL was wrong
The CLI "Next Steps" and `deploy/docker/README.md` pointed at `/health`, which isn't a route — the probes are **`/health/live`** and **`/health/ready`**. A request to `/health` matches no endpoint, and the global fallback authorization policy (`RequireAuthenticatedUser`) returns **401** (not 404) for the unmatched path, so the advertised URL looked "broken." Pointed both at `/health/live`.

Verified end-to-end against a running stack: `/health/live` and `/health/ready` → 200, OpenAPI → 200 (132 paths), tenant login → 200, wrong password → 401, missing tenant header → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
