### PR TITLE
fix(cli,template): drop the unimplemented --db sqlserver option

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -69,7 +69,7 @@ jobs:
         run: dotnet new install "$RUNNER_TEMP"/pkg/FullStackHero.NET.StarterKit.*.nupkg
 
       - name: Scaffold project
-        run: dotnet new fsh -n Smoke.App -o "$RUNNER_TEMP/smoke" --db postgresql --aspire true --frontend true --skipRestore true
+        run: dotnet new fsh -n Smoke.App -o "$RUNNER_TEMP/smoke" --aspire true --frontend true --skipRestore true
 
       - name: Build backend (warnings as errors)
         run: dotnet build "$RUNNER_TEMP/smoke/src/Smoke.App.slnx" -c Release -warnaserror
@@ -110,7 +110,7 @@ jobs:
       # Backend-only path must still compile — guards the //#if (frontend) and
       # (!aspire) conditional gating in AppHost.cs and the solution.
       - name: Scaffold backend-only project
-        run: dotnet new fsh -n Smoke.Api -o "$RUNNER_TEMP/min" --db postgresql --aspire false --frontend false --skipRestore true
+        run: dotnet new fsh -n Smoke.Api -o "$RUNNER_TEMP/min" --aspire false --frontend false --skipRestore true
 
       - name: Build backend (warnings as errors)
         run: dotnet build "$RUNNER_TEMP/min/src/Smoke.Api.slnx" -c Release -warnaserror

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -23,22 +23,6 @@
     "sourceName": "FSH.Starter",
     "preferNameDirectory": true,
     "symbols": {
-        "db": {
-            "type": "parameter",
-            "datatype": "choice",
-            "description": "Database provider for migrations and persistence.",
-            "defaultValue": "postgresql",
-            "choices": [
-                {
-                    "choice": "postgresql",
-                    "description": "PostgreSQL (default)"
-                },
-                {
-                    "choice": "sqlserver",
-                    "description": "SQL Server"
-                }
-            ]
-        },
         "aspire": {
             "type": "parameter",
             "datatype": "bool",

--- a/src/Tools/CLI/Commands/NewCommand.cs
+++ b/src/Tools/CLI/Commands/NewCommand.cs
@@ -18,10 +18,6 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
         [CommandOption("-o|--output")]
         public string? Output { get; init; }
 
-        [Description("Database provider: postgresql (default) or sqlserver.")]
-        [CommandOption("--db")]
-        public string? Database { get; init; }
-
         [Description("Exclude the .NET Aspire AppHost project.")]
         [CommandOption("--no-aspire")]
         [DefaultValue(false)]
@@ -69,8 +65,6 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             return 1;
         }
 
-        string db = await ResolveDatabaseAsync(settings, cancellationToken).ConfigureAwait(false);
-
         bool aspire = await ResolveAspireAsync(settings, cancellationToken).ConfigureAwait(false);
 
         bool frontend = await ResolveFrontendAsync(settings, cancellationToken).ConfigureAwait(false);
@@ -95,7 +89,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
         }
 
         // 3. Print summary
-        PrintSummary(name, db, aspire, frontend, output, settings.DryRun);
+        PrintSummary(name, aspire, frontend, output, settings.DryRun);
 
         if (settings.DryRun)
         {
@@ -108,7 +102,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             return 1;
 
         // 5. Scaffold project
-        int result = await ScaffoldProjectAsync(name, db, aspire, frontend, output, cancellationToken).ConfigureAwait(false);
+        int result = await ScaffoldProjectAsync(name, aspire, frontend, output, cancellationToken).ConfigureAwait(false);
         if (result != 0)
         {
             AnsiConsole.MarkupLine($"[{FshConstants.ErrorColor}]Scaffolding failed. Check the output above for errors.[/]");
@@ -165,17 +159,6 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             .ShowAsync(AnsiConsole.Console, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<string> ResolveDatabaseAsync(Settings settings, CancellationToken cancellationToken)
-    {
-        if (settings.Database is not null) return settings.Database;
-        if (settings.NonInteractive) return "postgresql";
-
-        return await new SelectionPrompt<string>()
-            .Title($"[{FshConstants.AccentColor}]Database provider:[/]")
-            .AddChoices("postgresql", "sqlserver")
-            .ShowAsync(AnsiConsole.Console, cancellationToken).ConfigureAwait(false);
-    }
-
     private static async Task<bool> ResolveAspireAsync(Settings settings, CancellationToken cancellationToken)
     {
         if (settings.NoAspire) return false;
@@ -196,13 +179,12 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             .ShowAsync(AnsiConsole.Console, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void PrintSummary(string name, string db, bool aspire, bool frontend, string output, bool dryRun)
+    private static void PrintSummary(string name, bool aspire, bool frontend, string output, bool dryRun)
     {
         AnsiConsole.WriteLine();
 
         string mode = dryRun ? " [yellow](dry run)[/]" : "";
         AnsiConsole.MarkupLine($"[bold]Creating project:[/] {name.EscapeMarkup()}{mode}");
-        AnsiConsole.MarkupLine($"  [{FshConstants.DimColor}]Database:[/]  {db}");
         AnsiConsole.MarkupLine($"  [{FshConstants.DimColor}]Aspire:[/]    {(aspire ? "yes" : "no")}");
         AnsiConsole.MarkupLine($"  [{FshConstants.DimColor}]Frontend:[/]  {(frontend ? "yes (admin + dashboard)" : "no")}");
         AnsiConsole.MarkupLine($"  [{FshConstants.DimColor}]Output:[/]    {output.EscapeMarkup()}");
@@ -242,7 +224,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
     }
 
     private static async Task<int> ScaffoldProjectAsync(
-        string name, string db, bool aspire, bool frontend, string output, CancellationToken cancellationToken)
+        string name, bool aspire, bool frontend, string output, CancellationToken cancellationToken)
     {
         return await AnsiConsole.Status()
             .Spinner(Spinner.Known.Dots)
@@ -251,7 +233,7 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             {
                 string aspireFlag = aspire ? "true" : "false";
                 string frontendFlag = frontend ? "true" : "false";
-                string args = $"new {FshConstants.TemplateShortName} -n {name} -o \"{output}\" --db {db} --aspire {aspireFlag} --frontend {frontendFlag} --force";
+                string args = $"new {FshConstants.TemplateShortName} -n {name} -o \"{output}\" --aspire {aspireFlag} --frontend {frontendFlag} --force";
                 await ProcessRunner.RunAsync("dotnet", args, showOutput: false, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/Tools/CLI/Program.cs
+++ b/src/Tools/CLI/Program.cs
@@ -10,7 +10,6 @@ app.Configure(config =>
     config.AddCommand<NewCommand>("new")
         .WithDescription("Create a new FullStackHero .NET project.")
         .WithExample("new", "MyApp")
-        .WithExample("new", "MyApp", "--db", "sqlserver")
         .WithExample("new", "MyApp", "--no-aspire", "--no-git");
 
     config.AddCommand<DoctorCommand>("doctor")


### PR DESCRIPTION
Found during the pre-release smoke test.

`--db sqlserver` (CLI option + template `db` choice) advertised SQL Server but did **nothing** — the generated project was always PostgreSQL (provider `POSTGRESQL`, Postgres connection string, only a `*.Migrations.PostgreSQL` project). The `db` symbol had no conditional wiring at all.

Rather than ship a misleading option in the grand release, this removes it so the scaffold only offers what works:
- CLI: dropped the `--db` option, the interactive DB prompt, and the `--db sqlserver` example.
- Template: removed the `db` choice symbol.

The backend's latent provider abstraction (`DbProviders`, `OptionsBuilderExtensions`) is **left intact**, so proper SQL Server support can be added later without re-plumbing.

Verified: CLI builds, `fsh new --help` no longer lists `--db`, and a fresh pack→install→scaffold→build (no `--db`) produces a clean PostgreSQL app (build 0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
