### PR TITLE
fix(cli): correct update-check version comparison + support --version

### DIFF
--- a/src/Tools/CLI/Commands/InfoCommand.cs
+++ b/src/Tools/CLI/Commands/InfoCommand.cs
@@ -41,10 +41,10 @@ public sealed class InfoCommand : AsyncCommand
         // Latest CLI
         if (latestCli is not null)
         {
-            bool isUpToDate = latestCli == currentVersion;
-            table.AddRow("Latest CLI", isUpToDate
-                ? $"[{FshConstants.SuccessColor}]{latestCli} (up to date)[/]"
-                : $"[{FshConstants.WarningColor}]{latestCli} (update available — run 'fsh update')[/]");
+            bool updateAvailable = VersionComparer.IsNewer(latestCli, currentVersion);
+            table.AddRow("Latest CLI", updateAvailable
+                ? $"[{FshConstants.WarningColor}]{latestCli} (update available — run 'fsh update')[/]"
+                : $"[{FshConstants.SuccessColor}]{latestCli} (up to date)[/]");
         }
         else
         {
@@ -61,10 +61,10 @@ public sealed class InfoCommand : AsyncCommand
 
         if (latestTemplate is not null)
         {
-            bool isUpToDate = latestTemplate == templateVersion;
-            table.AddRow("Latest Template", isUpToDate
-                ? $"[{FshConstants.SuccessColor}]{latestTemplate} (up to date)[/]"
-                : $"[{FshConstants.WarningColor}]{latestTemplate} (update available)[/]");
+            bool updateAvailable = VersionComparer.IsNewer(latestTemplate, templateVersion);
+            table.AddRow("Latest Template", updateAvailable
+                ? $"[{FshConstants.WarningColor}]{latestTemplate} (update available)[/]"
+                : $"[{FshConstants.SuccessColor}]{latestTemplate} (up to date)[/]");
         }
 
         // .NET SDK

--- a/src/Tools/CLI/Commands/NewCommand.cs
+++ b/src/Tools/CLI/Commands/NewCommand.cs
@@ -423,7 +423,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
 
             string currentVersion = typeof(NewCommand).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
 
-            if (latest is not null && latest != currentVersion)
+            if (VersionComparer.IsNewer(latest, currentVersion))
             {
                 AnsiConsole.WriteLine();
                 AnsiConsole.MarkupLine($"[{FshConstants.WarningColor}]A newer version of FSH CLI is available: {latest} (current: {currentVersion})[/]");

--- a/src/Tools/CLI/Infrastructure/VersionComparer.cs
+++ b/src/Tools/CLI/Infrastructure/VersionComparer.cs
@@ -1,0 +1,55 @@
+namespace FSH.CLI.Infrastructure;
+
+/// <summary>
+/// Minimal semantic-version comparison for the CLI's "update available" hints.
+/// Purpose-built so a locally-built CLI/template that is AHEAD of what's published
+/// (e.g. a 10.0.0 dev build vs a 10.0.0-rc.2 on NuGet) never nags about a phantom
+/// update — the old code compared with string inequality, which also tripped over
+/// the `+gitsha` build-metadata suffix on the informational version.
+/// </summary>
+internal static class VersionComparer
+{
+    /// <summary>
+    /// True only when <paramref name="latest"/> is a strictly higher semantic
+    /// version than <paramref name="current"/>. Build metadata (<c>+...</c>) is
+    /// ignored; a stable release outranks any pre-release of the same core
+    /// version (per SemVer precedence).
+    /// </summary>
+    internal static bool IsNewer(string? latest, string? current)
+    {
+        if (string.IsNullOrWhiteSpace(latest)) return false;
+        if (string.IsNullOrWhiteSpace(current)) return true;
+
+        (Version latestCore, string latestPre) = Parse(latest);
+        (Version currentCore, string currentPre) = Parse(current);
+
+        int coreComparison = latestCore.CompareTo(currentCore);
+        if (coreComparison != 0) return coreComparison > 0;
+
+        // Same core version: a stable build (no pre-release tag) ranks above any
+        // pre-release; between two pre-releases, compare the tags ordinally.
+        bool latestStable = latestPre.Length == 0;
+        bool currentStable = currentPre.Length == 0;
+        if (latestStable && currentStable) return false;            // identical
+        if (latestStable) return true;                              // stable > pre-release
+        if (currentStable) return false;                            // pre-release < stable
+        return string.CompareOrdinal(latestPre, currentPre) > 0;    // both pre-release
+    }
+
+    // Splits "10.0.0-rc.2+abc123" into (Version 10.0.0, "rc.2"), dropping build metadata.
+    private static (Version Core, string PreRelease) Parse(string version)
+    {
+        int plus = version.IndexOf('+', StringComparison.Ordinal);
+        if (plus >= 0) version = version[..plus];
+
+        string pre = string.Empty;
+        int dash = version.IndexOf('-', StringComparison.Ordinal);
+        if (dash >= 0)
+        {
+            pre = version[(dash + 1)..];
+            version = version[..dash];
+        }
+
+        return (Version.TryParse(version, out Version? core) ? core : new Version(0, 0, 0), pre);
+    }
+}

--- a/src/Tools/CLI/Program.cs
+++ b/src/Tools/CLI/Program.cs
@@ -1,11 +1,19 @@
+using System.Reflection;
 using FSH.CLI.Commands;
 using Spectre.Console.Cli;
+
+// Strip the +gitsha build-metadata suffix so `fsh --version` prints a clean version.
+var cliVersion = Assembly.GetExecutingAssembly()
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion?.Split('+')[0]
+    ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)
+    ?? "unknown";
 
 var app = new CommandApp();
 
 app.Configure(config =>
 {
     config.SetApplicationName("fsh");
+    config.SetApplicationVersion(cliVersion);
 
     config.AddCommand<NewCommand>("new")
         .WithDescription("Create a new FullStackHero .NET project.")


### PR DESCRIPTION
Found while smoke-testing the CLI ahead of release.

**Bug 1 — phantom "update available".** `fsh info` and the post-scaffold update check in `fsh new` compared versions with string inequality. Since the running version carries a `+gitsha` suffix (and "latest" from NuGet can be a prerelease), they *always* nagged "update available" — even when the local build was newer than what's published (`10.0.0` vs `10.0.0-rc.2`; template `10.0.0` vs `2.0.4-rc`). Added `VersionComparer.IsNewer` (semver-aware: ignores build metadata, ranks stable above prerelease of the same core version) and used it in both spots.

**Bug 2 — `fsh --version` errored.** It printed "Did you forget the command?". Wired `config.SetApplicationVersion(...)` so `fsh --version` → `10.0.0`.

Verified: `fsh --version` → `10.0.0`; `fsh info` now shows "up to date" for CLI + template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
