### PR TITLE
fix(identity): advertise the dev root password as Password123!

### DIFF
--- a/clients/dashboard/src/pages/login.demo-accounts.ts
+++ b/clients/dashboard/src/pages/login.demo-accounts.ts
@@ -20,10 +20,12 @@ export type DemoAccount = {
 
 export const DEMO_PASSWORD = "Password123!";
 
-// Root tenant uses the platform default password (kept in sync with
-// MultitenancyConstants.DefaultPassword on the backend) — distinct from the
-// dev seed password used by the Acme/Globex demo accounts.
-export const ROOT_PASSWORD = "123Pa$$word!";
+// In the Aspire dev stack the demo seeder (`seed-demo`) runs after `apply --seed`
+// and realigns every tenant admin — including root's admin@root.com — to the
+// shared demo password, so in dev the root account signs in with the same
+// Password123! as the Acme/Globex demo users. (A production deploy that skips
+// seed-demo keeps whatever Seed:DefaultAdminPassword is configured.)
+export const ROOT_PASSWORD = DEMO_PASSWORD;
 
 const acme = (
   email: string,

--- a/src/Host/FSH.Starter.Api/Requests/Identity/identity-token.http
+++ b/src/Host/FSH.Starter.Api/Requests/Identity/identity-token.http
@@ -8,6 +8,6 @@ tenant: {{tenant}}
 
 {
   "email": "admin@root.com",
-  "password": "123Pa$$word!"
+  "password": "Password123!"
 }
 


### PR DESCRIPTION
Follow-up to #1260 / #1262.

Once AppHost runs `seed-demo` on launch (#1260), `DemoSeeder` realigns **every** tenant admin — including root's `admin@root.com` — to the shared demo password. So in the Aspire dev stack the root account signs in with **`Password123!`**, not the framework default `123Pa$$word!`. The advertised credentials were stale and 401'd:

- `clients/dashboard/src/pages/login.demo-accounts.ts` — `ROOT_PASSWORD = DEMO_PASSWORD` (the demo login panel's root account now works).
- `src/Host/FSH.Starter.Api/Requests/Identity/identity-token.http` — sample request uses `Password123!`.

The framework seed default (`Seed:DefaultAdminPassword`) is **unchanged** — a production deploy that skips `seed-demo` keeps its configured admin password.

> Note: this change was originally committed onto the #1262 branch *after* that PR had already merged, so it never landed. This PR re-applies it (cherry-pick of `a6434f2f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
