### PR TITLE
Tenant billing completion + activation/impersonation fixes

### DIFF
--- a/clients/admin/src/api/billing.ts
+++ b/clients/admin/src/api/billing.ts
@@ -1,5 +1,7 @@
-import { apiFetch } from "@/lib/api-client";
+import { apiFetch, ApiRequestError } from "@/lib/api-client";
 import type { PagedResponse } from "@/lib/api-types";
+import { env } from "@/env";
+import { tokenStore } from "@/auth/token-store";
 
 // ─── shared enums ────────────────────────────────────────────────────
 
@@ -180,6 +182,48 @@ export function listInvoices(params: ListInvoicesParams = {}): Promise<PagedResp
 
 export function getInvoice(invoiceId: string): Promise<InvoiceDto> {
   return apiFetch<InvoiceDto>(`/api/v1/billing/invoices/${encodeURIComponent(invoiceId)}`);
+}
+
+/**
+ * Fetch the invoice PDF as a blob and trigger a browser download named
+ * `{invoiceNumber}.pdf`. The endpoint streams `application/pdf`, so it can't
+ * go through `apiFetch` (which only parses JSON). We replicate apiFetch's
+ * auth + tenant headers by hand so cross-tenant viewing works identically to
+ * how the detail page loads the invoice via `getInvoice`.
+ */
+export async function downloadInvoicePdf(invoiceId: string, invoiceNumber: string): Promise<void> {
+  const headers = new Headers({ Accept: "application/pdf" });
+
+  const accessToken = tokenStore.getAccessToken();
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+  const tenant = tokenStore.getTenant() ?? env.defaultTenant;
+  if (tenant) {
+    headers.set("tenant", tenant);
+  }
+
+  const response = await fetch(
+    `${env.apiBase}/api/v1/billing/invoices/${encodeURIComponent(invoiceId)}/pdf`,
+    { headers },
+  );
+
+  if (!response.ok) {
+    throw new ApiRequestError(response.status, `Failed to download invoice PDF (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = `${invoiceNumber}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
 }
 
 export function generateInvoices(periodYear: number, periodMonth: number): Promise<{ generated: number }> {

--- a/clients/admin/src/api/tenants.ts
+++ b/clients/admin/src/api/tenants.ts
@@ -42,6 +42,11 @@ export type RenewTenantResponse = {
   planChanged: boolean;
 };
 
+export type AdjustTenantValidityResponse = {
+  tenantId: string;
+  validUpto: string;
+};
+
 export type CreateTenantResponse = {
   id: string;
   provisioningCorrelationId?: string;
@@ -109,6 +114,18 @@ export async function renewTenant(id: string, planKey?: string | null): Promise<
   return apiFetch<RenewTenantResponse>(`/api/v1/tenants/${encodeURIComponent(id)}/renew`, {
     method: "POST",
     body: JSON.stringify({ tenantId: id, planKey: planKey ?? null }),
+  });
+}
+
+/**
+ * Operator override: set a tenant's ValidUpto directly with NO invoice
+ * (comp/correction). Backdating is allowed server-side. Root-operator only —
+ * gated by MultitenancyPermissions.Tenants.UpgradeSubscription, same as renew.
+ */
+export async function adjustTenantValidity(id: string, validUpto: string): Promise<AdjustTenantValidityResponse> {
+  return apiFetch<AdjustTenantValidityResponse>(`/api/v1/tenants/${encodeURIComponent(id)}/adjust-validity`, {
+    method: "POST",
+    body: JSON.stringify({ tenantId: id, validUpto }),
   });
 }
 

--- a/clients/admin/src/components/billing/plan-form-dialog.tsx
+++ b/clients/admin/src/components/billing/plan-form-dialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
 import { CreditCard, Gauge } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -25,6 +26,24 @@ import { ApiRequestError } from "@/lib/api-client";
 
 const PLAN_KEY_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/;
 
+// A money/rate field is a free-text decimal string. These refinements run
+// client-side so a negative price is rejected before any network call (the
+// server also rejects it, but we don't rely on that).
+const NON_NEGATIVE_MSG = "Must be a non-negative number.";
+
+/** Required non-negative decimal (e.g. monthly base price). */
+const requiredNonNegative = z
+  .string()
+  .trim()
+  .min(1, "Required.")
+  .refine((v) => Number.isFinite(Number(v)) && Number(v) >= 0, NON_NEGATIVE_MSG);
+
+/** Optional non-negative decimal (blank allowed → omitted). */
+const optionalNonNegative = z
+  .string()
+  .trim()
+  .refine((v) => v === "" || (Number.isFinite(Number(v)) && Number(v) >= 0), NON_NEGATIVE_MSG);
+
 const INTERVAL_OPTIONS: SelectOption<PlanInterval>[] = [
   { value: "Monthly", label: "Monthly", hint: "billed every month" },
   { value: "Yearly", label: "Yearly", hint: "billed every 12 months" },
@@ -46,11 +65,19 @@ function toOverageNumbers(state: OverageState): Record<string, number> | null {
     const raw = state[key];
     if (raw === undefined || raw.trim() === "") continue;
     const n = Number(raw);
+    // Submission is blocked upstream when a value is invalid, so anything that
+    // reaches here is a non-negative finite number.
     if (!Number.isFinite(n) || n < 0) continue;
     out[key] = n;
     any = true;
   }
   return any ? out : null;
+}
+
+/** First validation message for a value against a schema, or undefined when valid. */
+function fieldError(schema: z.ZodTypeAny, value: string): string | undefined {
+  const result = schema.safeParse(value);
+  return result.success ? undefined : result.error.issues[0]?.message;
 }
 
 function describe(err: unknown, fallback: string): string {
@@ -126,10 +153,27 @@ export function PlanFormDialog({
 
   const keyInvalid = !isEdit && key.length > 0 && !PLAN_KEY_PATTERN.test(key);
   const priceNum = Number(monthlyBasePrice);
-  const priceInvalid = monthlyBasePrice.length > 0 && (!Number.isFinite(priceNum) || priceNum < 0);
+  // Only surface the price error once something's been typed; submit-time
+  // validation (onSubmit) still blocks an empty required field.
+  const priceError =
+    monthlyBasePrice.length > 0 ? fieldError(requiredNonNegative, monthlyBasePrice) : undefined;
   const annualNum = Number(annualPrice);
-  const annualInvalid = annualPrice.trim().length > 0 && (!Number.isFinite(annualNum) || annualNum < 0);
+  const annualError = fieldError(optionalNonNegative, annualPrice);
   const annualPricePayload = interval === "Yearly" && annualPrice.trim().length > 0 ? annualNum : null;
+
+  // Per-resource overage validation — a negative or non-numeric rate blocks submit.
+  const overageErrors = useMemo(() => {
+    const out: Partial<Record<string, string>> = {};
+    for (const { key: resKey } of OVERAGE_RESOURCES) {
+      const err = fieldError(optionalNonNegative, overage[resKey] ?? "");
+      if (err) out[resKey] = err;
+    }
+    return out;
+  }, [overage]);
+  const hasOverageError = Object.keys(overageErrors).length > 0;
+  // Aggregate validity for disabling submit. Monthly price is required + non-negative.
+  const pricingInvalid =
+    !!fieldError(requiredNonNegative, monthlyBasePrice) || !!annualError || hasOverageError;
 
   const onClose = () => onOpenChange(false);
 
@@ -157,7 +201,7 @@ export function PlanFormDialog({
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (priceInvalid || annualInvalid) return;
+    if (pricingInvalid) return;
     const overageRates = toOverageNumbers(overage);
 
     if (isEdit && plan) {
@@ -252,7 +296,7 @@ export function PlanFormDialog({
                   label="Monthly base price"
                   hint="Canonical monthly rate; the term price for monthly plans."
                   required
-                  error={priceInvalid ? "Must be a non-negative number." : undefined}
+                  error={priceError}
                 >
                   <Input
                     id="pf-monthlyBasePrice"
@@ -275,7 +319,7 @@ export function PlanFormDialog({
                     id="pf-annualPrice"
                     label="Annual price"
                     hint="Per yearly term. Blank → 12× monthly."
-                    error={annualInvalid ? "Must be a non-negative number." : undefined}
+                    error={annualError}
                   >
                     <Input
                       id="pf-annualPrice"
@@ -299,7 +343,12 @@ export function PlanFormDialog({
               <div className="h-px bg-[var(--color-border)] opacity-60" />
               <div className="grid gap-4 sm:grid-cols-2">
                 {OVERAGE_RESOURCES.map((res) => (
-                  <Field key={res.key} id={`pf-overage-${res.key}`} label={res.label}>
+                  <Field
+                    key={res.key}
+                    id={`pf-overage-${res.key}`}
+                    label={res.label}
+                    error={overageErrors[res.key]}
+                  >
                     <Input
                       id={`pf-overage-${res.key}`}
                       value={overage[res.key] ?? ""}
@@ -317,7 +366,7 @@ export function PlanFormDialog({
             <Button type="button" variant="outline" onClick={onClose} disabled={pending}>
               Cancel
             </Button>
-            <Button type="submit" disabled={pending || keyInvalid || priceInvalid || annualInvalid}>
+            <Button type="submit" disabled={pending || keyInvalid || pricingInvalid}>
               {pending ? "Saving…" : isEdit ? "Save changes" : "Create plan"}
             </Button>
           </DialogFooter>

--- a/clients/admin/src/components/layout/topbar.tsx
+++ b/clients/admin/src/components/layout/topbar.tsx
@@ -102,31 +102,6 @@ function SimpleMenuItem({
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TenantChip — tenant indicator in the topbar right zone.
-// ─────────────────────────────────────────────────────────────────────────────
-
-function TenantChip({ tenant }: { tenant?: string }) {
-  return (
-    <div
-      className="hidden items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)] px-2.5 py-1 md:inline-flex"
-      title="Active tenant"
-    >
-      <span
-        aria-hidden
-        className="inline-flex h-1.5 w-1.5 rounded-full bg-[var(--color-success)]"
-        style={{ color: "var(--color-success)" }}
-      />
-      <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
-        tenant
-      </span>
-      <span className="font-mono text-[12px] font-medium tracking-tight text-[var(--color-foreground)]">
-        {tenant ?? "—"}
-      </span>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Topbar
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -154,9 +129,6 @@ export function Topbar() {
 
       {/* Spacer pushes right-side actions to the trailing edge */}
       <div className="flex-1" />
-
-      {/* Tenant chip */}
-      <TenantChip tenant={user?.tenant} />
 
       {/* Notification bell */}
       <NotificationBell />

--- a/clients/admin/src/components/tenants/adjust-validity-dialog.tsx
+++ b/clients/admin/src/components/tenants/adjust-validity-dialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { CalendarCog } from "lucide-react";
+import { toast } from "sonner";
+import { adjustTenantValidity } from "@/api/tenants";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Field } from "@/components/list";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ApiRequestError } from "@/lib/api-client";
+
+// A `type="date"` input yields a `YYYY-MM-DD` string. zod validates the shape
+// and that it parses to a real calendar date.
+const schema = z.object({
+  validUpto: z
+    .string()
+    .min(1, "Pick a date.")
+    .refine((v) => !Number.isNaN(new Date(v).getTime()), "Enter a valid date."),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+function describe(err: unknown, fallback: string): string {
+  if (err instanceof ApiRequestError) return err.problem?.detail ?? err.problem?.title ?? err.message;
+  if (err instanceof Error) return err.message;
+  return fallback;
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString();
+}
+
+/** `YYYY-MM-DD` (the native date input value) for an ISO/date string, for prefill. */
+function toDateInputValue(value?: string | null): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Operator override that sets a tenant's ValidUpto directly with NO invoice —
+ * a comp/correction, distinct from Renew (which issues a term invoice).
+ * Backdating is permitted server-side. Root-operator only.
+ */
+export function AdjustValidityDialog({
+  open,
+  onOpenChange,
+  tenantId,
+  validUpto,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tenantId: string;
+  validUpto?: string;
+}) {
+  const queryClient = useQueryClient();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { validUpto: "" },
+  });
+
+  // Prefill with the tenant's current validity each time the dialog opens.
+  useEffect(() => {
+    if (open) reset({ validUpto: toDateInputValue(validUpto) });
+  }, [open, validUpto, reset]);
+
+  const mutation = useMutation({
+    // Pass the date via mutate(arg) — never close over form state at submit time.
+    mutationFn: (value: string) => adjustTenantValidity(tenantId, new Date(value).toISOString()),
+    onSuccess: (result) => {
+      toast.success("Validity adjusted", {
+        description: `Valid until ${formatDate(result.validUpto)}. No invoice was issued.`,
+      });
+      queryClient.invalidateQueries({ queryKey: ["tenant", tenantId] });
+      queryClient.invalidateQueries({ queryKey: ["tenants"] });
+      handleClose();
+    },
+    onError: (err) => toast.error("Adjust failed", { description: describe(err, "Could not adjust validity.") }),
+  });
+
+  function handleClose() {
+    reset({ validUpto: "" });
+    onOpenChange(false);
+  }
+
+  const onSubmit = handleSubmit((values) => mutation.mutate(values.validUpto));
+  const submitting = isSubmitting || mutation.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) handleClose();
+        else onOpenChange(true);
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className="grid h-9 w-9 shrink-0 place-items-center rounded-xl
+                bg-[oklch(from_var(--color-primary)_l_c_h_/_0.12)] text-[var(--color-primary)]
+                ring-1 ring-inset ring-[oklch(from_var(--color-primary)_l_c_h_/_0.18)]"
+            >
+              <CalendarCog className="h-[18px] w-[18px]" />
+            </span>
+            <DialogTitle className="text-[16px]">Adjust validity</DialogTitle>
+          </div>
+          <DialogDescription className="mt-1">
+            Set this tenant's expiry date directly — an operator override with{" "}
+            <strong className="text-[var(--color-foreground)]">no invoice</strong>. Use for comps or
+            corrections; renewals that should bill belong in Renew. Currently valid until{" "}
+            {formatDate(validUpto)}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={onSubmit}>
+          <DialogBody className="space-y-4">
+            <Field
+              id="av-validUpto"
+              label="Valid until"
+              required
+              hint="Backdating is allowed. No invoice is issued for an adjustment."
+              error={errors.validUpto?.message}
+            >
+              <Input id="av-validUpto" type="date" {...register("validUpto")} />
+            </Field>
+          </DialogBody>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Adjust validity"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/clients/admin/src/components/ui/confirm-dialog.tsx
+++ b/clients/admin/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/cn";
+
+/**
+ * A reusable confirmation dialog for important / irreversible actions. Replaces ad-hoc
+ * window.confirm calls with a styled, accessible Radix dialog. The confirm button shows a pending
+ * state while the action runs and the dialog stays open until the caller closes it.
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  destructive = false,
+  pending = false,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  destructive?: boolean;
+  pending?: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => (pending ? undefined : onOpenChange(o))}>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className={cn(
+                "grid h-9 w-9 shrink-0 place-items-center rounded-xl ring-1 ring-inset",
+                destructive
+                  ? "bg-[oklch(from_var(--color-destructive)_l_c_h_/_0.12)] text-[var(--color-destructive)] ring-[oklch(from_var(--color-destructive)_l_c_h_/_0.18)]"
+                  : "bg-[oklch(from_var(--color-primary)_l_c_h_/_0.12)] text-[var(--color-primary)] ring-[oklch(from_var(--color-primary)_l_c_h_/_0.18)]",
+              )}
+            >
+              <AlertTriangle className="h-[18px] w-[18px]" />
+            </span>
+            <DialogTitle className="text-[16px]">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+
+        <DialogBody>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogBody>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "default"}
+            onClick={onConfirm}
+            disabled={pending}
+          >
+            {pending ? "Working…" : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/clients/admin/src/pages/billing/invoice-detail.tsx
+++ b/clients/admin/src/pages/billing/invoice-detail.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Ban, CheckCircle2, FileText, Send } from "lucide-react";
+import { ArrowLeft, Ban, CheckCircle2, Download, FileText, Send } from "lucide-react";
 import { toast } from "sonner";
 import {
+  downloadInvoicePdf,
   getInvoice,
   issueInvoice,
   markInvoicePaid,
@@ -89,6 +90,13 @@ export function InvoiceDetailPage() {
   const [dueAt, setDueAt] = useState("");
   const [voidReason, setVoidReason] = useState("");
 
+  // Pass id + number via mutate(arg) — never close over invoice state, which
+  // could be stale if the query refetched between render and click.
+  const downloadMutation = useMutation({
+    mutationFn: ({ id, number }: { id: string; number: string }) => downloadInvoicePdf(id, number),
+    onError: (err) => toast.error("Download failed", { description: describe(err, "Could not download the invoice PDF.") }),
+  });
+
   const issueMutation = useMutation({
     mutationFn: () => issueInvoice(invoiceId, dueAt ? new Date(dueAt).toISOString() : null),
     onSuccess: () => {
@@ -170,7 +178,20 @@ export function InvoiceDetailPage() {
                 </span>
               </span>
             }
-          />
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                downloadMutation.mutate({ id: invoice.id, number: invoice.invoiceNumber })
+              }
+              disabled={downloadMutation.isPending}
+              title="Download this invoice as a PDF"
+            >
+              <Download className="mr-1.5 h-3.5 w-3.5" />
+              {downloadMutation.isPending ? "Preparing…" : "Download PDF"}
+            </Button>
+          </EntityPageHeader>
         ) : null}
       </div>
 

--- a/clients/admin/src/pages/tenants/detail.tsx
+++ b/clients/admin/src/pages/tenants/detail.tsx
@@ -24,6 +24,7 @@ import { ImpersonateDialog } from "@/components/impersonation/impersonate-dialog
 import { ActiveGrantsCard } from "@/components/impersonation/active-grants-card";
 import { TenantBrandingCard } from "@/components/tenants/tenant-branding-card";
 import { RenewTenantDialog } from "@/components/tenants/renew-tenant-dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { IdentityPermissions } from "@/lib/permissions";
 import {
   changeTenantActivation,
@@ -51,6 +52,7 @@ export function TenantDetailPage() {
   const { user: currentUser } = useAuth();
   const [impersonateOpen, setImpersonateOpen] = useState(false);
   const [renewOpen, setRenewOpen] = useState(false);
+  const [activationConfirmOpen, setActivationConfirmOpen] = useState(false);
   const canImpersonate = (currentUser?.permissions ?? []).includes(
     IdentityPermissions.Users.Impersonate,
   );
@@ -85,6 +87,7 @@ export function TenantDetailPage() {
     mutationFn: (isActive: boolean) => changeTenantActivation(id, isActive),
     onSuccess: (result) => {
       toast.success(result.isActive ? "Tenant activated" : "Tenant deactivated");
+      setActivationConfirmOpen(false);
       queryClient.invalidateQueries({ queryKey: ["tenant", id] });
       queryClient.invalidateQueries({ queryKey: ["tenants"] });
     },
@@ -199,7 +202,7 @@ export function TenantDetailPage() {
                 </Button>
                 <Button
                   variant={tenant.isActive ? "outline" : "default"}
-                  onClick={() => activationMutation.mutate(!tenant.isActive)}
+                  onClick={() => setActivationConfirmOpen(true)}
                   disabled={activationMutation.isPending}
                   className="shrink-0"
                 >
@@ -226,6 +229,30 @@ export function TenantDetailPage() {
             tenantId={tenant.id}
             currentPlanKey={tenant.plan}
             validUpto={tenant.validUpto}
+          />
+
+          <ConfirmDialog
+            open={activationConfirmOpen}
+            onOpenChange={setActivationConfirmOpen}
+            destructive={tenant.isActive}
+            title={tenant.isActive ? "Deactivate tenant?" : "Activate tenant?"}
+            description={
+              tenant.isActive ? (
+                <>
+                  Users of <strong className="text-[var(--color-foreground)]">{tenant.name}</strong> will
+                  be blocked from signing in and all their API requests will be rejected until you
+                  reactivate the tenant.
+                </>
+              ) : (
+                <>
+                  <strong className="text-[var(--color-foreground)]">{tenant.name}</strong>&apos;s users
+                  will be able to sign in and use the platform again.
+                </>
+              )
+            }
+            confirmLabel={tenant.isActive ? "Deactivate" : "Activate"}
+            pending={activationMutation.isPending}
+            onConfirm={() => activationMutation.mutate(!tenant.isActive)}
           />
 
           <ActiveGrantsCard tenantId={tenant.id} />

--- a/clients/admin/src/pages/tenants/detail.tsx
+++ b/clients/admin/src/pages/tenants/detail.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   Building2,
   CalendarClock,
+  CalendarCog,
   CheckCircle2,
   CircleDashed,
   ClipboardList,
@@ -24,8 +25,9 @@ import { ImpersonateDialog } from "@/components/impersonation/impersonate-dialog
 import { ActiveGrantsCard } from "@/components/impersonation/active-grants-card";
 import { TenantBrandingCard } from "@/components/tenants/tenant-branding-card";
 import { RenewTenantDialog } from "@/components/tenants/renew-tenant-dialog";
+import { AdjustValidityDialog } from "@/components/tenants/adjust-validity-dialog";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { IdentityPermissions } from "@/lib/permissions";
+import { IdentityPermissions, MultitenancyPermissions } from "@/lib/permissions";
 import {
   changeTenantActivation,
   getTenantProvisioningStatus,
@@ -52,9 +54,13 @@ export function TenantDetailPage() {
   const { user: currentUser } = useAuth();
   const [impersonateOpen, setImpersonateOpen] = useState(false);
   const [renewOpen, setRenewOpen] = useState(false);
+  const [adjustOpen, setAdjustOpen] = useState(false);
   const [activationConfirmOpen, setActivationConfirmOpen] = useState(false);
-  const canImpersonate = (currentUser?.permissions ?? []).includes(
-    IdentityPermissions.Users.Impersonate,
+  const permissions = currentUser?.permissions ?? [];
+  const canImpersonate = permissions.includes(IdentityPermissions.Users.Impersonate);
+  // Same gate as Renew — adjusting validity is a root-operator subscription action.
+  const canManageSubscription = permissions.includes(
+    MultitenancyPermissions.Tenants.UpgradeSubscription,
   );
 
   const tenantQuery = useQuery({
@@ -200,6 +206,17 @@ export function TenantDetailPage() {
                   <CalendarClock className="mr-1.5 h-3.5 w-3.5" />
                   Renew / change plan
                 </Button>
+                {canManageSubscription && (
+                  <Button
+                    variant="outline"
+                    onClick={() => setAdjustOpen(true)}
+                    className="shrink-0"
+                    title="Set the expiry date directly with no invoice (operator override)"
+                  >
+                    <CalendarCog className="mr-1.5 h-3.5 w-3.5" />
+                    Adjust validity
+                  </Button>
+                )}
                 <Button
                   variant={tenant.isActive ? "outline" : "default"}
                   onClick={() => setActivationConfirmOpen(true)}
@@ -230,6 +247,15 @@ export function TenantDetailPage() {
             currentPlanKey={tenant.plan}
             validUpto={tenant.validUpto}
           />
+
+          {canManageSubscription && (
+            <AdjustValidityDialog
+              open={adjustOpen}
+              onOpenChange={setAdjustOpen}
+              tenantId={tenant.id}
+              validUpto={tenant.validUpto}
+            />
+          )}
 
           <ConfirmDialog
             open={activationConfirmOpen}

--- a/clients/admin/tests/billing/invoice-detail.spec.ts
+++ b/clients/admin/tests/billing/invoice-detail.spec.ts
@@ -153,6 +153,45 @@ test.describe("billing invoice detail", () => {
     await expect(page.getByText(/marked paid/i)).toBeVisible();
   });
 
+  test("Download PDF fetches the invoice /pdf endpoint", async ({ page }) => {
+    await page.route("**/api/v1/billing/invoices/inv-1", async (route) => {
+      const method = route.request().method();
+      if (method === "GET") {
+        await route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(DRAFT_INVOICE),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+    // Stub the PDF stream with a tiny fake body so the blob download succeeds.
+    await page.route("**/api/v1/billing/invoices/inv-1/pdf", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/pdf" },
+        body: "%PDF-1.4 fake",
+      });
+    });
+
+    await page.goto("/billing/invoices/inv-1");
+    const main = page.getByRole("main");
+    const downloadBtn = main.getByRole("button", { name: /download pdf/i });
+    await expect(downloadBtn).toBeEnabled({ timeout: 10_000 });
+
+    const reqPromise = page.waitForRequest(
+      (r) => r.url().endsWith("/api/v1/billing/invoices/inv-1/pdf") && r.method() === "GET",
+      { timeout: 5_000 },
+    );
+    await downloadBtn.click();
+    const req = await reqPromise;
+
+    // Replicates getInvoice's auth + tenant headers so cross-tenant viewing works.
+    expect(req.headers()["authorization"]).toMatch(/^Bearer /);
+    expect(req.headers()["tenant"]).toBe("root");
+  });
+
   test("Void invoice POSTs to /void with the supplied reason", async ({ page }) => {
     await page.route("**/api/v1/billing/invoices/inv-1", async (route) => {
       const method = route.request().method();

--- a/clients/admin/tests/tenants/tenant-billing.spec.ts
+++ b/clients/admin/tests/tenants/tenant-billing.spec.ts
@@ -167,6 +167,73 @@ test.describe("tenant detail — renew", () => {
   });
 });
 
+test.describe("tenant detail — adjust validity", () => {
+  test("posts the expected body to /adjust-validity", async ({ page }) => {
+    await mockPlans(page);
+    await page.route("**/api/v1/tenants/acme-corp/status", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "acme-corp", name: "Acme Corp", adminEmail: "admin@acme.example",
+          isActive: true, validUpto: "2026-05-01T00:00:00Z", issuer: "acme-corp.issuer",
+          plan: "pro", expiryState: "Active", graceEndsUtc: "2026-05-08T00:00:00Z",
+        }),
+      }),
+    );
+    await page.route("**/api/v1/tenants/*/provisioning", (route) =>
+      route.fulfill({ status: 404, headers: { "Content-Type": "application/json" }, body: "{}" }),
+    );
+    await page.route("**/api/v1/tenants/theme", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          lightPalette: {}, darkPalette: {}, brandAssets: {},
+          typography: { fontFamily: "Inter", headingFontFamily: "Inter", fontSizeBase: 14, lineHeightBase: 1.5 },
+          layout: { borderRadius: "4px", defaultElevation: 1 },
+          isDefault: true,
+        }),
+      }),
+    );
+    await page.route("**/api/v1/identity/impersonation/grants**", (route) =>
+      route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: "[]" }),
+    );
+
+    await page.goto("/tenants/acme-corp");
+
+    // The adjust button is gated behind UpgradeSubscription (in ADMIN_PERMS).
+    const adjustButton = page.getByRole("main").getByRole("button", { name: /Adjust validity/ });
+    await expect(adjustButton).toBeVisible({ timeout: 10_000 });
+    await adjustButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("heading", { name: "Adjust validity" })).toBeVisible();
+
+    await dialog.getByLabel(/^Valid until/).fill("2026-09-15");
+
+    const adjustReq = page.waitForRequest(
+      (r) => r.url().includes("/api/v1/tenants/acme-corp/adjust-validity") && r.method() === "POST",
+      { timeout: 5_000 },
+    );
+    await page.route("**/api/v1/tenants/acme-corp/adjust-validity", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tenantId: "acme-corp", validUpto: "2026-09-15T00:00:00Z" }),
+      }),
+    );
+    await dialog.getByRole("button", { name: "Adjust validity", exact: true }).click();
+    const req = await adjustReq;
+
+    const body = JSON.parse(req.postData() ?? "{}");
+    expect(body.tenantId).toBe("acme-corp");
+    // validUpto is sent as an ISO 8601 string for the picked date.
+    expect(body.validUpto).toMatch(/^2026-09-15T/);
+    expect(Number.isNaN(new Date(body.validUpto).getTime())).toBe(false);
+  });
+});
+
 test.describe("plan dialog — billing interval", () => {
   test("yearly reveals the annual price field and posts interval + annualPrice", async ({ page }) => {
     await mockPlans(page); // plans list query
@@ -206,6 +273,42 @@ test.describe("plan dialog — billing interval", () => {
     expect(JSON.parse(req.postData() ?? "{}")).toMatchObject({
       key: "team-annual", interval: "Yearly", annualPrice: 500, monthlyBasePrice: 50,
     });
+  });
+
+  test("rejects a negative monthly price client-side with no network call", async ({ page }) => {
+    await mockPlans(page); // plans list query
+
+    // Fail the test if a create POST is ever attempted.
+    let posted = false;
+    await page.route("**/api/v1/billing/plans", async (route) => {
+      if (route.request().method() === "POST") {
+        posted = true;
+        await route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify("p-new") });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto("/billing/plans");
+    await page.getByRole("button", { name: "New plan", exact: true }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("heading", { name: "New plan", exact: true })).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByLabel(/^Key/).fill("cheap");
+    await dialog.getByLabel(/^Display name/).fill("Cheap");
+    await dialog.getByLabel(/^Currency/).fill("USD");
+    await dialog.getByLabel(/^Monthly base price/).fill("-5");
+
+    // The client-side zod refinement surfaces the error and disables submit.
+    await expect(dialog.getByText("Must be a non-negative number.")).toBeVisible();
+
+    const submit = dialog.getByRole("button", { name: "Create plan", exact: true });
+    await expect(submit).toBeDisabled();
+    // Force a click even while disabled to prove the guard holds — no request fires.
+    await submit.click({ force: true });
+    await page.waitForTimeout(300);
+    expect(posted).toBe(false);
   });
 
   test("editing a plan opens the dialog prefilled", async ({ page }) => {

--- a/clients/dashboard/src/api/billing.ts
+++ b/clients/dashboard/src/api/billing.ts
@@ -1,4 +1,6 @@
-import { apiFetch } from "@/lib/api-client";
+import { apiFetch, ApiRequestError } from "@/lib/api-client";
+import { env } from "@/env";
+import { tokenStore } from "@/auth/token-store";
 
 export type QuotaResource =
   | "ApiCalls"
@@ -21,6 +23,20 @@ export type UsageSnapshotDto = {
 
 export type InvoiceStatus = "Draft" | "Issued" | "Paid" | "Void" | (string & {});
 
+export type InvoicePurpose = "Subscription" | "Usage" | (string & {});
+
+export type InvoiceLineItemKind = "BaseFee" | "Overage" | "Adjustment" | (string & {});
+
+export type InvoiceLineItemDto = {
+  id: string;
+  kind: InvoiceLineItemKind;
+  resource?: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+};
+
 export type InvoiceDto = {
   id: string;
   tenantId: string;
@@ -36,10 +52,13 @@ export type InvoiceDto = {
   paidAtUtc?: string | null;
   voidedAtUtc?: string | null;
   notes?: string | null;
-  lineItems: unknown[];
+  lineItems: InvoiceLineItemDto[];
+  purpose?: InvoicePurpose;
+  periodStartUtc?: string | null;
+  periodEndUtc?: string | null;
 };
 
-export type SubscriptionStatus = "Active" | "Canceled" | "Expired" | (string & {});
+export type SubscriptionStatus = "Active" | "Suspended" | "Cancelled" | (string & {});
 
 export type SubscriptionDto = {
   id: string;
@@ -51,6 +70,37 @@ export type SubscriptionDto = {
   status: SubscriptionStatus;
 };
 
+export type TenantExpiryState = "Active" | "InGrace" | "Expired" | (string & {});
+
+export type TenantStatusDto = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  validUpto: string;
+  hasConnectionString: boolean;
+  adminEmail: string;
+  issuer?: string | null;
+  plan?: string | null;
+  expiryState: TenantExpiryState;
+  graceEndsUtc: string;
+};
+
+export type PagedResult<T> = {
+  items: T[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+export type InvoiceSearchParams = {
+  status?: InvoiceStatus;
+  periodYear?: number;
+  periodMonth?: number;
+  pageNumber?: number;
+  pageSize?: number;
+};
+
 export function getUsageSnapshots(params?: { periodYear?: number; periodMonth?: number }) {
   const query = new URLSearchParams();
   if (params?.periodYear) query.set("periodYear", String(params.periodYear));
@@ -59,10 +109,67 @@ export function getUsageSnapshots(params?: { periodYear?: number; periodMonth?: 
   return apiFetch<UsageSnapshotDto[]>(`/api/v1/billing/usage${suffix}`);
 }
 
-export function getMyInvoices() {
-  return apiFetch<InvoiceDto[]>("/api/v1/billing/invoices/me");
+/**
+ * Paged tenant-scoped invoice search. The backend uses PascalCase search
+ * keys (see frontend/shared.md) and returns a paged envelope.
+ */
+export function getMyInvoices(params: InvoiceSearchParams = {}) {
+  const query = new URLSearchParams();
+  if (params.status) query.set("status", params.status);
+  if (params.periodYear) query.set("periodYear", String(params.periodYear));
+  if (params.periodMonth) query.set("periodMonth", String(params.periodMonth));
+  if (params.pageNumber) query.set("pageNumber", String(params.pageNumber));
+  if (params.pageSize) query.set("pageSize", String(params.pageSize));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return apiFetch<PagedResult<InvoiceDto>>(`/api/v1/billing/invoices/me${suffix}`);
+}
+
+export function getMyInvoice(id: string) {
+  return apiFetch<InvoiceDto>(`/api/v1/billing/invoices/${id}`);
 }
 
 export function getMySubscription() {
   return apiFetch<SubscriptionDto | null>("/api/v1/billing/subscriptions/me");
+}
+
+export function getMyStatus() {
+  return apiFetch<TenantStatusDto>("/api/v1/tenants/me/status");
+}
+
+/**
+ * Stream an invoice PDF and trigger a browser download named
+ * `{invoiceNumber}.pdf`. apiFetch only returns parsed JSON, so we fetch
+ * the blob directly here while replicating the same auth + tenant headers
+ * apiFetch sets (Authorization bearer + lowercase `tenant`).
+ */
+export async function downloadInvoicePdf(id: string, invoiceNumber: string): Promise<void> {
+  const accessToken = tokenStore.getAccessToken();
+  if (!accessToken) {
+    throw new ApiRequestError(401, "Not signed in");
+  }
+
+  const headers = new Headers({ Authorization: `Bearer ${accessToken}` });
+  const tenant = tokenStore.getTenant() ?? env.defaultTenant;
+  if (tenant) headers.set("tenant", tenant);
+
+  const response = await fetch(`${env.apiBase}/api/v1/billing/invoices/${id}/pdf`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(response.status, `Failed to download invoice (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const objectUrl = window.URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = `${invoiceNumber}.pdf`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    window.URL.revokeObjectURL(objectUrl);
+  }
 }

--- a/clients/dashboard/src/auth/auth-context.tsx
+++ b/clients/dashboard/src/auth/auth-context.tsx
@@ -210,10 +210,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const stopImpersonation = useCallback(async () => {
+    // No stash ⇒ the operator arrived via a cross-app handoff (e.g. a root
+    // SuperAdmin started impersonation from the admin app), so there is no
+    // dashboard session to return to. Restoring the operator here would drop a
+    // root-tenant account into the tenant dashboard — which `login` explicitly
+    // forbids — so end cleanly by logging out instead.
+    const crossAppHandoff = !tokenStore.hasImpersonationStash();
     try {
+      // Still call the server so the impersonation grant is ended + audited.
       const fresh = await endImpersonation();
+      if (crossAppHandoff) {
+        logout();
+        return;
+      }
       tokenStore.endImpersonationWithFreshTokens(fresh.accessToken, fresh.refreshToken);
     } catch {
+      if (crossAppHandoff) {
+        logout();
+        return;
+      }
       // End endpoint failed (server unreachable / token invalid). Fall
       // back to whatever we stashed locally; the operator may need to
       // re-authenticate if the stashed access token has expired.
@@ -222,7 +237,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       queryClient.clear();
     }
-  }, [queryClient]);
+  }, [queryClient, logout]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/clients/dashboard/src/auth/auth-context.tsx
+++ b/clients/dashboard/src/auth/auth-context.tsx
@@ -212,23 +212,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const stopImpersonation = useCallback(async () => {
     // No stash ⇒ the operator arrived via a cross-app handoff (e.g. a root
     // SuperAdmin started impersonation from the admin app), so there is no
-    // dashboard session to return to. Restoring the operator here would drop a
-    // root-tenant account into the tenant dashboard — which `login` explicitly
-    // forbids — so end cleanly by logging out instead.
-    const crossAppHandoff = !tokenStore.hasImpersonationStash();
+    // dashboard session to return to. The local impersonation token is
+    // disposable, so end INSTANTLY by logging out — don't block the UI on the
+    // server `end` call (it has a 30s timeout and intermittently leaves the
+    // banner stuck on "Ending…"). Fire it best-effort for grant revocation +
+    // audit; the short-lived impersonation token expires shortly regardless.
+    // Restoring the operator here would also drop a root-tenant account into
+    // the tenant dashboard, which `login` forbids.
+    if (!tokenStore.hasImpersonationStash()) {
+      void endImpersonation().catch(() => {
+        /* best-effort: token expires shortly, nothing to recover here */
+      });
+      logout();
+      return;
+    }
+
+    // Intra-app impersonation: we genuinely need the server-minted operator
+    // tokens to restore the original dashboard session, so await the call.
     try {
-      // Still call the server so the impersonation grant is ended + audited.
       const fresh = await endImpersonation();
-      if (crossAppHandoff) {
-        logout();
-        return;
-      }
       tokenStore.endImpersonationWithFreshTokens(fresh.accessToken, fresh.refreshToken);
     } catch {
-      if (crossAppHandoff) {
-        logout();
-        return;
-      }
       // End endpoint failed (server unreachable / token invalid). Fall
       // back to whatever we stashed locally; the operator may need to
       // re-authenticate if the stashed access token has expired.

--- a/clients/dashboard/src/components/layout/app-shell.tsx
+++ b/clients/dashboard/src/components/layout/app-shell.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router-dom";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Topbar } from "@/components/layout/topbar";
 import { ImpersonationBanner } from "@/components/layout/impersonation-banner";
+import { ExpiryBanner } from "@/components/layout/expiry-banner";
 import {
   MobileNavProvider,
   MobileNavRoot,
@@ -35,6 +36,7 @@ export function AppShell() {
 
         <div className="flex h-screen flex-col overflow-hidden bg-[var(--color-background)] text-[var(--color-foreground)]">
           <ImpersonationBanner />
+          <ExpiryBanner />
           <div className="flex min-h-0 flex-1">
             <Sidebar />
             <div className="flex min-w-0 flex-1 flex-col">

--- a/clients/dashboard/src/components/layout/expiry-banner.tsx
+++ b/clients/dashboard/src/components/layout/expiry-banner.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Clock, X } from "lucide-react";
+import { getMyStatus, type TenantStatusDto } from "@/api/billing";
+import { useAuth } from "@/auth/use-auth";
+import { cn } from "@/lib/cn";
+
+// Days within which an "Active" subscription nearing its validUpto starts
+// surfacing the soft info bar.
+const NEARING_EXPIRY_DAYS = 7;
+
+type BannerView =
+  | { kind: "none" }
+  | {
+      kind: "grace";
+      daysLeft: number;
+      graceEndsLabel: string;
+    }
+  | {
+      kind: "nearing";
+      daysLeft: number;
+    };
+
+const dateFmt = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+/**
+ * Whole calendar-ish days from `now` until `iso`, never negative. Uses a
+ * ceil so "23 hours left" still reads as "1 day".
+ */
+function daysUntil(iso: string, now: number = Date.now()): number {
+  const target = Date.parse(iso);
+  if (Number.isNaN(target)) return 0;
+  return Math.max(0, Math.ceil((target - now) / (24 * 60 * 60 * 1000)));
+}
+
+function deriveBannerView(
+  status: TenantStatusDto | undefined,
+  now: number = Date.now(),
+): BannerView {
+  if (!status) return { kind: "none" };
+
+  if (status.expiryState === "InGrace") {
+    return {
+      kind: "grace",
+      daysLeft: daysUntil(status.graceEndsUtc, now),
+      graceEndsLabel: status.graceEndsUtc
+        ? dateFmt.format(new Date(status.graceEndsUtc))
+        : "soon",
+    };
+  }
+
+  if (status.expiryState === "Active") {
+    const daysLeft = daysUntil(status.validUpto, now);
+    if (daysLeft <= NEARING_EXPIRY_DAYS) {
+      return { kind: "nearing", daysLeft };
+    }
+  }
+
+  // Expired and fully-healthy states render nothing in this bar.
+  return { kind: "none" };
+}
+
+function pluralizeDays(n: number): string {
+  return `${n} day${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Global subscription health bar. Shows a warning while the tenant is in
+ * its post-expiry grace window, and a softer info note when an active
+ * subscription is within a week of expiring. Dismissal is per browser
+ * session — it reappears on reload while the condition still holds.
+ */
+export function ExpiryBanner() {
+  const { user } = useAuth();
+  const [dismissed, setDismissed] = useState(false);
+
+  const statusQuery = useQuery({
+    queryKey: ["tenant", "me", "status"],
+    queryFn: () => getMyStatus(),
+    staleTime: 5 * 60_000,
+    // Only meaningful for an authenticated tenant session.
+    enabled: !!user,
+  });
+
+  const view = deriveBannerView(statusQuery.data);
+
+  if (dismissed || view.kind === "none") return null;
+
+  const isGrace = view.kind === "grace";
+  const tone = isGrace ? "var(--color-warning)" : "var(--color-info)";
+  const Icon = isGrace ? AlertTriangle : Clock;
+  const message = isGrace
+    ? `Your subscription expired — ${pluralizeDays(view.daysLeft)} of grace left (until ${view.graceEndsLabel}). Contact your operator to renew.`
+    : `Your subscription expires in ${pluralizeDays(view.daysLeft)}.`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "relative z-30 flex flex-wrap items-center justify-between gap-3 overflow-hidden",
+        "border-b px-4 py-2.5 sm:px-6",
+      )}
+      style={{
+        borderColor: `oklch(from ${tone} l c h / 0.28)`,
+        backgroundColor: `oklch(from ${tone} l c h / 0.08)`,
+      }}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          aria-hidden
+          className="grid size-7 shrink-0 place-items-center rounded-lg"
+          style={{
+            backgroundColor: `oklch(from ${tone} l c h / 0.14)`,
+            color: tone,
+          }}
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </span>
+        <p
+          className="min-w-0 text-[12.5px] font-medium leading-snug"
+          style={{ color: tone }}
+        >
+          {message}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss subscription notice"
+        title="Dismiss"
+        className="grid size-7 shrink-0 cursor-pointer place-items-center rounded-md transition-colors hover:bg-[oklch(from_var(--color-foreground)_l_c_h_/_0.06)]"
+        style={{ color: tone }}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/clients/dashboard/src/components/layout/nav-data.ts
+++ b/clients/dashboard/src/components/layout/nav-data.ts
@@ -22,6 +22,13 @@ export type NavSpec = {
   to: string;
   label: string;
   icon: React.ComponentType<{ className?: string }>;
+  /**
+   * Permission required to see this item. Items without a `perm` are visible to
+   * every authenticated tenant user; gated items are hidden when the current
+   * user (or impersonated user) lacks the permission, so they never land on a
+   * page the API will reject with 403.
+   */
+  perm?: string;
 };
 
 export type NavSection = {
@@ -90,12 +97,29 @@ export const sections: NavSection[] = [
     icon: HeartPulse,
     items: [
       { to: "/system/health", label: "Health", icon: HeartPulse },
-      { to: "/system/audits", label: "Audit trail", icon: ScrollText },
-      { to: "/system/sessions", label: "Sessions", icon: Wifi },
+      { to: "/system/audits", label: "Audit trail", icon: ScrollText, perm: "Permissions.AuditTrails.View" },
+      { to: "/system/sessions", label: "Sessions", icon: Wifi, perm: "Permissions.Sessions.ViewAll" },
       { to: "/system/trash", label: "Trash", icon: Trash2 },
     ],
   },
 ];
+
+/** True when the item is ungated, or the user holds its required permission. */
+function isNavItemVisible(item: NavSpec, permissions: readonly string[]): boolean {
+  return !item.perm || permissions.includes(item.perm);
+}
+
+/** Drop items the user can't access, then drop any section left empty. */
+export function visibleSections(permissions: readonly string[]): NavSection[] {
+  return sections
+    .map((s) => ({ ...s, items: s.items.filter((i) => isNavItemVisible(i, permissions)) }))
+    .filter((s) => s.items.length > 0);
+}
+
+/** Filter a flat nav list (top/bottom) by permission. */
+export function visibleItems(items: NavSpec[], permissions: readonly string[]): NavSpec[] {
+  return items.filter((i) => isNavItemVisible(i, permissions));
+}
 
 /** Find the section whose items contain the given path (best prefix match). */
 export function findSectionForPath(pathname: string): string | null {

--- a/clients/dashboard/src/components/layout/nav-data.ts
+++ b/clients/dashboard/src/components/layout/nav-data.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  CreditCard,
   FolderOpen,
   FolderTree,
   HeartPulse,
@@ -60,6 +61,7 @@ export const sections: NavSection[] = [
     icon: Activity,
     items: [
       { to: "/activity", label: "Live activity", icon: Activity },
+      { to: "/subscription", label: "Subscription", icon: CreditCard },
       { to: "/invoices", label: "Invoices", icon: Receipt },
     ],
   },

--- a/clients/dashboard/src/components/layout/sidebar.tsx
+++ b/clients/dashboard/src/components/layout/sidebar.tsx
@@ -6,11 +6,13 @@ import {
   PanelLeftOpen,
 } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { useAuth } from "@/auth/use-auth";
 import {
   findSectionForPath,
-  sections,
   topNavBottom,
   topNavTop,
+  visibleItems,
+  visibleSections,
   type NavSection,
   type NavSpec,
 } from "@/components/layout/nav-data";
@@ -186,6 +188,14 @@ export function SidebarNavBody({
    *  drawer to close itself on navigation. */
   onNavigate?: () => void;
 }) {
+  // Hide nav entries the current (or impersonated) user lacks permission for,
+  // so they can't navigate to a page the API will reject with 403.
+  const { user } = useAuth();
+  const perms = user?.permissions ?? [];
+  const navTop = visibleItems(topNavTop, perms);
+  const navSections = visibleSections(perms);
+  const navBottom = visibleItems(topNavBottom, perms);
+
   return (
     /* Nav scrolls vertically when item count exceeds available height.
        `overflow-x: clip` keeps the collapsed-mode hover tooltips from
@@ -194,7 +204,7 @@ export function SidebarNavBody({
     <nav className="flex-1 space-y-1.5 overflow-y-auto overflow-x-clip px-2.5 py-3.5">
       {/* Top-level: Overview */}
       <div className="space-y-0.5">
-        {topNavTop.map((item) => (
+        {navTop.map((item) => (
           <NavItemLink key={item.to} item={item} collapsed={collapsed} indent={false} onNavigate={onNavigate} />
         ))}
       </div>
@@ -202,7 +212,7 @@ export function SidebarNavBody({
       {/* Section accordions */}
       {!collapsed && (
         <div className="space-y-1.5 pt-1.5">
-          {sections.map((section) => (
+          {navSections.map((section) => (
             <AccordionSection
               key={section.id}
               section={section}
@@ -221,7 +231,7 @@ export function SidebarNavBody({
           label-driven affordance and isn't useful at 64px wide. */}
       {collapsed && (
         <div className="space-y-1 pt-1.5">
-          {sections.map((section, idx) => (
+          {navSections.map((section, idx) => (
             <div key={section.id}>
               {idx > 0 && (
                 <div
@@ -247,7 +257,7 @@ export function SidebarNavBody({
 
       {/* Top-level: Settings */}
       <div className="space-y-0.5 pt-1.5">
-        {topNavBottom.map((item) => (
+        {navBottom.map((item) => (
           <NavItemLink key={item.to} item={item} collapsed={collapsed} indent={false} onNavigate={onNavigate} />
         ))}
       </div>

--- a/clients/dashboard/src/pages/invoice-detail.tsx
+++ b/clients/dashboard/src/pages/invoice-detail.tsx
@@ -1,0 +1,396 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Download, FileText, Receipt } from "lucide-react";
+import {
+  downloadInvoicePdf,
+  getMyInvoice,
+  type InvoiceDto,
+  type InvoiceLineItemDto,
+  type InvoiceStatus,
+} from "@/api/billing";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  EntityDetailBack,
+  EntityDetailSection,
+  EntityStatusBadge,
+  ErrorBand,
+  type EntityStatusTone,
+} from "@/components/list";
+import { describe, formatDate, formatMoney } from "@/lib/list-helpers";
+
+// ────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────
+
+function statusTone(status: InvoiceStatus): EntityStatusTone {
+  switch (status) {
+    case "Paid":
+      return "success";
+    case "Issued":
+      return "info";
+    case "Void":
+      return "danger";
+    default:
+      return "default";
+  }
+}
+
+function formatPeriod(year: number, month: number) {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Page
+// ────────────────────────────────────────────────────────────────────
+
+export function InvoiceDetailPage() {
+  const { id = "" } = useParams<{ id: string }>();
+
+  const query = useQuery({
+    queryKey: ["billing", "invoices", id],
+    queryFn: () => getMyInvoice(id),
+    enabled: !!id,
+  });
+
+  const invoice = query.data;
+
+  return (
+    <div className="pb-12">
+      <EntityDetailBack to="/invoices" label="Back to invoices" />
+
+      {query.isError && (
+        <div className="mb-5">
+          <ErrorBand message={describe(query.error)} />
+        </div>
+      )}
+
+      {query.isLoading ? (
+        <DetailSkeleton />
+      ) : invoice ? (
+        <InvoiceBody invoice={invoice} />
+      ) : (
+        <NotFoundPanel />
+      )}
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Body
+// ────────────────────────────────────────────────────────────────────
+
+function InvoiceBody({ invoice }: { invoice: InvoiceDto }) {
+  return (
+    <div className="space-y-5">
+      <InvoiceHeader invoice={invoice} />
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_300px]">
+        {/* Left: line items + totals */}
+        <EntityDetailSection title="Line items" icon={FileText} padded={false}>
+          <LineItemsTable invoice={invoice} />
+        </EntityDetailSection>
+
+        {/* Right: meta + dates + notes */}
+        <aside className="space-y-5">
+          <EntityDetailSection title="Details" icon={Receipt}>
+            <DetailsBody invoice={invoice} />
+          </EntityDetailSection>
+
+          {invoice.notes && (
+            <EntityDetailSection title="Notes" icon={FileText}>
+              <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-[var(--color-foreground)]/90">
+                {invoice.notes}
+              </p>
+            </EntityDetailSection>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function InvoiceHeader({ invoice }: { invoice: InvoiceDto }) {
+  const [downloading, setDownloading] = useState(false);
+
+  const onDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      await downloadInvoicePdf(invoice.id, invoice.invoiceNumber);
+    } catch (err) {
+      toast.error("Download failed", { description: describe(err) });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div className="fsh-enter overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] shadow-xs">
+      <div
+        aria-hidden
+        className="h-1 w-full"
+        style={{
+          background:
+            "linear-gradient(90deg, var(--color-primary), oklch(from var(--color-primary) l c h / 0.8), var(--color-saffron))",
+        }}
+      />
+      <div className="flex flex-col gap-4 p-5 sm:flex-row sm:items-start sm:justify-between sm:px-6">
+        <div className="flex min-w-0 items-center gap-4">
+          <span
+            aria-hidden
+            className="grid size-11 shrink-0 place-items-center rounded-xl bg-[oklch(from_var(--color-primary)_l_c_h_/_0.08)] text-[var(--color-primary)] sm:size-14"
+          >
+            <Receipt className="size-5 sm:size-6" />
+          </span>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="truncate font-display text-[17px] font-bold leading-none tracking-tight text-[var(--color-foreground)] sm:text-[20px]">
+                {invoice.invoiceNumber}
+              </h1>
+              <EntityStatusBadge tone={statusTone(invoice.status)}>
+                {invoice.status}
+              </EntityStatusBadge>
+              {invoice.purpose && (
+                <EntityStatusBadge tone="default">{invoice.purpose}</EntityStatusBadge>
+              )}
+            </div>
+            <p className="mt-1.5 text-[12px] text-[var(--color-muted-foreground)]">
+              Period {formatPeriod(invoice.periodYear, invoice.periodMonth)} ·{" "}
+              <span className="font-display font-semibold text-[var(--color-foreground)]">
+                {formatMoney(invoice.subtotalAmount, invoice.currency)}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDownload}
+            disabled={downloading}
+            className="gap-1.5"
+          >
+            <Download className="size-3.5" />
+            {downloading ? "Preparing…" : "Download PDF"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Line items table
+// ────────────────────────────────────────────────────────────────────
+
+const LINE_GRID = "grid-cols-[1fr_80px_110px_110px] sm:grid-cols-[1fr_100px_130px_130px]";
+
+function LineItemsTable({ invoice }: { invoice: InvoiceDto }) {
+  const items = invoice.lineItems ?? [];
+
+  if (items.length === 0) {
+    return (
+      <div className="px-5 py-10 text-center">
+        <p className="text-[13px] font-semibold text-[var(--color-foreground)]">
+          No line items
+        </p>
+        <p className="mt-1 text-[11.5px] text-[var(--color-muted-foreground)]">
+          This invoice has no itemized charges.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className={`grid ${LINE_GRID} items-center gap-3 border-b border-[var(--color-border)] bg-[oklch(from_var(--color-muted)_l_c_h_/_0.4)] px-5 py-3 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]`}
+      >
+        <span>Description</span>
+        <span className="text-right">Qty</span>
+        <span className="text-right">Unit price</span>
+        <span className="text-right">Amount</span>
+      </div>
+
+      {items.map((item, i) => (
+        <LineItemRow
+          key={item.id}
+          item={item}
+          currency={invoice.currency}
+          isLast={i === items.length - 1}
+        />
+      ))}
+
+      {/* Total */}
+      <div
+        className={`grid ${LINE_GRID} items-center gap-3 border-t border-[var(--color-border)] bg-[oklch(from_var(--color-muted)_l_c_h_/_0.25)] px-5 py-3.5`}
+      >
+        <span className="text-[12px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+          Total
+        </span>
+        <span />
+        <span />
+        <span className="text-right font-display text-[15px] font-bold tabular-nums text-[var(--color-foreground)]">
+          {formatMoney(invoice.subtotalAmount, invoice.currency)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function LineItemRow({
+  item,
+  currency,
+  isLast,
+}: {
+  item: InvoiceLineItemDto;
+  currency: string;
+  isLast: boolean;
+}) {
+  return (
+    <div
+      className={`grid ${LINE_GRID} items-center gap-3 px-5 py-3 ${
+        isLast ? "" : "border-b border-[oklch(from_var(--color-border)_l_c_h_/_0.3)]"
+      }`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[13px] font-medium text-[var(--color-foreground)]">
+            {item.description}
+          </span>
+          <EntityStatusBadge tone="default">{item.kind}</EntityStatusBadge>
+        </div>
+        {item.resource && (
+          <span className="mt-0.5 block truncate font-mono text-[11px] text-[var(--color-muted-foreground)]">
+            {item.resource}
+          </span>
+        )}
+      </div>
+      <span className="text-right text-[13px] tabular-nums text-[var(--color-muted-foreground)]">
+        {item.quantity}
+      </span>
+      <span className="text-right text-[13px] tabular-nums text-[var(--color-muted-foreground)]">
+        {formatMoney(item.unitPrice, currency)}
+      </span>
+      <span className="text-right font-display text-[13px] font-semibold tabular-nums text-[var(--color-foreground)]">
+        {formatMoney(item.amount, currency)}
+      </span>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Details / dates
+// ────────────────────────────────────────────────────────────────────
+
+function DetailsBody({ invoice }: { invoice: InvoiceDto }) {
+  return (
+    <dl className="space-y-2.5 text-[12.5px]">
+      <Row label="Status">
+        <EntityStatusBadge tone={statusTone(invoice.status)}>
+          {invoice.status}
+        </EntityStatusBadge>
+      </Row>
+      <Row label="Currency">{invoice.currency}</Row>
+      <Row label="Period">{formatPeriod(invoice.periodYear, invoice.periodMonth)}</Row>
+      <Row label="Created">{formatDate(invoice.createdAtUtc)}</Row>
+      {invoice.issuedAtUtc && <Row label="Issued">{formatDate(invoice.issuedAtUtc)}</Row>}
+      {invoice.dueAtUtc && (
+        <Row label="Due" tone={invoice.status === "Issued" ? "warning" : undefined}>
+          {formatDate(invoice.dueAtUtc)}
+        </Row>
+      )}
+      {invoice.paidAtUtc && (
+        <Row label="Paid" tone="success">
+          {formatDate(invoice.paidAtUtc)}
+        </Row>
+      )}
+      {invoice.voidedAtUtc && (
+        <Row label="Voided" tone="danger">
+          {formatDate(invoice.voidedAtUtc)}
+        </Row>
+      )}
+      {invoice.periodStartUtc && (
+        <Row label="Period start">{formatDate(invoice.periodStartUtc)}</Row>
+      )}
+      {invoice.periodEndUtc && (
+        <Row label="Period end">{formatDate(invoice.periodEndUtc)}</Row>
+      )}
+    </dl>
+  );
+}
+
+function Row({
+  label,
+  children,
+  tone,
+}: {
+  label: string;
+  children: React.ReactNode;
+  tone?: "warning" | "success" | "danger";
+}) {
+  const toneColor =
+    tone === "warning"
+      ? "text-[var(--color-warning)]"
+      : tone === "success"
+        ? "text-[var(--color-success)]"
+        : tone === "danger"
+          ? "text-[var(--color-destructive)]"
+          : "text-[var(--color-foreground)]";
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-[var(--color-muted-foreground)]">{label}</dt>
+      <dd className={`tabular-nums ${toneColor}`}>{children}</dd>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Loading + not found
+// ────────────────────────────────────────────────────────────────────
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-5">
+      <div className="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-card)]">
+        <Skeleton className="h-1 w-full rounded-none" />
+        <div className="p-5 sm:px-6">
+          <div className="flex items-center gap-4">
+            <Skeleton className="size-14 rounded-2xl" />
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-3 w-56" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_300px]">
+        <Skeleton className="h-64 rounded-xl" />
+        <Skeleton className="h-48 rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+function NotFoundPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] px-8 py-16 text-center">
+      <div className="mb-5 grid size-16 place-items-center rounded-2xl bg-[oklch(from_var(--color-primary)_l_c_h_/_0.08)]">
+        <Receipt className="size-7 text-[var(--color-primary)]" />
+      </div>
+      <h3 className="mb-1.5 text-[17px] font-semibold text-[var(--color-foreground)]">
+        Invoice not found
+      </h3>
+      <p className="mb-6 text-[13px] text-[var(--color-muted-foreground)]">
+        It may not belong to your tenant, or the link may be wrong.
+      </p>
+      <Button asChild variant="outline" size="sm">
+        <Link to="/invoices">Back to invoices</Link>
+      </Button>
+    </div>
+  );
+}

--- a/clients/dashboard/src/pages/invoices.tsx
+++ b/clients/dashboard/src/pages/invoices.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Receipt } from "lucide-react";
 import {
@@ -67,8 +68,8 @@ const DESKTOP_GRID =
 export function InvoicesPage() {
   const { user } = useAuth();
   const query = useQuery({
-    queryKey: ["billing", "invoices", "me"],
-    queryFn: getMyInvoices,
+    queryKey: ["billing", "invoices", "me", { pageNumber: 1, pageSize: 100 }],
+    queryFn: () => getMyInvoices({ pageNumber: 1, pageSize: 100 }),
     staleTime: 30_000,
   });
 
@@ -78,7 +79,7 @@ export function InvoicesPage() {
 
   const [search, setSearch] = useState("");
 
-  const invoices = useMemo(() => query.data ?? [], [query.data]);
+  const invoices = useMemo(() => query.data?.items ?? [], [query.data]);
 
   const sorted = useMemo(
     () =>
@@ -115,7 +116,7 @@ export function InvoicesPage() {
       <EntityPageHeader
         icon={Receipt}
         title="Invoices"
-        total={query.data?.length ?? null}
+        total={query.data?.totalCount ?? null}
         unit="invoice"
         description="Your tenant's billing history, newest first."
       />
@@ -196,7 +197,9 @@ export function InvoicesPage() {
 
 function MobileCard({ invoice }: { invoice: InvoiceDto }) {
   return (
-    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] p-4 shadow-xs">
+    <Link
+      to={`/invoices/${invoice.id}`}
+      className="block rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] p-4 shadow-xs transition-colors hover:border-[var(--color-border-strong)]">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-center gap-3">
           <ToneIconTile icon={Receipt} tone="primary" size="md" className="rounded-xl" />
@@ -225,7 +228,7 @@ function MobileCard({ invoice }: { invoice: InvoiceDto }) {
           )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }
 
@@ -236,8 +239,13 @@ function DesktopRow({
   invoice: InvoiceDto;
   isLast: boolean;
 }) {
+  const navigate = useNavigate();
   return (
-    <EntityListRow className={DESKTOP_GRID} isLast={isLast}>
+    <EntityListRow
+      className={DESKTOP_GRID}
+      isLast={isLast}
+      onClick={() => navigate(`/invoices/${invoice.id}`)}
+    >
       {/* Invoice number + icon */}
       <div className="flex min-w-0 items-center gap-3">
         <ToneIconTile icon={Receipt} tone="primary" size="md" className="rounded-xl" />

--- a/clients/dashboard/src/pages/overview.tsx
+++ b/clients/dashboard/src/pages/overview.tsx
@@ -113,8 +113,8 @@ function relativeTime(iso: string, now: number = Date.now()): string {
 
 function subscriptionTone(status: SubscriptionDto["status"] | undefined) {
   if (status === "Active") return "success" as const;
-  if (status === "Canceled") return "warning" as const;
-  if (status === "Expired") return "danger" as const;
+  if (status === "Suspended") return "warning" as const;
+  if (status === "Cancelled") return "danger" as const;
   return "default" as const;
 }
 
@@ -329,7 +329,7 @@ function SubscriptionBody({
           </p>
         </div>
         <Button asChild variant="soft" size="sm">
-          <Link to="/invoices">Choose plan</Link>
+          <Link to="/subscription">View subscription</Link>
         </Button>
       </div>
     );
@@ -611,9 +611,9 @@ const QUICK_ACTIONS: QuickAction[] = [
     tone: "success",
   },
   {
-    to: "/invoices",
+    to: "/subscription",
     title: "Subscription",
-    description: "Plans, invoices, usage.",
+    description: "Plan, usage, invoices.",
     icon: CreditCard,
     tone: "primary",
   },

--- a/clients/dashboard/src/pages/subscription.tsx
+++ b/clients/dashboard/src/pages/subscription.tsx
@@ -1,0 +1,540 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowUpRight,
+  CalendarClock,
+  CreditCard,
+  Gauge,
+  Receipt,
+} from "lucide-react";
+import {
+  getMyInvoices,
+  getMyStatus,
+  getMySubscription,
+  getUsageSnapshots,
+  type InvoiceDto,
+  type InvoiceStatus,
+  type SubscriptionDto,
+  type TenantExpiryState,
+  type TenantStatusDto,
+  type UsageSnapshotDto,
+} from "@/api/billing";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  EntityDetailSection,
+  EntityPageHeader,
+  EntityStatusBadge,
+  ErrorBand,
+  type EntityStatusTone,
+} from "@/components/list";
+import { describe, formatDate, formatMoney } from "@/lib/list-helpers";
+import { cn } from "@/lib/cn";
+
+// ────────────────────────────────────────────────────────────────────
+// Pure view helpers — module scope.
+// ────────────────────────────────────────────────────────────────────
+
+const numberFmt = new Intl.NumberFormat("en-US");
+const formatNumber = (n: number) => numberFmt.format(n);
+
+type UsageRowVm = {
+  resource: string;
+  used: number;
+  limit: number;
+  overage: number;
+  utilization: number;
+};
+
+function toUsageRows(snapshots: UsageSnapshotDto[]): UsageRowVm[] {
+  const now = new Date();
+  const cy = now.getUTCFullYear();
+  const cm = now.getUTCMonth() + 1;
+  return snapshots
+    .filter((s) => s.periodYear === cy && s.periodMonth === cm)
+    .map((s) => ({
+      resource: String(s.resource),
+      used: s.usedUnits,
+      limit: s.limitUnits,
+      overage: s.overage,
+      utilization: s.limitUnits > 0 ? Math.min(100, (s.usedUnits / s.limitUnits) * 100) : 0,
+    }))
+    .sort((a, b) => b.utilization - a.utilization);
+}
+
+function expiryTone(state: TenantExpiryState | undefined): {
+  tone: EntityStatusTone;
+  label: string;
+} {
+  switch (state) {
+    case "InGrace":
+      return { tone: "warning", label: "In grace" };
+    case "Expired":
+      return { tone: "danger", label: "Expired" };
+    case "Active":
+      return { tone: "success", label: "Active" };
+    default:
+      return { tone: "default", label: "Unknown" };
+  }
+}
+
+function subscriptionTone(status: SubscriptionDto["status"] | undefined): EntityStatusTone {
+  if (status === "Active") return "success";
+  if (status === "Suspended") return "warning";
+  if (status === "Cancelled") return "danger";
+  return "default";
+}
+
+function invoiceStatusTone(status: InvoiceStatus): EntityStatusTone {
+  switch (status) {
+    case "Paid":
+      return "success";
+    case "Issued":
+      return "info";
+    case "Void":
+      return "danger";
+    default:
+      return "default";
+  }
+}
+
+function formatPeriod(year: number, month: number) {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Page
+// ────────────────────────────────────────────────────────────────────
+
+export function SubscriptionPage() {
+  const status = useQuery({
+    queryKey: ["tenant", "me", "status"],
+    queryFn: () => getMyStatus(),
+    staleTime: 60_000,
+  });
+
+  const subscription = useQuery({
+    queryKey: ["billing", "subscriptions", "me"],
+    queryFn: () => getMySubscription(),
+    staleTime: 60_000,
+  });
+
+  const usage = useQuery({
+    queryKey: ["billing", "usage"],
+    queryFn: () => getUsageSnapshots(),
+    staleTime: 60_000,
+  });
+
+  const invoices = useQuery({
+    queryKey: ["billing", "invoices", "me", { pageNumber: 1, pageSize: 5 }],
+    queryFn: () => getMyInvoices({ pageNumber: 1, pageSize: 5 }),
+    staleTime: 60_000,
+  });
+
+  const usageRows = useMemo(
+    () => (usage.data ? toUsageRows(usage.data) : []),
+    [usage.data],
+  );
+
+  const recentInvoices = useMemo(() => {
+    const items = invoices.data?.items ?? [];
+    return [...items].sort(
+      (a, b) => new Date(b.createdAtUtc).getTime() - new Date(a.createdAtUtc).getTime(),
+    );
+  }, [invoices.data]);
+
+  const errorMessage = status.error
+    ? describe(status.error)
+    : subscription.error
+      ? describe(subscription.error)
+      : null;
+
+  const planName =
+    status.data?.plan ?? subscription.data?.planKey ?? null;
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <EntityPageHeader
+        icon={CreditCard}
+        title="Subscription"
+        description="Your tenant's plan, validity, usage, and recent invoices."
+      />
+
+      {errorMessage && <ErrorBand message={errorMessage} />}
+
+      <div className="flex flex-col gap-4 lg:flex-row">
+        {/* Left rail — plan + validity */}
+        <aside className="w-full space-y-4 lg:w-[360px] lg:shrink-0">
+          <EntityDetailSection title="Plan" icon={CreditCard}>
+            <PlanBody
+              planName={planName}
+              subscription={subscription.data}
+              loading={status.isLoading || subscription.isLoading}
+            />
+          </EntityDetailSection>
+
+          <EntityDetailSection title="Validity" icon={CalendarClock}>
+            <ValidityBody status={status.data} loading={status.isLoading} />
+          </EntityDetailSection>
+        </aside>
+
+        {/* Right column — usage + invoices */}
+        <div className="w-full min-w-0 flex-1 space-y-4">
+          <EntityDetailSection
+            title="Usage by resource"
+            icon={Gauge}
+            description="Current-month consumption against your plan limits."
+          >
+            <UsageBody
+              rows={usageRows}
+              loading={usage.isLoading}
+              isError={usage.isError}
+            />
+          </EntityDetailSection>
+
+          <EntityDetailSection
+            title="Recent invoices"
+            icon={Receipt}
+            description="Your five most recent invoices."
+            action={
+              <Link
+                to="/invoices"
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
+              >
+                See all <ArrowUpRight className="size-3" />
+              </Link>
+            }
+          >
+            <RecentInvoicesBody invoices={recentInvoices} loading={invoices.isLoading} />
+          </EntityDetailSection>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Plan body
+// ────────────────────────────────────────────────────────────────────
+
+function PlanBody({
+  planName,
+  subscription,
+  loading,
+}: {
+  planName: string | null;
+  subscription: SubscriptionDto | null | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-7 w-3/5" />
+        <Skeleton className="h-3 w-2/5" />
+        <Skeleton className="h-3 w-4/5" />
+      </div>
+    );
+  }
+
+  if (!planName && !subscription) {
+    return (
+      <div className="space-y-1">
+        <div className="text-[13px] font-semibold tracking-tight text-[var(--color-foreground)]">
+          No active subscription
+        </div>
+        <p className="text-[11.5px] leading-relaxed text-[var(--color-muted-foreground)]">
+          Your tenant has no plan assigned. Contact your operator to enable
+          billing, quotas, and overage tracking.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-display text-[22px] font-bold tracking-tight text-[var(--color-foreground)]">
+          {planName ?? "—"}
+        </span>
+        {subscription && (
+          <Badge variant={badgeVariantFor(subscriptionTone(subscription.status))}>
+            {subscription.status}
+          </Badge>
+        )}
+      </div>
+
+      {subscription && (
+        <dl className="space-y-1.5 text-[12px]">
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-[var(--color-muted-foreground)]">Started</dt>
+            <dd className="tabular-nums text-[var(--color-foreground)]">
+              {formatDate(subscription.startUtc)}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-[var(--color-muted-foreground)]">Ends</dt>
+            <dd className="tabular-nums text-[var(--color-foreground)]">
+              {subscription.endUtc ? formatDate(subscription.endUtc) : "open-ended"}
+            </dd>
+          </div>
+        </dl>
+      )}
+
+      <p className="text-[11px] leading-relaxed text-[var(--color-muted-foreground)]">
+        Plan changes are operator-driven. Contact your operator to upgrade,
+        renew, or cancel.
+      </p>
+    </div>
+  );
+}
+
+/** Map a status tone to the matching Badge variant. */
+function badgeVariantFor(
+  tone: EntityStatusTone,
+): "default" | "success" | "warning" | "danger" | "info" {
+  return tone === "default" ? "default" : tone;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Validity body
+// ────────────────────────────────────────────────────────────────────
+
+function ValidityBody({
+  status,
+  loading,
+}: {
+  status: TenantStatusDto | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-3 w-3/5" />
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <p className="text-[12px] text-[var(--color-muted-foreground)]">
+        Tenant status is unavailable right now.
+      </p>
+    );
+  }
+
+  const { tone, label } = expiryTone(status.expiryState);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <EntityStatusBadge tone={tone}>{label}</EntityStatusBadge>
+        {!status.isActive && (
+          <EntityStatusBadge tone="danger">Inactive</EntityStatusBadge>
+        )}
+      </div>
+
+      <dl className="space-y-1.5 text-[12px]">
+        <div className="flex items-center justify-between gap-3">
+          <dt className="text-[var(--color-muted-foreground)]">Valid until</dt>
+          <dd className="tabular-nums text-[var(--color-foreground)]">
+            {formatDate(status.validUpto)}
+          </dd>
+        </div>
+        {status.expiryState === "InGrace" && (
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-[var(--color-muted-foreground)]">Grace ends</dt>
+            <dd className="tabular-nums text-[var(--color-warning)]">
+              {formatDate(status.graceEndsUtc)}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Usage body
+// ────────────────────────────────────────────────────────────────────
+
+function UsageBody({
+  rows,
+  loading,
+  isError,
+}: {
+  rows: UsageRowVm[];
+  loading: boolean;
+  isError: boolean;
+}) {
+  if (loading) {
+    return (
+      <ul className="space-y-3">
+        {[0, 1, 2].map((i) => (
+          <li key={i} className="space-y-2 py-1.5">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-3.5 w-24" />
+            </div>
+            <Skeleton className="h-1 w-full" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="py-6 text-center text-[12px] text-[var(--color-muted-foreground)]">
+        Couldn't load usage. Try refreshing.
+      </p>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-8 text-center">
+        <span
+          aria-hidden
+          className="grid size-8 place-items-center rounded-lg bg-[oklch(from_var(--color-primary)_l_c_h_/_0.10)]"
+        >
+          <Gauge className="size-3.5 text-[var(--color-primary)]" />
+        </span>
+        <div className="text-[13px] font-semibold tracking-tight text-[var(--color-foreground)]">
+          No usage captured yet
+        </div>
+        <p className="max-w-sm text-[11.5px] leading-relaxed text-[var(--color-muted-foreground)]">
+          Consumption will appear here as snapshots are recorded for this period.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul>
+      {rows.map((row) => (
+        <UsageRow key={row.resource} row={row} />
+      ))}
+    </ul>
+  );
+}
+
+function UsageRow({ row }: { row: UsageRowVm }) {
+  const overUtilized = row.utilization >= 80;
+  const overage = row.overage > 0;
+  return (
+    <li className="grid grid-cols-[1fr_auto] items-center gap-x-4 gap-y-1.5 border-t border-[oklch(from_var(--color-border)_l_c_h_/_0.5)] py-2.5 first:border-t-0 first:pt-0">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate text-[12.5px] font-medium tracking-tight text-[var(--color-foreground)]">
+          {row.resource}
+        </span>
+        {overage && <Badge variant="danger">+{formatNumber(row.overage)}</Badge>}
+      </div>
+
+      <div className="text-right tabular-nums">
+        <span className="text-[12.5px] font-semibold tracking-tight text-[var(--color-foreground)]">
+          {formatNumber(row.used)}
+        </span>
+        <span className="ml-1 text-[11.5px] font-normal text-[var(--color-muted-foreground)]">
+          / {formatNumber(row.limit)}
+        </span>
+        <span className="ml-2 text-[11px] tabular-nums text-[var(--color-muted-foreground)]">
+          {row.utilization.toFixed(0)}%
+        </span>
+      </div>
+
+      <div className="col-span-2">
+        <div className="relative h-1 overflow-hidden rounded-full bg-[var(--color-muted)]">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-[700ms] ease-[var(--ease-out-cubic)]",
+              overage
+                ? "bg-[var(--color-destructive)]"
+                : overUtilized
+                  ? "bg-[var(--color-warning)]"
+                  : "bg-[var(--color-primary)]",
+            )}
+            style={{ width: `${row.utilization}%` }}
+          />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Recent invoices body
+// ────────────────────────────────────────────────────────────────────
+
+function RecentInvoicesBody({
+  invoices,
+  loading,
+}: {
+  invoices: InvoiceDto[];
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <ul className="space-y-2.5">
+        {[0, 1, 2].map((i) => (
+          <li key={i} className="flex items-center gap-3">
+            <Skeleton className="size-8 rounded-lg" />
+            <Skeleton className="h-3.5 w-40" />
+            <Skeleton className="ml-auto h-3.5 w-16" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (invoices.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-6 text-center">
+        <Receipt className="size-4 text-[var(--color-muted-foreground)]" />
+        <div className="text-[13px] font-semibold tracking-tight text-[var(--color-foreground)]">
+          No invoices yet
+        </div>
+        <p className="max-w-sm text-[11.5px] text-[var(--color-muted-foreground)]">
+          Once your tenant has been billed for a period, invoices will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="-my-1 divide-y divide-[oklch(from_var(--color-border)_l_c_h_/_0.5)]">
+      {invoices.map((invoice) => (
+        <li key={invoice.id}>
+          <Link
+            to={`/invoices/${invoice.id}`}
+            className="group/row -mx-1 flex items-center gap-3 rounded-md px-1 py-2.5 transition-colors hover:bg-[var(--color-accent)]"
+          >
+            <span
+              aria-hidden
+              className="grid size-8 shrink-0 place-items-center rounded-lg bg-[oklch(from_var(--color-primary)_l_c_h_/_0.10)] text-[var(--color-primary)]"
+            >
+              <Receipt className="size-3.5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <code className="truncate font-mono text-[12.5px] font-medium tracking-tight text-[var(--color-foreground)]">
+                  {invoice.invoiceNumber}
+                </code>
+                <EntityStatusBadge tone={invoiceStatusTone(invoice.status)}>
+                  {invoice.status}
+                </EntityStatusBadge>
+              </div>
+              <div className="mt-0.5 font-mono text-[11px] text-[var(--color-muted-foreground)]">
+                period {formatPeriod(invoice.periodYear, invoice.periodMonth)}
+              </div>
+            </div>
+            <span className="shrink-0 font-display text-[13px] font-semibold tabular-nums text-[var(--color-foreground)]">
+              {formatMoney(invoice.subtotalAmount, invoice.currency)}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/clients/dashboard/src/routes.tsx
+++ b/clients/dashboard/src/routes.tsx
@@ -44,6 +44,14 @@ const ConfirmEmailPage = lazyNamed(
 const OverviewPage = lazyNamed(() => import("@/pages/overview"), "OverviewPage");
 const ActivityPage = lazyNamed(() => import("@/pages/activity"), "ActivityPage");
 const InvoicesPage = lazyNamed(() => import("@/pages/invoices"), "InvoicesPage");
+const InvoiceDetailPage = lazyNamed(
+  () => import("@/pages/invoice-detail"),
+  "InvoiceDetailPage",
+);
+const SubscriptionPage = lazyNamed(
+  () => import("@/pages/subscription"),
+  "SubscriptionPage",
+);
 const BrandsPage = lazyNamed(() => import("@/pages/catalog/brands"), "BrandsPage");
 const CategoriesPage = lazyNamed(() => import("@/pages/catalog/categories"), "CategoriesPage");
 const ProductsPage = lazyNamed(() => import("@/pages/catalog/products"), "ProductsPage");
@@ -160,7 +168,9 @@ export const router = createBrowserRouter([
         children: [
           { index: true, element: withSuspense(<OverviewPage />) },
           { path: "activity", element: withSuspense(<ActivityPage />) },
+          { path: "subscription", element: withSuspense(<SubscriptionPage />) },
           { path: "invoices", element: withSuspense(<InvoicesPage />) },
+          { path: "invoices/:id", element: withSuspense(<InvoiceDetailPage />) },
           { path: "system/health", element: withSuspense(<HealthPage />) },
           { path: "system/audits", element: withSuspense(<AuditsPage />) },
           { path: "system/trash", element: withSuspense(<TrashPage />) },

--- a/clients/dashboard/tests/billing/subscription.spec.ts
+++ b/clients/dashboard/tests/billing/subscription.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test } from "@playwright/test";
+import { mockJsonResponse } from "../helpers/api-mocks";
+import { installShellMocks, paged } from "../helpers/shell-mocks";
+import { seedAuthedSession, TEST_USER } from "../helpers/auth-seed";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const now = new Date();
+const PERIOD_YEAR = now.getUTCFullYear();
+const PERIOD_MONTH = now.getUTCMonth() + 1;
+
+const SUBSCRIPTION = {
+  id: "sub-1",
+  tenantId: "acme",
+  planId: "plan-scale",
+  planKey: "Scale",
+  startUtc: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+  endUtc: null,
+  status: "Active",
+};
+
+/** Status with plenty of runway — banner stays hidden. */
+const HEALTHY_STATUS = {
+  id: "acme",
+  name: "Acme Corp",
+  isActive: true,
+  validUpto: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+  hasConnectionString: false,
+  adminEmail: "admin@acme.com",
+  issuer: null,
+  plan: "Scale",
+  expiryState: "Active",
+  graceEndsUtc: new Date(Date.now() + 97 * 24 * 60 * 60 * 1000).toISOString(),
+};
+
+/** Active but within the 7-day window — soft info bar should appear. */
+const NEARING_STATUS = {
+  ...HEALTHY_STATUS,
+  validUpto: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  expiryState: "Active",
+};
+
+/** Expired, still inside the grace window — warning bar should appear. */
+const GRACE_STATUS = {
+  ...HEALTHY_STATUS,
+  validUpto: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  expiryState: "InGrace",
+  graceEndsUtc: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+};
+
+const USAGE = [
+  {
+    id: "use-1",
+    tenantId: "acme",
+    periodYear: PERIOD_YEAR,
+    periodMonth: PERIOD_MONTH,
+    resource: "ApiCalls",
+    usedUnits: 4200,
+    limitUnits: 10000,
+    overage: 0,
+    capturedAtUtc: now.toISOString(),
+  },
+  {
+    id: "use-2",
+    tenantId: "acme",
+    periodYear: PERIOD_YEAR,
+    periodMonth: PERIOD_MONTH,
+    resource: "StorageBytes",
+    usedUnits: 900,
+    limitUnits: 1000,
+    overage: 120,
+    capturedAtUtc: now.toISOString(),
+  },
+];
+
+const INVOICE = {
+  id: "inv-1",
+  tenantId: "acme",
+  invoiceNumber: "INV-2026-05",
+  periodYear: 2026,
+  periodMonth: 5,
+  currency: "USD",
+  subtotalAmount: 149,
+  status: "Issued",
+  createdAtUtc: "2026-05-01T00:00:00Z",
+  issuedAtUtc: "2026-05-01T00:00:00Z",
+  dueAtUtc: "2026-05-15T00:00:00Z",
+  paidAtUtc: null,
+  voidedAtUtc: null,
+  notes: null,
+  lineItems: [],
+  purpose: "Subscription",
+};
+
+const INVOICE_DETAIL = {
+  ...INVOICE,
+  notes: "Thanks for your business.",
+  lineItems: [
+    {
+      id: "li-1",
+      kind: "BaseFee",
+      resource: null,
+      description: "Scale plan — monthly base fee",
+      quantity: 1,
+      unitPrice: 99,
+      amount: 99,
+    },
+    {
+      id: "li-2",
+      kind: "Overage",
+      resource: "StorageBytes",
+      description: "Storage overage",
+      quantity: 50,
+      unitPrice: 1,
+      amount: 50,
+    },
+  ],
+};
+
+// ── Subscription page ────────────────────────────────────────────────
+
+test.describe("subscription (/subscription)", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuthedSession(page, TEST_USER);
+    await installShellMocks(page);
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", HEALTHY_STATUS);
+    await mockJsonResponse(page, "**/api/v1/billing/subscriptions/me**", SUBSCRIPTION);
+    await mockJsonResponse(page, "**/api/v1/billing/usage**", USAGE);
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", paged([INVOICE]));
+  });
+
+  test("renders plan, usage rows, and a recent invoice link", async ({ page }) => {
+    await page.goto("/subscription");
+
+    await expect(page.getByRole("heading", { name: /subscription/i })).toBeVisible();
+
+    // Plan name + status.
+    await expect(page.getByText("Scale").first()).toBeVisible();
+
+    // Usage section + both resources.
+    await expect(page.getByText("Usage by resource", { exact: true })).toBeVisible();
+    await expect(page.getByText("ApiCalls", { exact: true })).toBeVisible();
+    await expect(page.getByText("StorageBytes", { exact: true })).toBeVisible();
+
+    // Recent invoices section + a clickable invoice.
+    await expect(page.getByText("Recent invoices", { exact: true })).toBeVisible();
+    const invoiceLink = page.getByRole("link", { name: /INV-2026-05/i });
+    await expect(invoiceLink).toBeVisible();
+    await expect(invoiceLink).toHaveAttribute("href", "/invoices/inv-1");
+  });
+
+  test("shows the no-subscription empty state", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/billing/subscriptions/me**", null);
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", {
+      ...HEALTHY_STATUS,
+      plan: null,
+    });
+    await page.goto("/subscription");
+    await expect(page.getByText(/no active subscription/i)).toBeVisible();
+  });
+});
+
+// ── Expiry banner ──────────────────────────────────────────────────────
+
+test.describe("expiry banner", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuthedSession(page, TEST_USER);
+    await installShellMocks(page);
+    await mockJsonResponse(page, "**/api/v1/billing/subscriptions/me**", SUBSCRIPTION);
+    await mockJsonResponse(page, "**/api/v1/billing/usage**", []);
+    await mockJsonResponse(page, "**/api/v1/audits**", paged([]));
+  });
+
+  test("warns while in grace", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", GRACE_STATUS);
+    await page.goto("/");
+    await expect(page.getByText(/your subscription expired/i)).toBeVisible();
+    await expect(page.getByText(/grace left/i)).toBeVisible();
+  });
+
+  test("informs when nearing expiry", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", NEARING_STATUS);
+    await page.goto("/");
+    await expect(page.getByText(/your subscription expires in/i)).toBeVisible();
+  });
+
+  test("is absent when healthy", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", HEALTHY_STATUS);
+    await page.goto("/");
+    // Wait for the page to settle, then assert the bar never showed.
+    await expect(page.getByRole("heading", { name: /good (morning|afternoon|evening)/i })).toBeVisible();
+    await expect(page.getByText(/your subscription expire/i)).toHaveCount(0);
+  });
+
+  test("can be dismissed for the session", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", GRACE_STATUS);
+    await page.goto("/");
+    await expect(page.getByText(/your subscription expired/i)).toBeVisible();
+    await page.getByRole("button", { name: /dismiss subscription notice/i }).click();
+    await expect(page.getByText(/your subscription expired/i)).toHaveCount(0);
+  });
+});
+
+// ── Invoice detail ───────────────────────────────────────────────────
+
+test.describe("invoice detail (/invoices/:id)", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuthedSession(page, TEST_USER);
+    await installShellMocks(page);
+    await mockJsonResponse(page, "**/api/v1/tenants/me/status**", HEALTHY_STATUS);
+  });
+
+  test("renders line items and totals", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/inv-1", INVOICE_DETAIL);
+    await page.goto("/invoices/inv-1");
+
+    await expect(page.getByRole("heading", { name: /INV-2026-05/i })).toBeVisible();
+    await expect(page.getByText("Scale plan — monthly base fee")).toBeVisible();
+    await expect(page.getByText("Storage overage")).toBeVisible();
+    await expect(page.getByText("Total", { exact: true })).toBeVisible();
+    await expect(page.getByText("Thanks for your business.")).toBeVisible();
+  });
+
+  test("Download PDF button issues the /pdf request", async ({ page }) => {
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/inv-1", INVOICE_DETAIL);
+
+    // Intercept the PDF stream and fulfil with a tiny binary body so the
+    // blob/anchor download path runs without a real backend.
+    let pdfRequested = false;
+    await page.route("**/api/v1/billing/invoices/inv-1/pdf", async (route) => {
+      pdfRequested = true;
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/pdf" },
+        body: "%PDF-1.4 mock",
+      });
+    });
+
+    await page.goto("/invoices/inv-1");
+    await page.getByRole("button", { name: /download pdf/i }).click();
+
+    await expect.poll(() => pdfRequested).toBe(true);
+  });
+
+  test("shows a not-found panel on 404", async ({ page }) => {
+    await page.route("**/api/v1/billing/invoices/missing", (route) =>
+      route.fulfill({
+        status: 404,
+        headers: { "Content-Type": "application/problem+json" },
+        body: JSON.stringify({ status: 404, title: "Not Found" }),
+      }),
+    );
+    await page.goto("/invoices/missing");
+    await expect(page.getByText(/invoice not found/i)).toBeVisible();
+  });
+});

--- a/clients/dashboard/tests/helpers/shell-mocks.ts
+++ b/clients/dashboard/tests/helpers/shell-mocks.ts
@@ -46,6 +46,22 @@ export async function installShellMocks(page: Page): Promise<void> {
   // Defensive: profile + permissions (harmless if a page re-reads them).
   await mockJsonResponse(page, "**/api/v1/identity/profile", DEFAULT_PROFILE);
   await mockJsonResponse(page, "**/api/v1/identity/permissions", []);
+
+  // Tenant status drives the global expiry/grace banner mounted in the
+  // AppShell. Default to a healthy, far-future tenant so the banner stays
+  // hidden; specs that exercise the banner override this after the call.
+  await mockJsonResponse(page, "**/api/v1/tenants/me/status**", {
+    id: "acme",
+    name: "Acme Corp",
+    isActive: true,
+    validUpto: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+    hasConnectionString: false,
+    adminEmail: "admin@acme.com",
+    issuer: null,
+    plan: "Scale",
+    expiryState: "Active",
+    graceEndsUtc: new Date(Date.now() + 372 * 24 * 60 * 60 * 1000).toISOString(),
+  });
 }
 
 /** Build a Playwright-shaped paged response body. */

--- a/clients/dashboard/tests/overview/overview.spec.ts
+++ b/clients/dashboard/tests/overview/overview.spec.ts
@@ -78,7 +78,7 @@ test.describe("invoices (/invoices)", () => {
   });
 
   test("renders an invoice row from the API", async ({ page }) => {
-    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", [INVOICE]);
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", paged([INVOICE]));
     await page.goto("/invoices");
     await expect(page.getByRole("heading", { name: /invoices/i })).toBeVisible();
     // Invoice number + status render in both a (hidden) mobile card and the
@@ -88,13 +88,13 @@ test.describe("invoices (/invoices)", () => {
   });
 
   test("shows the empty state when there are no invoices", async ({ page }) => {
-    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", []);
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", paged([]));
     await page.goto("/invoices");
     await expect(page.getByText(/no invoices yet/i)).toBeVisible();
   });
 
   test("filters by search term", async ({ page }) => {
-    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", [INVOICE]);
+    await mockJsonResponse(page, "**/api/v1/billing/invoices/me**", paged([INVOICE]));
     await page.goto("/invoices");
     await expect(page.getByText("INV-2026-05").last()).toBeVisible();
     await page.getByPlaceholder(/search by invoice number/i).fill("nomatch-xyz");

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,11 +17,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
@@ -30,6 +28,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.0-beta.1" />
+    <PackageVersion Include="QuestPDF" Version="2026.5.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
@@ -107,7 +106,6 @@
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Minio" Version="4.11.0" />
   </ItemGroup>
-
   <ItemGroup Label="AWS">
     <PackageVersion Include="AWSSDK.S3" Version="4.0.23.4" />
   </ItemGroup>

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/MultiTenancy/20260528151105_AddTenantExpiryNotices.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/MultiTenancy/20260528151105_AddTenantExpiryNotices.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Multitenancy.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.MultiTenancy
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528151105_AddTenantExpiryNotices")]
+    partial class AddTenantExpiryNotices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/MultiTenancy/20260528151105_AddTenantExpiryNotices.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/MultiTenancy/20260528151105_AddTenantExpiryNotices.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.MultiTenancy
+{
+    /// <inheritdoc />
+    public partial class AddTenantExpiryNotices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TenantExpiryNotices",
+                schema: "tenant",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    NoticeType = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ValidUptoUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenantExpiryNotices", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_tenant_expiry_notices_tenant_type_validupto",
+                schema: "tenant",
+                table: "TenantExpiryNotices",
+                columns: new[] { "TenantId", "NoticeType", "ValidUptoUtc" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TenantExpiryNotices",
+                schema: "tenant");
+        }
+    }
+}

--- a/src/Modules/Billing/Modules.Billing.Contracts/Events/InvoiceIssuedIntegrationEvent.cs
+++ b/src/Modules/Billing/Modules.Billing.Contracts/Events/InvoiceIssuedIntegrationEvent.cs
@@ -1,0 +1,22 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Modules.Billing.Contracts.Events;
+
+/// <summary>
+/// Raised when an invoice transitions to Issued and becomes a real bill (e.g. the subscription invoice
+/// generated on tenant create/renew). Consumers notify the tenant that an invoice is due.
+/// </summary>
+public sealed record InvoiceIssuedIntegrationEvent(
+    Guid Id,
+    DateTime OccurredOnUtc,
+    string? TenantId,
+    string CorrelationId,
+    string Source,
+    Guid InvoiceId,
+    string InvoiceNumber,
+    decimal Amount,
+    string Currency,
+    DateTime? DueAtUtc,
+    int PeriodYear,
+    int PeriodMonth)
+    : IIntegrationEvent;

--- a/src/Modules/Billing/Modules.Billing.Contracts/Modules.Billing.Contracts.csproj
+++ b/src/Modules/Billing/Modules.Billing.Contracts/Modules.Billing.Contracts.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\BuildingBlocks\Shared\Shared.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\Eventing.Abstractions\Eventing.Abstractions.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Modules/Billing/Modules.Billing/BillingModule.cs
+++ b/src/Modules/Billing/Modules.Billing/BillingModule.cs
@@ -6,6 +6,7 @@ using FSH.Modules.Billing.Data;
 using FSH.Modules.Billing.Features.v1.Invoices.GenerateInvoices;
 using FSH.Modules.Billing.Features.v1.Invoices.GetInvoiceById;
 using FSH.Modules.Billing.Features.v1.Invoices.GetInvoices;
+using FSH.Modules.Billing.Features.v1.Invoices.GetInvoicePdf;
 using FSH.Modules.Billing.Features.v1.Invoices.GetMyInvoices;
 using FSH.Modules.Billing.Features.v1.Invoices.IssueInvoice;
 using FSH.Modules.Billing.Features.v1.Invoices.MarkInvoicePaid;
@@ -44,6 +45,7 @@ public sealed class BillingModule : IModule
         builder.Services.AddScoped<IDbInitializer, BillingDbInitializer>();
         builder.Services.AddScoped<IUsageReporter, UsageReporter>();
         builder.Services.AddScoped<IBillingService, BillingService>();
+        builder.Services.AddSingleton<IInvoicePdfRenderer, InvoicePdfRenderer>();
 
         // React to tenant create/renew events (Multitenancy.Contracts) to drive subscriptions + invoices.
         builder.Services.AddIntegrationEventHandlers(typeof(BillingModule).Assembly);
@@ -85,6 +87,7 @@ public sealed class BillingModule : IModule
         group.MapGetInvoicesEndpoint();
         group.MapGetMyInvoicesEndpoint();
         group.MapGetInvoiceByIdEndpoint();
+        group.MapGetInvoicePdfEndpoint();
         group.MapGenerateInvoicesEndpoint();
         group.MapIssueInvoiceEndpoint();
         group.MapMarkInvoicePaidEndpoint();

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfEndpoint.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfEndpoint.cs
@@ -1,0 +1,28 @@
+using FSH.Framework.Shared.Identity.Authorization;
+using FSH.Modules.Billing.Contracts.Authorization;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace FSH.Modules.Billing.Features.v1.Invoices.GetInvoicePdf;
+
+public static class GetInvoicePdfEndpoint
+{
+    internal static RouteHandlerBuilder MapGetInvoicePdfEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapGet("/invoices/{invoiceId:guid}/pdf",
+                async (Guid invoiceId, IMediator mediator, CancellationToken ct) =>
+                {
+                    var result = await mediator.Send(new GetInvoicePdfQuery(invoiceId), ct).ConfigureAwait(false);
+                    return Results.File(result.Content, "application/pdf", result.FileName);
+                })
+            .WithName("GetInvoicePdf")
+            .WithSummary("Download an invoice as a PDF")
+            // BillingPermissions.View is basic (granted to tenant users), and the handler scopes to the
+            // caller's tenant — so this single endpoint serves both operators and tenant self-service.
+            .RequirePermission(BillingPermissions.View)
+            .Produces(StatusCodes.Status200OK, contentType: "application/pdf")
+            .Produces(StatusCodes.Status404NotFound);
+    }
+}

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQuery.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQuery.cs
@@ -1,0 +1,9 @@
+using Mediator;
+
+namespace FSH.Modules.Billing.Features.v1.Invoices.GetInvoicePdf;
+
+/// <summary>Fetches the caller-tenant's invoice and renders it to a PDF. Module-internal (the byte[]
+/// result is not a cross-module contract).</summary>
+public sealed record GetInvoicePdfQuery(Guid InvoiceId) : IQuery<InvoicePdfResult>;
+
+public sealed record InvoicePdfResult(byte[] Content, string FileName);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
@@ -1,0 +1,36 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Services;
+using Mediator;
+using Microsoft.EntityFrameworkCore;
+
+namespace FSH.Modules.Billing.Features.v1.Invoices.GetInvoicePdf;
+
+public sealed class GetInvoicePdfQueryHandler(
+    BillingDbContext dbContext,
+    IMultiTenantContextAccessor<AppTenantInfo> tenantAccessor,
+    IInvoicePdfRenderer renderer)
+    : IQueryHandler<GetInvoicePdfQuery, InvoicePdfResult>
+{
+    public async ValueTask<InvoicePdfResult> Handle(GetInvoicePdfQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // BillingDbContext is not tenant-filtered, so scope the fetch to the caller's tenant explicitly
+        // (mirrors GetInvoiceById) — cross-tenant ids resolve to 404, never leak another tenant's PDF.
+        var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
+            ?? throw new UnauthorizedException("Tenant context is required.");
+
+        var invoice = await dbContext.Invoices.AsNoTracking()
+            .Include(i => i.LineItems)
+            .FirstOrDefaultAsync(i => i.Id == query.InvoiceId && i.TenantId == tenantId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Invoice {query.InvoiceId} not found.");
+
+        var dto = invoice.ToDto();
+        var content = renderer.Render(dto);
+        return new InvoicePdfResult(content, $"{dto.InvoiceNumber}.pdf");
+    }
+}

--- a/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
+++ b/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
@@ -17,4 +17,8 @@
 	  <ProjectReference Include="..\..\Multitenancy\Modules.Multitenancy.Contracts\Modules.Multitenancy.Contracts.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="QuestPDF" />
+	</ItemGroup>
+
 </Project>

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -1,8 +1,10 @@
 using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Eventing.Abstractions;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Framework.Shared.Quota;
 using FSH.Modules.Billing.Contracts;
+using FSH.Modules.Billing.Contracts.Events;
 using FSH.Modules.Billing.Data;
 using FSH.Modules.Billing.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -15,17 +17,23 @@ public sealed class BillingService : IBillingService
     private readonly BillingDbContext _db;
     private readonly IUsageReporter _usageReporter;
     private readonly IMultiTenantStore<AppTenantInfo> _tenantStore;
+    private readonly IEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<BillingService> _logger;
 
     public BillingService(
         BillingDbContext db,
         IUsageReporter usageReporter,
         IMultiTenantStore<AppTenantInfo> tenantStore,
+        IEventBus eventBus,
+        TimeProvider timeProvider,
         ILogger<BillingService> logger)
     {
         _db = db;
         _usageReporter = usageReporter;
         _tenantStore = tenantStore;
+        _eventBus = eventBus;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -219,6 +227,23 @@ public sealed class BillingService : IBillingService
             _logger.LogInformation("[Billing] issued subscription invoice {InvoiceNumber} for tenant {TenantId} total={Total} {Currency}",
                 invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount, invoice.Currency);
         }
+
+        // Notify (e.g. email the tenant) that a real bill was issued. Only fires for newly-created
+        // invoices — the idempotent early-return above skips this on event redelivery.
+        await _eventBus.PublishAsync(new InvoiceIssuedIntegrationEvent(
+            Id: Guid.NewGuid(),
+            OccurredOnUtc: _timeProvider.GetUtcNow().UtcDateTime,
+            TenantId: tenantId,
+            CorrelationId: Guid.NewGuid().ToString(),
+            Source: "Billing",
+            InvoiceId: invoice.Id,
+            InvoiceNumber: invoice.InvoiceNumber,
+            Amount: invoice.SubtotalAmount,
+            Currency: invoice.Currency,
+            DueAtUtc: invoice.DueAtUtc,
+            PeriodYear: invoice.PeriodYear,
+            PeriodMonth: invoice.PeriodMonth), cancellationToken).ConfigureAwait(false);
+
         return invoice;
     }
 

--- a/src/Modules/Billing/Modules.Billing/Services/IInvoicePdfRenderer.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/IInvoicePdfRenderer.cs
@@ -1,0 +1,9 @@
+using FSH.Modules.Billing.Contracts.Dtos;
+
+namespace FSH.Modules.Billing.Services;
+
+/// <summary>Renders an invoice to a self-contained PDF document (on-demand, no stored artifact).</summary>
+public interface IInvoicePdfRenderer
+{
+    byte[] Render(InvoiceDto invoice);
+}

--- a/src/Modules/Billing/Modules.Billing/Services/InvoicePdfRenderer.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/InvoicePdfRenderer.cs
@@ -1,0 +1,116 @@
+using System.Globalization;
+using FSH.Modules.Billing.Contracts.Dtos;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace FSH.Modules.Billing.Services;
+
+/// <summary>
+/// QuestPDF-based invoice renderer. QuestPDF's Community license is free for organisations under
+/// $1M USD/year revenue; larger downstream users must obtain a license. The dependency is isolated
+/// behind <see cref="IInvoicePdfRenderer"/> so it can be swapped without touching callers.
+/// </summary>
+public sealed class InvoicePdfRenderer : IInvoicePdfRenderer
+{
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    static InvoicePdfRenderer()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    public byte[] Render(InvoiceDto invoice)
+    {
+        ArgumentNullException.ThrowIfNull(invoice);
+
+        return Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(40);
+                page.DefaultTextStyle(t => t.FontSize(10).FontColor(Colors.Grey.Darken4));
+
+                page.Header().Column(col =>
+                {
+                    col.Item().Text("INVOICE").FontSize(22).Bold();
+                    col.Item().Text(invoice.InvoiceNumber).FontSize(12).FontColor(Colors.Grey.Darken1);
+                });
+
+                page.Content().PaddingVertical(15).Column(col =>
+                {
+                    col.Spacing(10);
+
+                    col.Item().Row(row =>
+                    {
+                        row.RelativeItem().Column(c =>
+                        {
+                            c.Item().Text("Billed to").SemiBold();
+                            c.Item().Text(invoice.TenantId);
+                        });
+                        row.RelativeItem().AlignRight().Column(c =>
+                        {
+                            c.Item().Text($"Status: {invoice.Status}").SemiBold();
+                            c.Item().Text($"Purpose: {invoice.Purpose}");
+                            c.Item().Text($"Period: {invoice.PeriodYear}-{invoice.PeriodMonth:00}");
+                            if (invoice.PeriodStartUtc is { } ps && invoice.PeriodEndUtc is { } pe)
+                            {
+                                c.Item().Text($"{ps:yyyy-MM-dd} → {pe:yyyy-MM-dd}").FontColor(Colors.Grey.Darken1);
+                            }
+                        });
+                    });
+
+                    col.Item().Row(row =>
+                    {
+                        row.RelativeItem().Text($"Issued: {FormatDate(invoice.IssuedAtUtc)}");
+                        row.RelativeItem().AlignRight().Text($"Due: {FormatDate(invoice.DueAtUtc)}");
+                    });
+
+                    col.Item().Table(table =>
+                    {
+                        table.ColumnsDefinition(cd =>
+                        {
+                            cd.RelativeColumn(5);
+                            cd.RelativeColumn(1);
+                            cd.RelativeColumn(2);
+                            cd.RelativeColumn(2);
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Text("Description").SemiBold();
+                            header.Cell().AlignRight().Text("Qty").SemiBold();
+                            header.Cell().AlignRight().Text("Unit Price").SemiBold();
+                            header.Cell().AlignRight().Text("Amount").SemiBold();
+                        });
+
+                        foreach (var line in invoice.LineItems)
+                        {
+                            table.Cell().Text(line.Description);
+                            table.Cell().AlignRight().Text(line.Quantity.ToString("0.##", Culture));
+                            table.Cell().AlignRight().Text(line.UnitPrice.ToString("0.00", Culture));
+                            table.Cell().AlignRight().Text(line.Amount.ToString("0.00", Culture));
+                        }
+                    });
+
+                    col.Item().AlignRight()
+                        .Text($"Subtotal: {invoice.SubtotalAmount.ToString("0.00", Culture)} {invoice.Currency}")
+                        .FontSize(12).Bold();
+
+                    if (!string.IsNullOrWhiteSpace(invoice.Notes))
+                    {
+                        col.Item().PaddingTop(10).Text($"Notes: {invoice.Notes}").FontColor(Colors.Grey.Darken1);
+                    }
+                });
+
+                page.Footer().AlignCenter()
+                    .Text($"Generated {DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm 'UTC'", Culture)}")
+                    .FontSize(8).FontColor(Colors.Grey.Medium);
+            });
+        }).GeneratePdf();
+    }
+
+    private static string FormatDate(DateTime? value) =>
+        value is null ? "—" : value.Value.ToString("yyyy-MM-dd", Culture);
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantEnteredGraceIntegrationEvent.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantEnteredGraceIntegrationEvent.cs
@@ -1,0 +1,20 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Modules.Multitenancy.Contracts.Events;
+
+/// <summary>
+/// Raised by the daily expiry scan when a tenant has passed <c>ValidUpto</c> but is still inside the
+/// grace window (access continues). Consumers warn the tenant that the grace period is counting down.
+/// </summary>
+public sealed record TenantEnteredGraceIntegrationEvent(
+    Guid Id,
+    DateTime OccurredOnUtc,
+    string? TenantId,
+    string CorrelationId,
+    string Source,
+    string TenantName,
+    string AdminEmail,
+    string? PlanKey,
+    DateTime ValidUpto,
+    DateTime GraceEndsUtc)
+    : IIntegrationEvent;

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantExpiredIntegrationEvent.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantExpiredIntegrationEvent.cs
@@ -1,0 +1,20 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Modules.Multitenancy.Contracts.Events;
+
+/// <summary>
+/// Raised by the daily expiry scan when a tenant has passed <c>ValidUpto + grace</c> and is now
+/// hard-blocked. Consumers notify the tenant that access is suspended until they renew.
+/// </summary>
+public sealed record TenantExpiredIntegrationEvent(
+    Guid Id,
+    DateTime OccurredOnUtc,
+    string? TenantId,
+    string CorrelationId,
+    string Source,
+    string TenantName,
+    string AdminEmail,
+    string? PlanKey,
+    DateTime ValidUpto,
+    DateTime GraceEndsUtc)
+    : IIntegrationEvent;

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantNearingExpiryIntegrationEvent.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Events/TenantNearingExpiryIntegrationEvent.cs
@@ -1,0 +1,21 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Modules.Multitenancy.Contracts.Events;
+
+/// <summary>
+/// Raised by the daily expiry scan when an active tenant is within the configured lead time of its
+/// <c>ValidUpto</c> (but not yet lapsed). Consumers notify the tenant so they can renew in time.
+/// </summary>
+public sealed record TenantNearingExpiryIntegrationEvent(
+    Guid Id,
+    DateTime OccurredOnUtc,
+    string? TenantId,
+    string CorrelationId,
+    string Source,
+    string TenantName,
+    string AdminEmail,
+    string? PlanKey,
+    DateTime ValidUpto,
+    DateTime GraceEndsUtc,
+    int DaysRemaining)
+    : IIntegrationEvent;

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/ITenantService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/ITenantService.cs
@@ -29,6 +29,14 @@ public interface ITenantService
     Task<(DateTime PeriodStartUtc, DateTime ValidUpto, bool PlanChanged)> RenewAsync(
         string id, string newPlanKey, int termMonths, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Operator override that sets the tenant's validity to an explicit date with no billing
+    /// side-effect (no subscription, no invoice, no renewal event) — for comps, support extensions,
+    /// or immediate expiry. Unlike <see cref="RenewAsync"/> this may move the date backward. Returns
+    /// the applied <c>ValidUpto</c> (UTC).
+    /// </summary>
+    Task<DateTime> AdjustValidityAsync(string id, DateTime validUpto, CancellationToken cancellationToken = default);
+
     Task MigrateTenantAsync(AppTenantInfo tenant, CancellationToken cancellationToken);
 
     Task SeedTenantAsync(AppTenantInfo tenant, CancellationToken cancellationToken);

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommand.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommand.cs
@@ -1,0 +1,11 @@
+using Mediator;
+
+namespace FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+
+/// <summary>
+/// Operator override that sets a tenant's validity to an explicit date with no billing side-effect
+/// (no subscription, no invoice, no renewal event). Intended for comps, support extensions, or
+/// immediate expiry. May move the date backward, unlike renewal.
+/// </summary>
+public sealed record AdjustTenantValidityCommand(string TenantId, DateTime ValidUpto)
+    : ICommand<AdjustTenantValidityCommandResponse>;

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommandResponse.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommandResponse.cs
@@ -1,0 +1,3 @@
+namespace FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+
+public sealed record AdjustTenantValidityCommandResponse(string TenantId, DateTime ValidUpto);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Data/Configurations/TenantExpiryNoticeConfiguration.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Data/Configurations/TenantExpiryNoticeConfiguration.cs
@@ -1,0 +1,28 @@
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Multitenancy.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FSH.Modules.Multitenancy.Data.Configurations;
+
+public sealed class TenantExpiryNoticeConfiguration : IEntityTypeConfiguration<TenantExpiryNotice>
+{
+    public void Configure(EntityTypeBuilder<TenantExpiryNotice> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("TenantExpiryNotices", MultitenancyConstants.Schema);
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.TenantId).HasMaxLength(64).IsRequired();
+        builder.Property(x => x.NoticeType).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.ValidUptoUtc).IsRequired();
+        builder.Property(x => x.CreatedAtUtc).IsRequired();
+
+        // One notice per tenant per state per validity period — the dedup guarantee.
+        builder.HasIndex(x => new { x.TenantId, x.NoticeType, x.ValidUptoUtc })
+            .IsUnique()
+            .HasDatabaseName("ux_tenant_expiry_notices_tenant_type_validupto");
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Data/TenantDbContext.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Data/TenantDbContext.cs
@@ -21,6 +21,8 @@ public class TenantDbContext : EFCoreStoreDbContext<AppTenantInfo>
 
     public DbSet<TenantTheme> TenantThemes => Set<TenantTheme>();
 
+    public DbSet<TenantExpiryNotice> TenantExpiryNotices => Set<TenantExpiryNotice>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Domain/TenantExpiryNotice.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Domain/TenantExpiryNotice.cs
@@ -1,0 +1,44 @@
+namespace FSH.Modules.Multitenancy.Domain;
+
+/// <summary>
+/// Dedup ledger for expiry notifications. The daily scan records one row per
+/// (tenant, notice type, validity period) so a tenant is notified once per state per validity window —
+/// the row re-arms automatically when <c>ValidUpto</c> changes on renewal. Lives in the cross-tenant
+/// <c>TenantDbContext</c> (not tenant-filtered), so the background scan can read/write it without a
+/// tenant context.
+/// </summary>
+public sealed class TenantExpiryNotice
+{
+    public Guid Id { get; private set; }
+    public string TenantId { get; private set; } = default!;
+    public string NoticeType { get; private set; } = default!;
+    public DateTime ValidUptoUtc { get; private set; }
+    public DateTime CreatedAtUtc { get; private set; }
+
+    private TenantExpiryNotice()
+    {
+    }
+
+    public static TenantExpiryNotice Record(string tenantId, string noticeType, DateTime validUptoUtc, DateTime nowUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(noticeType);
+
+        return new TenantExpiryNotice
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            NoticeType = noticeType,
+            ValidUptoUtc = DateTime.SpecifyKind(validUptoUtc, DateTimeKind.Utc),
+            CreatedAtUtc = DateTime.SpecifyKind(nowUtc, DateTimeKind.Utc),
+        };
+    }
+}
+
+/// <summary>Stable string keys for <see cref="TenantExpiryNotice.NoticeType"/>.</summary>
+public static class TenantExpiryNoticeTypes
+{
+    public const string NearingExpiry = "NearingExpiry";
+    public const string EnteredGrace = "EnteredGrace";
+    public const string Expired = "Expired";
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandHandler.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandHandler.cs
@@ -1,0 +1,21 @@
+using FSH.Modules.Multitenancy.Contracts;
+using FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+using Mediator;
+
+namespace FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
+
+public sealed class AdjustTenantValidityCommandHandler(ITenantService tenantService)
+    : ICommandHandler<AdjustTenantValidityCommand, AdjustTenantValidityCommandResponse>
+{
+    public async ValueTask<AdjustTenantValidityCommandResponse> Handle(
+        AdjustTenantValidityCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var validUpto = await tenantService
+            .AdjustValidityAsync(command.TenantId, command.ValidUpto, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new AdjustTenantValidityCommandResponse(command.TenantId, validUpto);
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+
+namespace FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
+
+public sealed class AdjustTenantValidityCommandValidator : AbstractValidator<AdjustTenantValidityCommand>
+{
+    public AdjustTenantValidityCommandValidator()
+    {
+        RuleFor(t => t.TenantId).NotEmpty();
+
+        RuleFor(t => t.ValidUpto)
+            .Must(d => d != default)
+            .WithMessage("A valid 'validUpto' date is required.");
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityEndpoint.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityEndpoint.cs
@@ -1,0 +1,41 @@
+using FSH.Framework.Shared.Identity.Authorization;
+using FSH.Modules.Multitenancy.Contracts.Authorization;
+using FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
+
+public static class AdjustTenantValidityEndpoint
+{
+    internal static RouteHandlerBuilder Map(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapPost("/{id}/adjust-validity", Handler)
+            .WithName("AdjustTenantValidity")
+            .WithSummary("Adjust tenant validity (operator override)")
+            .RequirePermission(MultitenancyPermissions.Tenants.UpgradeSubscription)
+            .WithDescription("Set a tenant's validity to an explicit date with no invoice or renewal event — for comps, support extensions, or immediate expiry.")
+            .Produces<AdjustTenantValidityCommandResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden);
+    }
+
+    private static async Task<Results<Ok<AdjustTenantValidityCommandResponse>, BadRequest>> Handler(
+        string id,
+        AdjustTenantValidityCommand command,
+        IMediator dispatcher,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(id, command.TenantId, StringComparison.Ordinal))
+        {
+            return TypedResults.BadRequest();
+        }
+
+        var result = await dispatcher.Send(command, cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(result);
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/GetMyTenantStatus/GetMyTenantStatusEndpoint.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/GetMyTenantStatus/GetMyTenantStatusEndpoint.cs
@@ -1,0 +1,36 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Multitenancy.Contracts;
+using FSH.Modules.Multitenancy.Contracts.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace FSH.Modules.Multitenancy.Features.v1.GetMyTenantStatus;
+
+public static class GetMyTenantStatusEndpoint
+{
+    public static RouteHandlerBuilder Map(IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapGet("/me/status", async (
+                IMultiTenantContextAccessor<AppTenantInfo> tenantAccessor,
+                ITenantService tenantService,
+                CancellationToken cancellationToken) =>
+            {
+                var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id;
+                if (string.IsNullOrEmpty(tenantId))
+                {
+                    return Results.Unauthorized();
+                }
+
+                var status = await tenantService.GetStatusAsync(tenantId, cancellationToken).ConfigureAwait(false);
+                return Results.Ok(status);
+            })
+            .WithName("GetMyTenantStatus")
+            .WithSummary("Get the calling tenant's status")
+            .WithDescription("Returns plan, validity, and expiry/grace state for the authenticated tenant — used by the tenant dashboard to show plan info and expiry warnings.")
+            .RequireAuthorization()
+            .Produces<TenantStatusDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -26,6 +26,8 @@ using FSH.Modules.Multitenancy.Features.v1.RenewTenant;
 using FSH.Modules.Multitenancy.Features.v1.UpdateTenantTheme;
 using FSH.Modules.Multitenancy.Provisioning;
 using FSH.Modules.Multitenancy.Services;
+using Hangfire;
+using Hangfire.Common;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -54,6 +56,7 @@ public sealed class MultitenancyModule : IModule
         builder.Services.AddTransient<IConnectionStringValidator, ConnectionStringValidator>();
         builder.Services.AddScoped<ITenantProvisioningService, TenantProvisioningService>();
         builder.Services.AddTransient<TenantProvisioningJob>();
+        builder.Services.AddTransient<TenantExpiryScanJob>();
 
         // Singleton — the buffer survives the request scope that calls Store(...)
         // so the background Hangfire-scheduled seed scope can still TryConsume(...).
@@ -250,5 +253,16 @@ public sealed class MultitenancyModule : IModule
         GetTenantThemeEndpoint.Map(group);
         UpdateTenantThemeEndpoint.Map(group);
         ResetTenantThemeEndpoint.Map(group);
+
+        var jobManager = endpoints.ServiceProvider.GetService<IRecurringJobManager>();
+        if (jobManager is not null)
+        {
+            // Scan tenants daily at 02:00 UTC; publishes nearing-expiry / entered-grace / expired notices.
+            jobManager.AddOrUpdate(
+                "tenant-expiry-scan",
+                Job.FromExpression<TenantExpiryScanJob>(j => j.RunAsync(CancellationToken.None)),
+                "0 2 * * *",
+                new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+        }
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -12,6 +12,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Framework.Web.Modules;
 using FSH.Modules.Multitenancy.Contracts;
 using FSH.Modules.Multitenancy.Data;
+using FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
 using FSH.Modules.Multitenancy.Features.v1.ChangeTenantActivation;
 using FSH.Modules.Multitenancy.Features.v1.CreateTenant;
 using FSH.Modules.Multitenancy.Features.v1.GetTenantMigrations;
@@ -196,9 +197,25 @@ public sealed class MultitenancyModule : IModule
                     var graceDays = ctx.RequestServices
                         .GetRequiredService<IOptions<TenantBillingOptions>>().Value.GraceWindowDays;
                     var nowUtc = ctx.RequestServices.GetRequiredService<TimeProvider>().GetUtcNow().UtcDateTime;
-                    if (nowUtc > tenant.ValidUpto.AddDays(graceDays))
+                    var graceEndsUtc = tenant.ValidUpto.AddDays(graceDays);
+                    if (nowUtc > graceEndsUtc)
                     {
                         throw new ForbiddenException("This tenant's subscription has expired. Please renew to continue.");
+                    }
+
+                    // Inside the grace window (past ValidUpto, before grace ends): surface the days left
+                    // so clients can warn the tenant. Set via OnStarting so the header survives even when
+                    // an exception handler rewrites the response (e.g. a failed login still in grace).
+                    if (nowUtc > tenant.ValidUpto)
+                    {
+                        var daysLeft = (int)Math.Ceiling((graceEndsUtc - nowUtc).TotalDays);
+                        var headerValue = daysLeft.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        ctx.Response.OnStarting(static state =>
+                        {
+                            var (response, value) = ((HttpResponse, string))state;
+                            response.Headers["X-Subscription-Grace"] = value;
+                            return Task.CompletedTask;
+                        }, (ctx.Response, headerValue));
                     }
                 }
             }
@@ -222,6 +239,7 @@ public sealed class MultitenancyModule : IModule
         ChangeTenantActivationEndpoint.Map(group);
         GetTenantsEndpoint.Map(group);
         RenewTenantEndpoint.Map(group);
+        AdjustTenantValidityEndpoint.Map(group);
         CreateTenantEndpoint.Map(group);
         GetTenantStatusEndpoint.Map(group);
         GetTenantProvisioningStatusEndpoint.Map(group);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -15,6 +15,7 @@ using FSH.Modules.Multitenancy.Data;
 using FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
 using FSH.Modules.Multitenancy.Features.v1.ChangeTenantActivation;
 using FSH.Modules.Multitenancy.Features.v1.CreateTenant;
+using FSH.Modules.Multitenancy.Features.v1.GetMyTenantStatus;
 using FSH.Modules.Multitenancy.Features.v1.GetTenantMigrations;
 using FSH.Modules.Multitenancy.Features.v1.GetTenants;
 using FSH.Modules.Multitenancy.Features.v1.GetTenantStatus;
@@ -245,6 +246,7 @@ public sealed class MultitenancyModule : IModule
         AdjustTenantValidityEndpoint.Map(group);
         CreateTenantEndpoint.Map(group);
         GetTenantStatusEndpoint.Map(group);
+        GetMyTenantStatusEndpoint.Map(group);
         GetTenantProvisioningStatusEndpoint.Map(group);
         RetryTenantProvisioningEndpoint.Map(group);
         TenantMigrationsEndpoint.Map(group);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
@@ -1,0 +1,149 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Multitenancy.Contracts.Events;
+using FSH.Modules.Multitenancy.Data;
+using FSH.Modules.Multitenancy.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FSH.Modules.Multitenancy.Services;
+
+/// <summary>
+/// Daily scan that notifies tenants approaching or past their <c>ValidUpto</c>. For each active,
+/// non-root tenant it classifies the state (nearing expiry / in grace / expired), records a dedup row
+/// in <see cref="TenantExpiryNotice"/> (one per tenant+state+validity period), and publishes the
+/// matching integration event. Notification side-effects (email) are handled by event consumers.
+/// </summary>
+public sealed class TenantExpiryScanJob
+{
+    private readonly IMultiTenantStore<AppTenantInfo> _tenantStore;
+    private readonly TenantDbContext _db;
+    private readonly IEventBus _eventBus;
+    private readonly IMultiTenantContextSetter _tenantContextSetter;
+    private readonly TimeProvider _timeProvider;
+    private readonly TenantBillingOptions _options;
+    private readonly ILogger<TenantExpiryScanJob> _logger;
+
+    public TenantExpiryScanJob(
+        IMultiTenantStore<AppTenantInfo> tenantStore,
+        TenantDbContext db,
+        IEventBus eventBus,
+        IMultiTenantContextSetter tenantContextSetter,
+        TimeProvider timeProvider,
+        IOptions<TenantBillingOptions> options,
+        ILogger<TenantExpiryScanJob> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _tenantStore = tenantStore;
+        _db = db;
+        _eventBus = eventBus;
+        _tenantContextSetter = tenantContextSetter;
+        _timeProvider = timeProvider;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var tenants = await _tenantStore.GetAllAsync().ConfigureAwait(false);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var published = 0;
+        foreach (var tenant in tenants)
+        {
+            if (!tenant.IsActive ||
+                string.Equals(tenant.Id, MultitenancyConstants.Root.Id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (await TryNotifyAsync(tenant, now, cancellationToken).ConfigureAwait(false))
+                {
+                    published++;
+                }
+            }
+#pragma warning disable CA1031 // One tenant's failure must not block the rest of the scan
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogError(ex, "[Multitenancy] expiry scan failed for tenant {TenantId}", tenant.Id);
+            }
+        }
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("[Multitenancy] expiry scan published {Count} notice(s)", published);
+        }
+    }
+
+    private async Task<bool> TryNotifyAsync(AppTenantInfo tenant, DateTime now, CancellationToken ct)
+    {
+        var validUpto = tenant.ValidUpto;
+        var graceEnds = validUpto.AddDays(_options.GraceWindowDays);
+
+        string noticeType;
+        if (now > graceEnds)
+        {
+            noticeType = TenantExpiryNoticeTypes.Expired;
+        }
+        else if (now > validUpto)
+        {
+            noticeType = TenantExpiryNoticeTypes.EnteredGrace;
+        }
+        else if (now >= validUpto.AddDays(-_options.ExpiryNotificationLeadDays))
+        {
+            noticeType = TenantExpiryNoticeTypes.NearingExpiry;
+        }
+        else
+        {
+            return false; // healthy and outside the reminder window
+        }
+
+        // Dedup: one notice per tenant per state per validity period (re-arms when ValidUpto changes).
+        var alreadyNotified = await _db.TenantExpiryNotices
+            .AnyAsync(x => x.TenantId == tenant.Id && x.NoticeType == noticeType && x.ValidUptoUtc == validUpto, ct)
+            .ConfigureAwait(false);
+        if (alreadyNotified)
+        {
+            return false;
+        }
+
+        _db.TenantExpiryNotices.Add(TenantExpiryNotice.Record(tenant.Id, noticeType, validUpto, now));
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Install the tenant's Finbuckle context before publishing: downstream handlers (e.g. the
+        // webhook fan-out) touch tenant-filtered DbContexts that capture the ambient tenant at
+        // construction. With no HTTP request in a background job, that context is otherwise empty and
+        // their query filters NRE. The ambient (AsyncLocal) value flows into the bus's handler scope.
+        _tenantContextSetter.MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        await _eventBus.PublishAsync(BuildEvent(noticeType, tenant, validUpto, graceEnds, now), ct).ConfigureAwait(false);
+        return true;
+    }
+
+    private static IIntegrationEvent BuildEvent(
+        string noticeType, AppTenantInfo tenant, DateTime validUpto, DateTime graceEnds, DateTime now)
+    {
+        var id = Guid.NewGuid();
+        var correlationId = Guid.NewGuid().ToString();
+        const string source = "Multitenancy";
+        var name = tenant.Name ?? tenant.Id;
+        var email = tenant.AdminEmail;
+
+        return noticeType switch
+        {
+            TenantExpiryNoticeTypes.NearingExpiry => new TenantNearingExpiryIntegrationEvent(
+                id, now, tenant.Id, correlationId, source, name, email, tenant.Plan, validUpto, graceEnds,
+                DaysRemaining: Math.Max(0, (int)Math.Ceiling((validUpto - now).TotalDays))),
+            TenantExpiryNoticeTypes.EnteredGrace => new TenantEnteredGraceIntegrationEvent(
+                id, now, tenant.Id, correlationId, source, name, email, tenant.Plan, validUpto, graceEnds),
+            _ => new TenantExpiredIntegrationEvent(
+                id, now, tenant.Id, correlationId, source, name, email, tenant.Plan, validUpto, graceEnds),
+        };
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
@@ -200,7 +200,7 @@ public sealed class TenantService : ITenantService
         ArgumentException.ThrowIfNullOrWhiteSpace(newPlanKey);
 
         var tenant = await GetTenantInfoAsync(id, cancellationToken).ConfigureAwait(false);
-        var now = DateTime.UtcNow;
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
 
         // Stack remaining time: renew from ValidUpto if still in the future, otherwise from now.
         var periodStart = DateTime.SpecifyKind(tenant.ValidUpto > now ? tenant.ValidUpto : now, DateTimeKind.Utc);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
@@ -12,6 +12,7 @@ using FSH.Modules.Multitenancy.Features.v1.GetTenants;
 using FSH.Modules.Multitenancy.Provisioning;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace FSH.Modules.Multitenancy.Services;
@@ -25,6 +26,7 @@ public sealed class TenantService : ITenantService
     private readonly ITenantProvisioningService _provisioningService;
     private readonly TimeProvider _timeProvider;
     private readonly TenantBillingOptions _billingOptions;
+    private readonly ILogger<TenantService> _logger;
 
     public TenantService(
         IMultiTenantStore<AppTenantInfo> tenantStore,
@@ -33,7 +35,8 @@ public sealed class TenantService : ITenantService
         TenantDbContext dbContext,
         ITenantProvisioningService provisioningService,
         TimeProvider timeProvider,
-        IOptions<TenantBillingOptions> billingOptions)
+        IOptions<TenantBillingOptions> billingOptions,
+        ILogger<TenantService> logger)
     {
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(billingOptions);
@@ -44,6 +47,7 @@ public sealed class TenantService : ITenantService
         _provisioningService = provisioningService;
         _timeProvider = timeProvider;
         _billingOptions = billingOptions.Value;
+        _logger = logger;
     }
 
     public async Task<string> ActivateAsync(string id, CancellationToken cancellationToken)
@@ -217,6 +221,29 @@ public sealed class TenantService : ITenantService
         await RefreshTenantCacheAsync(tenant).ConfigureAwait(false);
 
         return (periodStart, newValidUpto, planChanged);
+    }
+
+    public async Task<DateTime> AdjustValidityAsync(string id, DateTime validUpto, CancellationToken cancellationToken = default)
+    {
+        var tenant = await GetTenantInfoAsync(id, cancellationToken).ConfigureAwait(false);
+
+        // Set directly rather than via SetValidity: this operator override is allowed to move the date
+        // backward (e.g. immediate expiry / correcting a mistake), which SetValidity forbids.
+        var normalized = DateTime.SpecifyKind(validUpto, DateTimeKind.Utc);
+        var previous = tenant.ValidUpto;
+        tenant.ValidUpto = normalized;
+
+        await _tenantStore.UpdateAsync(tenant).ConfigureAwait(false);
+        await RefreshTenantCacheAsync(tenant).ConfigureAwait(false);
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "[Multitenancy] operator adjusted tenant {TenantId} validity from {Previous:o} to {ValidUpto:o}",
+                id, previous, normalized);
+        }
+
+        return normalized;
     }
 
     private async Task<AppTenantInfo> GetTenantInfoAsync(string id, CancellationToken cancellationToken = default) =>

--- a/src/Modules/Multitenancy/Modules.Multitenancy/TenantBillingOptions.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/TenantBillingOptions.cs
@@ -14,4 +14,7 @@ public sealed class TenantBillingOptions
 
     /// <summary>Days past <c>ValidUpto</c> during which requests/logins still succeed.</summary>
     public int GraceWindowDays { get; set; } = 7;
+
+    /// <summary>How many days before <c>ValidUpto</c> the daily scan starts sending "nearing expiry" reminders.</summary>
+    public int ExpiryNotificationLeadDays { get; set; } = 7;
 }

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailBodies.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailBodies.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>
+/// Builds the subject + HTML body for tenant billing emails. Plain interpolated HTML (the framework
+/// has no template engine); kept here so the handlers stay thin and the copy is easy to review.
+/// </summary>
+internal static class BillingEmailBodies
+{
+    private static string Date(DateTime utc) => utc.ToString("MMMM d, yyyy", CultureInfo.InvariantCulture);
+
+    public static (string Subject, string Body) NearingExpiry(string tenantName, string? planKey, DateTime validUpto, int daysRemaining)
+    {
+        var subject = daysRemaining <= 1
+            ? "Your subscription expires tomorrow"
+            : $"Your subscription expires in {daysRemaining} days";
+        var body = Wrap(subject,
+            $"<p>Hi {Escape(tenantName)},</p>" +
+            $"<p>Your <strong>{Escape(planKey ?? "current")}</strong> subscription is valid until " +
+            $"<strong>{Date(validUpto)}</strong> ({daysRemaining} day(s) remaining).</p>" +
+            "<p>Please contact your account operator to renew and avoid any interruption to your service.</p>");
+        return (subject, body);
+    }
+
+    public static (string Subject, string Body) EnteredGrace(string tenantName, string? planKey, DateTime validUpto, DateTime graceEnds)
+    {
+        const string subject = "Your subscription has lapsed — grace period active";
+        var body = Wrap(subject,
+            $"<p>Hi {Escape(tenantName)},</p>" +
+            $"<p>Your <strong>{Escape(planKey ?? "current")}</strong> subscription expired on " +
+            $"<strong>{Date(validUpto)}</strong>. Your service continues during a grace period that ends on " +
+            $"<strong>{Date(graceEnds)}</strong>.</p>" +
+            "<p>Please renew before the grace period ends to keep your access uninterrupted.</p>");
+        return (subject, body);
+    }
+
+    public static (string Subject, string Body) Expired(string tenantName, string? planKey, DateTime validUpto)
+    {
+        const string subject = "Your subscription has expired";
+        var body = Wrap(subject,
+            $"<p>Hi {Escape(tenantName)},</p>" +
+            $"<p>Your <strong>{Escape(planKey ?? "current")}</strong> subscription expired on " +
+            $"<strong>{Date(validUpto)}</strong> and the grace period has ended, so access is now suspended.</p>" +
+            "<p>Contact your account operator to renew and restore access.</p>");
+        return (subject, body);
+    }
+
+    public static (string Subject, string Body) InvoiceIssued(string invoiceNumber, decimal amount, string currency, DateTime? dueAtUtc)
+    {
+        var subject = $"Invoice {invoiceNumber} issued";
+        var amountText = $"{amount.ToString("0.00", CultureInfo.InvariantCulture)} {currency}";
+        var due = dueAtUtc is null ? string.Empty : $"<p>Due by <strong>{Date(dueAtUtc.Value)}</strong>.</p>";
+        var body = Wrap(subject,
+            $"<p>A new invoice <strong>{Escape(invoiceNumber)}</strong> for <strong>{amountText}</strong> has been issued.</p>" +
+            due +
+            "<p>You can view and download this invoice from your dashboard.</p>");
+        return (subject, body);
+    }
+
+    private static string Wrap(string heading, string innerHtml) =>
+        "<div style=\"font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#1a1a1a;line-height:1.5\">" +
+        $"<h2 style=\"font-size:18px;margin:0 0 12px\">{Escape(heading)}</h2>" +
+        innerHtml +
+        "<p style=\"margin-top:24px;color:#6b7280;font-size:12px\">This is an automated message.</p>" +
+        "</div>";
+
+    private static string Escape(string value) =>
+        value.Replace("&", "&amp;", StringComparison.Ordinal)
+             .Replace("<", "&lt;", StringComparison.Ordinal)
+             .Replace(">", "&gt;", StringComparison.Ordinal);
+}

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailSender.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailSender.cs
@@ -1,0 +1,32 @@
+using System.Collections.ObjectModel;
+using FSH.Framework.Mailing;
+using FSH.Framework.Mailing.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>Shared best-effort send for billing emails — a delivery failure must never throw out of an
+/// integration-event handler (it would fail the originating create/renew/scan).</summary>
+internal static class BillingEmailSender
+{
+    public static async Task SendAsync(
+        IMailService mail, ILogger logger, string? email, string subject, string body, string context, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return;
+        }
+
+        try
+        {
+            await mail.SendAsync(new MailRequest(
+                to: new Collection<string> { email },
+                subject: subject,
+                body: body), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send {Context} email to {Email}", context, email);
+        }
+    }
+}

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/InvoiceIssuedEmailHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/InvoiceIssuedEmailHandler.cs
@@ -1,0 +1,37 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Mailing.Services;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Billing.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>Emails the tenant admin when an invoice is issued. Resolves the admin email from the tenant
+/// store (the event only carries the tenant id).</summary>
+public sealed class InvoiceIssuedEmailHandler(
+    IMultiTenantStore<AppTenantInfo> tenantStore,
+    IMailService mailService,
+    ILogger<InvoiceIssuedEmailHandler> logger)
+    : IIntegrationEventHandler<InvoiceIssuedIntegrationEvent>
+{
+    public async Task HandleAsync(InvoiceIssuedIntegrationEvent @event, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        if (string.IsNullOrWhiteSpace(@event.TenantId))
+        {
+            return;
+        }
+
+        var tenant = await tenantStore.GetAsync(@event.TenantId).ConfigureAwait(false);
+        if (tenant is null)
+        {
+            return;
+        }
+
+        var (subject, body) = BillingEmailBodies.InvoiceIssued(
+            @event.InvoiceNumber, @event.Amount, @event.Currency, @event.DueAtUtc);
+        await BillingEmailSender.SendAsync(mailService, logger, tenant.AdminEmail, subject, body, "invoice-issued", ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantEnteredGraceEmailHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantEnteredGraceEmailHandler.cs
@@ -1,0 +1,22 @@
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Mailing.Services;
+using FSH.Modules.Multitenancy.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>Emails the tenant admin that their subscription lapsed and the grace period is counting down.</summary>
+public sealed class TenantEnteredGraceEmailHandler(
+    IMailService mailService,
+    ILogger<TenantEnteredGraceEmailHandler> logger)
+    : IIntegrationEventHandler<TenantEnteredGraceIntegrationEvent>
+{
+    public async Task HandleAsync(TenantEnteredGraceIntegrationEvent @event, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        var (subject, body) = BillingEmailBodies.EnteredGrace(
+            @event.TenantName, @event.PlanKey, @event.ValidUpto, @event.GraceEndsUtc);
+        await BillingEmailSender.SendAsync(mailService, logger, @event.AdminEmail, subject, body, "entered-grace", ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantExpiredEmailHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantExpiredEmailHandler.cs
@@ -1,0 +1,21 @@
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Mailing.Services;
+using FSH.Modules.Multitenancy.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>Emails the tenant admin that their subscription expired and access is suspended.</summary>
+public sealed class TenantExpiredEmailHandler(
+    IMailService mailService,
+    ILogger<TenantExpiredEmailHandler> logger)
+    : IIntegrationEventHandler<TenantExpiredIntegrationEvent>
+{
+    public async Task HandleAsync(TenantExpiredIntegrationEvent @event, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        var (subject, body) = BillingEmailBodies.Expired(@event.TenantName, @event.PlanKey, @event.ValidUpto);
+        await BillingEmailSender.SendAsync(mailService, logger, @event.AdminEmail, subject, body, "expired", ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantNearingExpiryEmailHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/TenantNearingExpiryEmailHandler.cs
@@ -1,0 +1,22 @@
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Mailing.Services;
+using FSH.Modules.Multitenancy.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.Modules.Notifications.IntegrationEventHandlers;
+
+/// <summary>Emails the tenant admin that their subscription is nearing expiry.</summary>
+public sealed class TenantNearingExpiryEmailHandler(
+    IMailService mailService,
+    ILogger<TenantNearingExpiryEmailHandler> logger)
+    : IIntegrationEventHandler<TenantNearingExpiryIntegrationEvent>
+{
+    public async Task HandleAsync(TenantNearingExpiryIntegrationEvent @event, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        var (subject, body) = BillingEmailBodies.NearingExpiry(
+            @event.TenantName, @event.PlanKey, @event.ValidUpto, @event.DaysRemaining);
+        await BillingEmailSender.SendAsync(mailService, logger, @event.AdminEmail, subject, body, "nearing-expiry", ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
+++ b/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
@@ -15,8 +15,11 @@
 		<ProjectReference Include="..\..\..\BuildingBlocks\Persistence\Persistence.csproj" />
 		<ProjectReference Include="..\..\..\BuildingBlocks\Web\Web.csproj" />
 		<ProjectReference Include="..\..\..\BuildingBlocks\Eventing\Eventing.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\Mailing\Mailing.csproj" />
 		<ProjectReference Include="..\Modules.Notifications.Contracts\Modules.Notifications.Contracts.csproj" />
 		<ProjectReference Include="..\..\Chat\Modules.Chat.Contracts\Modules.Chat.Contracts.csproj" />
+		<ProjectReference Include="..\..\Multitenancy\Modules.Multitenancy.Contracts\Modules.Multitenancy.Contracts.csproj" />
+		<ProjectReference Include="..\..\Billing\Modules.Billing.Contracts\Modules.Billing.Contracts.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tests/Billing.Tests/Services/InvoicePdfRendererTests.cs
+++ b/src/Tests/Billing.Tests/Services/InvoicePdfRendererTests.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using FSH.Modules.Billing.Contracts;
+using FSH.Modules.Billing.Contracts.Dtos;
+using FSH.Modules.Billing.Services;
+
+namespace Billing.Tests.Services;
+
+public sealed class InvoicePdfRendererTests
+{
+    [Fact]
+    public void Render_Should_Produce_NonEmpty_PdfDocument()
+    {
+        var now = DateTime.UtcNow;
+        var dto = new InvoiceDto(
+            Id: Guid.NewGuid(),
+            TenantId: "acme",
+            InvoiceNumber: "SUB-202605-abc123",
+            PeriodYear: 2026,
+            PeriodMonth: 5,
+            Currency: "USD",
+            SubtotalAmount: 29.00m,
+            Status: InvoiceStatus.Issued,
+            CreatedAtUtc: now,
+            IssuedAtUtc: now,
+            DueAtUtc: now.AddDays(14),
+            PaidAtUtc: null,
+            VoidedAtUtc: null,
+            Notes: "Thank you for your business.",
+            LineItems: new[]
+            {
+                new InvoiceLineItemDto(Guid.NewGuid(), InvoiceLineItemKind.BaseFee, null,
+                    "Pro — Monthly subscription (2026-05-01 to 2026-06-01)", 1m, 29.00m, 29.00m),
+            },
+            Purpose: InvoicePurpose.Subscription,
+            PeriodStartUtc: now,
+            PeriodEndUtc: now.AddMonths(1));
+
+        var sut = new InvoicePdfRenderer();
+        var bytes = sut.Render(dto);
+
+        bytes.ShouldNotBeNull();
+        bytes.Length.ShouldBeGreaterThan(0);
+        Encoding.ASCII.GetString(bytes, 0, 4).ShouldBe("%PDF");
+    }
+
+    [Fact]
+    public void Render_Should_Handle_Invoice_WithNoLineItems_AndNullDates()
+    {
+        var dto = new InvoiceDto(
+            Id: Guid.NewGuid(),
+            TenantId: "globex",
+            InvoiceNumber: "USG-202605-def456",
+            PeriodYear: 2026,
+            PeriodMonth: 5,
+            Currency: "EUR",
+            SubtotalAmount: 0m,
+            Status: InvoiceStatus.Draft,
+            CreatedAtUtc: DateTime.UtcNow,
+            IssuedAtUtc: null,
+            DueAtUtc: null,
+            PaidAtUtc: null,
+            VoidedAtUtc: null,
+            Notes: null,
+            LineItems: Array.Empty<InvoiceLineItemDto>(),
+            Purpose: InvoicePurpose.Usage,
+            PeriodStartUtc: null,
+            PeriodEndUtc: null);
+
+        var bytes = new InvoicePdfRenderer().Render(dto);
+
+        bytes.Length.ShouldBeGreaterThan(0);
+        Encoding.ASCII.GetString(bytes, 0, 4).ShouldBe("%PDF");
+    }
+}

--- a/src/Tests/Integration.Tests/Infrastructure/NoOpMailService.cs
+++ b/src/Tests/Integration.Tests/Infrastructure/NoOpMailService.cs
@@ -1,13 +1,25 @@
+using System.Collections.Concurrent;
 using FSH.Framework.Mailing;
 using FSH.Framework.Mailing.Services;
 
 namespace Integration.Tests.Infrastructure;
 
 /// <summary>
-/// No-op mail service for integration tests ��� prevents real SMTP calls
-/// and avoids Hangfire retry loops from email failures.
+/// Capturing no-op mail service for integration tests — prevents real SMTP calls (and Hangfire retry
+/// loops from email failures) while recording sent messages so tests can assert email behavior.
+/// Tests in the shared collection run sequentially, so <see cref="Clear"/> + act + assert is safe.
 /// </summary>
 internal sealed class NoOpMailService : IMailService
 {
-    public Task SendAsync(MailRequest request, CancellationToken ct) => Task.CompletedTask;
+    private readonly ConcurrentQueue<MailRequest> _sent = new();
+
+    public IReadOnlyList<MailRequest> Sent => _sent.ToArray();
+
+    public void Clear() => _sent.Clear();
+
+    public Task SendAsync(MailRequest request, CancellationToken ct)
+    {
+        _sent.Enqueue(request);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Tests/Integration.Tests/Tests/Billing/InvoicePdfTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/InvoicePdfTests.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using System.Text.Json;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Billing;
+
+/// <summary>
+/// Coverage for the invoice PDF download endpoint (<c>GET /api/v1/billing/invoices/{id}/pdf</c>):
+/// a tenant can download its own invoice as application/pdf, and the fetch is scoped to the caller's
+/// tenant so another tenant's invoice id resolves to 404 (no cross-tenant leak).
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class InvoicePdfTests
+{
+    private const string BillingBasePath = "/api/v1/billing";
+
+    private readonly AuthHelper _auth;
+
+    public InvoicePdfTests(FshWebApplicationFactory factory)
+    {
+        _auth = new AuthHelper(factory);
+    }
+
+    [Fact]
+    public async Task Tenant_Should_Download_Own_Invoice_AsPdf_And_NotAnotherTenants()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"pdf-{unique}";
+        var adminEmail = $"pdf-{unique}@tenant.com";
+        var planKey = await CreatePlanAsync(rootClient, $"pdf-m-{unique}", 29m);
+        await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+        await WaitForProvisioningAsync(rootClient, tenantId);
+
+        // The subscription invoice was issued on create; grab its id from the operator list.
+        var invoiceId = await GetFirstInvoiceIdAsync(rootClient, tenantId);
+
+        using var tenantClient = await CreateTenantAdminClientWithRetryAsync(adminEmail, TestConstants.DefaultPassword, tenantId);
+
+        // Own invoice → 200 application/pdf with a real PDF body.
+        using var ownResponse = await tenantClient.GetAsync($"{BillingBasePath}/invoices/{invoiceId}/pdf");
+        ownResponse.StatusCode.ShouldBe(HttpStatusCode.OK, await ownResponse.Content.ReadAsStringAsync());
+        ownResponse.Content.Headers.ContentType?.MediaType.ShouldBe("application/pdf");
+        var bytes = await ownResponse.Content.ReadAsByteArrayAsync();
+        bytes.Length.ShouldBeGreaterThan(0);
+        Encoding.ASCII.GetString(bytes, 0, 4).ShouldBe("%PDF");
+
+        // Cross-tenant: the root operator's own context has no such invoice → 404 (no leak).
+        using var crossResponse = await rootClient.GetAsync($"{BillingBasePath}/invoices/{invoiceId}/pdf");
+        crossResponse.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    private static async Task<string> GetFirstInvoiceIdAsync(HttpClient client, string tenantId)
+    {
+        var resp = await client.GetAsync($"{BillingBasePath}/invoices?tenantId={tenantId}&pageNumber=1&pageSize=50");
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var items = doc.RootElement.GetProperty("items");
+        items.GetArrayLength().ShouldBeGreaterThan(0, "the paid-plan tenant must have a subscription invoice");
+        return items[0].GetProperty("id").GetString()!;
+    }
+
+    private async Task<HttpClient> CreateTenantAdminClientWithRetryAsync(
+        string email, string password, string tenant, int maxRetries = 30)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+            }
+            catch (HttpRequestException) when (i < maxRetries - 1)
+            {
+                await Task.Delay(1000);
+            }
+        }
+        return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+    }
+
+    private static async Task<string> CreatePlanAsync(HttpClient client, string key, decimal monthlyBasePrice)
+    {
+        var resp = await client.PostAsJsonAsync($"{BillingBasePath}/plans",
+            new { key, name = $"Plan {key}", currency = "USD", monthlyBasePrice });
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        return key;
+    }
+
+    private static async Task CreateTenantAsync(HttpClient rootClient, string tenantId, string adminEmail, string planKey)
+    {
+        var response = await rootClient.PostAsJsonAsync(TestConstants.TenantsBasePath, new
+        {
+            id = tenantId,
+            name = $"Pdf {tenantId}",
+            connectionString = (string?)null,
+            adminEmail,
+            adminPassword = TestConstants.DefaultPassword,
+            issuer = $"{tenantId}.issuer",
+            planKey,
+        });
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Created, $"Create tenant failed: {body}");
+    }
+
+    private static async Task WaitForProvisioningAsync(HttpClient client, string tenantId, int maxRetries = 60)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            var statusResponse = await client.GetAsync($"{TestConstants.TenantsBasePath}/{tenantId}/provisioning");
+            if (statusResponse.IsSuccessStatusCode)
+            {
+                var content = await statusResponse.Content.ReadAsStringAsync();
+                if (content.Contains("Completed", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+                if (content.Contains("Failed", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Tenant {tenantId} provisioning failed: {content}");
+                }
+            }
+            await Task.Delay(1000);
+        }
+        throw new TimeoutException($"Tenant {tenantId} did not finish provisioning.");
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/AdjustTenantValidityTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/AdjustTenantValidityTests.cs
@@ -1,0 +1,229 @@
+#pragma warning disable S1144 // Unused private members — populated by JSON deserialization
+#pragma warning disable S3459 // Unassigned members — populated by JSON deserialization
+using System.Text.Json;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Multitenancy;
+
+/// <summary>
+/// Coverage for the operator validity override (<c>POST /api/v1/tenants/{id}/adjust-validity</c>):
+/// sets <c>ValidUpto</c> to an explicit date with no billing side-effect (no new invoice / subscription),
+/// allows backdating (immediate expiry) unlike renewal, and is root-only.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class AdjustTenantValidityTests
+{
+    private const string BillingBasePath = "/api/v1/billing";
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly FshWebApplicationFactory _factory;
+    private readonly AuthHelper _auth;
+
+    public AdjustTenantValidityTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _auth = new AuthHelper(factory);
+    }
+
+    [Fact]
+    public async Task AdjustValidity_Should_Set_ExplicitFutureDate_WithoutBillingSideEffect()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"adj-{unique}";
+        var planKey = await CreatePlanAsync(rootClient, $"adj-m-{unique}", monthlyBasePrice: 10m);
+        await CreateTenantAsync(rootClient, tenantId, $"adj-{unique}@tenant.com", planKey);
+
+        // The subscription invoice is created synchronously on tenant create; capture the count first.
+        var invoicesBefore = await GetInvoiceCountAsync(rootClient, tenantId);
+
+        var target = DateTime.UtcNow.AddYears(2);
+        var response = await rootClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId, validUpto = target });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+        var result = await response.Content.ReadFromJsonAsync<AdjustResult>(Json);
+        result.ShouldNotBeNull();
+        result.ValidUpto.ShouldBe(target, tolerance: TimeSpan.FromSeconds(1));
+
+        var status = await GetStatusAsync(rootClient, tenantId);
+        status.ValidUpto!.Value.ShouldBe(target, tolerance: TimeSpan.FromSeconds(1));
+        status.ExpiryState.ShouldBe("Active");
+
+        var invoicesAfter = await GetInvoiceCountAsync(rootClient, tenantId);
+        invoicesAfter.ShouldBe(invoicesBefore, "adjust-validity must not create an invoice");
+    }
+
+    [Fact]
+    public async Task AdjustValidity_Should_Allow_Backdating_ToExpireImmediately()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"adj-back-{unique}";
+        var planKey = await CreatePlanAsync(rootClient, $"adj-b-{unique}", monthlyBasePrice: 10m);
+        await CreateTenantAsync(rootClient, tenantId, $"adj-back-{unique}@tenant.com", planKey);
+
+        // Backdate well past the grace window — renewal would reject this; the override allows it.
+        var target = DateTime.UtcNow.AddDays(-30);
+        var response = await rootClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId, validUpto = target });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        var status = await GetStatusAsync(rootClient, tenantId);
+        status.ValidUpto!.Value.ShouldBe(target, tolerance: TimeSpan.FromSeconds(1));
+        status.ExpiryState.ShouldBe("Expired", "a tenant backdated past grace is expired");
+    }
+
+    [Fact]
+    public async Task AdjustValidity_Should_Return400_When_RouteIdDoesNotMatchBody()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"adj-mm-{unique}";
+        var planKey = await CreatePlanAsync(rootClient, $"adj-mm-{unique}", monthlyBasePrice: 5m);
+        await CreateTenantAsync(rootClient, tenantId, $"adj-mm-{unique}@tenant.com", planKey);
+
+        var response = await rootClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId = "some-other-tenant", validUpto = DateTime.UtcNow.AddMonths(1) });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AdjustValidity_Should_Return401_When_NotAuthenticated()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("tenant", TestConstants.RootTenantId);
+
+        var response = await client.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/anytenant/adjust-validity",
+            new { tenantId = "anytenant", validUpto = DateTime.UtcNow.AddMonths(1) });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AdjustValidity_Should_Forbid_When_CallerIsTenantAdmin()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"adj-authz-{unique}";
+        var adminEmail = $"adj-authz-{unique}@tenant.com";
+        var planKey = await CreatePlanAsync(rootClient, $"adj-az-{unique}", monthlyBasePrice: 5m);
+        await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+        await WaitForProvisioningAsync(rootClient, tenantId);
+
+        using var tenantClient = await CreateTenantAdminClientWithRetryAsync(
+            adminEmail, TestConstants.DefaultPassword, tenantId);
+
+        var response = await tenantClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId, validUpto = DateTime.UtcNow.AddMonths(1) });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    #region Helpers
+
+    private async Task<HttpClient> CreateTenantAdminClientWithRetryAsync(
+        string email, string password, string tenant, int maxRetries = 30)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+            }
+            catch (HttpRequestException) when (i < maxRetries - 1)
+            {
+                await Task.Delay(1000);
+            }
+        }
+        return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+    }
+
+    private static async Task<string> CreatePlanAsync(HttpClient client, string key, decimal monthlyBasePrice)
+    {
+        var resp = await client.PostAsJsonAsync($"{BillingBasePath}/plans",
+            new { key, name = $"Plan {key}", currency = "USD", monthlyBasePrice });
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        return key;
+    }
+
+    private static async Task CreateTenantAsync(HttpClient rootClient, string tenantId, string adminEmail, string planKey)
+    {
+        var response = await rootClient.PostAsJsonAsync(TestConstants.TenantsBasePath, new
+        {
+            id = tenantId,
+            name = $"Adjust {tenantId}",
+            connectionString = (string?)null,
+            adminEmail,
+            adminPassword = TestConstants.DefaultPassword,
+            issuer = $"{tenantId}.issuer",
+            planKey,
+        });
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Created, $"Create tenant failed: {body}");
+    }
+
+    private static async Task<long> GetInvoiceCountAsync(HttpClient client, string tenantId)
+    {
+        var resp = await client.GetAsync($"{BillingBasePath}/invoices?tenantId={tenantId}&pageNumber=1&pageSize=50");
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("totalCount").GetInt64();
+    }
+
+    private static async Task<TenantStatus> GetStatusAsync(HttpClient client, string tenantId)
+    {
+        var resp = await client.GetAsync($"{TestConstants.TenantsBasePath}/{tenantId}/status");
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var status = await resp.Content.ReadFromJsonAsync<TenantStatus>(Json);
+        status.ShouldNotBeNull();
+        return status!;
+    }
+
+    private static async Task WaitForProvisioningAsync(HttpClient client, string tenantId, int maxRetries = 60)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            var statusResponse = await client.GetAsync($"{TestConstants.TenantsBasePath}/{tenantId}/provisioning");
+            if (statusResponse.IsSuccessStatusCode)
+            {
+                var content = await statusResponse.Content.ReadAsStringAsync();
+                if (content.Contains("Completed", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+                if (content.Contains("Failed", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Tenant {tenantId} provisioning failed: {content}");
+                }
+            }
+            await Task.Delay(1000);
+        }
+        throw new TimeoutException($"Tenant {tenantId} did not finish provisioning.");
+    }
+
+    private sealed record AdjustResult(string TenantId, DateTime ValidUpto);
+
+    private sealed record TenantStatus
+    {
+        public string Id { get; init; } = string.Empty;
+        public bool IsActive { get; init; }
+        public DateTime? ValidUpto { get; init; }
+        public string? Plan { get; init; }
+        public string ExpiryState { get; init; } = string.Empty;
+    }
+
+    #endregion
+}

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/MyTenantStatusTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/MyTenantStatusTests.cs
@@ -1,0 +1,133 @@
+#pragma warning disable S1144, S3459
+using System.Text.Json;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Multitenancy;
+
+/// <summary>
+/// Coverage for the tenant-self status endpoint (<c>GET /api/v1/tenants/me/status</c>) that powers the
+/// dashboard's plan view + expiry banner: an authenticated tenant gets its own plan/validity/expiry
+/// state resolved from the caller context; an unauthenticated request is rejected.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class MyTenantStatusTests
+{
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly FshWebApplicationFactory _factory;
+    private readonly AuthHelper _auth;
+
+    public MyTenantStatusTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _auth = new AuthHelper(factory);
+    }
+
+    [Fact]
+    public async Task GetMyStatus_Should_Return_CallersOwn_Plan_And_ExpiryState()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"mystatus-{unique}";
+        var adminEmail = $"mystatus-{unique}@tenant.com";
+        var planKey = await CreatePlanAsync(rootClient, $"mystatus-m-{unique}", 10m);
+        await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+        await WaitForProvisioningAsync(rootClient, tenantId);
+
+        using var tenantClient = await CreateTenantAdminClientWithRetryAsync(adminEmail, TestConstants.DefaultPassword, tenantId);
+
+        var resp = await tenantClient.GetAsync($"{TestConstants.TenantsBasePath}/me/status");
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+
+        var status = await resp.Content.ReadFromJsonAsync<MyStatus>(Json);
+        status.ShouldNotBeNull();
+        status!.Id.ShouldBe(tenantId);
+        status.Plan.ShouldBe(planKey);
+        status.ExpiryState.ShouldBe("Active");
+    }
+
+    [Fact]
+    public async Task GetMyStatus_Should_Return401_When_Unauthenticated()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("tenant", TestConstants.RootTenantId);
+
+        var resp = await client.GetAsync($"{TestConstants.TenantsBasePath}/me/status");
+
+        resp.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<HttpClient> CreateTenantAdminClientWithRetryAsync(
+        string email, string password, string tenant, int maxRetries = 30)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+            }
+            catch (HttpRequestException) when (i < maxRetries - 1)
+            {
+                await Task.Delay(1000);
+            }
+        }
+        return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+    }
+
+    private static async Task<string> CreatePlanAsync(HttpClient client, string key, decimal monthlyBasePrice)
+    {
+        var resp = await client.PostAsJsonAsync("/api/v1/billing/plans",
+            new { key, name = $"Plan {key}", currency = "USD", monthlyBasePrice });
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        return key;
+    }
+
+    private static async Task CreateTenantAsync(HttpClient rootClient, string tenantId, string adminEmail, string planKey)
+    {
+        var response = await rootClient.PostAsJsonAsync(TestConstants.TenantsBasePath, new
+        {
+            id = tenantId,
+            name = $"MyStatus {tenantId}",
+            connectionString = (string?)null,
+            adminEmail,
+            adminPassword = TestConstants.DefaultPassword,
+            issuer = $"{tenantId}.issuer",
+            planKey,
+        });
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Created, $"Create tenant failed: {body}");
+    }
+
+    private static async Task WaitForProvisioningAsync(HttpClient client, string tenantId, int maxRetries = 60)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            var statusResponse = await client.GetAsync($"{TestConstants.TenantsBasePath}/{tenantId}/provisioning");
+            if (statusResponse.IsSuccessStatusCode)
+            {
+                var content = await statusResponse.Content.ReadAsStringAsync();
+                if (content.Contains("Completed", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+                if (content.Contains("Failed", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Tenant {tenantId} provisioning failed: {content}");
+                }
+            }
+            await Task.Delay(1000);
+        }
+        throw new TimeoutException($"Tenant {tenantId} did not finish provisioning.");
+    }
+
+    private sealed record MyStatus
+    {
+        public string Id { get; init; } = string.Empty;
+        public string? Plan { get; init; }
+        public string ExpiryState { get; init; } = string.Empty;
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
@@ -87,6 +87,49 @@ public sealed class RenewTenantTests
         status.Plan.ShouldBe(annual);
     }
 
+    [Fact]
+    public async Task RenewTenant_Should_Stack_Two_Terms_When_RenewedTwice()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"renew-x2-{unique}";
+        var planKey = await CreatePlanAsync(rootClient, $"x2-m-{unique}", monthlyBasePrice: 10m);
+        await CreateTenantAsync(rootClient, tenantId, $"renew-x2-{unique}@tenant.com", planKey);
+
+        var before = (await GetStatusAsync(rootClient, tenantId)).ValidUpto!.Value;
+
+        await RenewAsync(rootClient, tenantId, planKey);
+        await RenewAsync(rootClient, tenantId, planKey);
+
+        var after = (await GetStatusAsync(rootClient, tenantId)).ValidUpto!.Value;
+        // Two monthly terms stacked onto the validity present before the renewals.
+        after.ShouldBeGreaterThan(before.AddDays(58));
+        after.ShouldBeLessThan(before.AddDays(64));
+    }
+
+    [Fact]
+    public async Task RenewTenant_Should_StartFromNow_When_TenantHasLapsed()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"renew-lapsed-{unique}";
+        var planKey = await CreatePlanAsync(rootClient, $"lap-m-{unique}", monthlyBasePrice: 10m);
+        await CreateTenantAsync(rootClient, tenantId, $"renew-lapsed-{unique}@tenant.com", planKey);
+
+        // Lapse the tenant 30 days ago (operator override), then renew: stacking must restart from "now",
+        // not from the long-past validity, so the tenant gets a full term going forward.
+        var adjust = await rootClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId, validUpto = DateTime.UtcNow.AddDays(-30) });
+        adjust.StatusCode.ShouldBe(HttpStatusCode.OK, await adjust.Content.ReadAsStringAsync());
+
+        var result = await RenewAsync(rootClient, tenantId, planKey);
+
+        result.ValidUpto.ShouldBeGreaterThan(DateTime.UtcNow.AddDays(27),
+            "renewing a lapsed tenant must restart the term from now, not stack on the past validity");
+        result.ValidUpto.ShouldBeLessThan(DateTime.UtcNow.AddDays(32));
+    }
+
     #endregion
 
     #region Validation / Bad Request
@@ -180,6 +223,17 @@ public sealed class RenewTenantTests
             }
         }
         return await _auth.CreateAuthenticatedClientAsync(email, password, tenant);
+    }
+
+    private static async Task<RenewResult> RenewAsync(HttpClient client, string tenantId, string planKey)
+    {
+        var response = await client.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/renew",
+            new { tenantId, planKey });
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+        var result = await response.Content.ReadFromJsonAsync<RenewResult>(Json);
+        result.ShouldNotBeNull();
+        return result!;
     }
 
     private static async Task<string> CreatePlanAsync(HttpClient client, string key, decimal monthlyBasePrice)

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryEnforcementTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryEnforcementTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.Stores;
 using FSH.Framework.Shared.Multitenancy;
@@ -51,6 +52,31 @@ public sealed class TenantExpiryEnforcementTests
             "a lapsed tenant within the grace window must still be allowed through the guard");
     }
 
+    [Fact]
+    public async Task LapsedTenant_WithinGrace_Should_Emit_GraceHeader()
+    {
+        var tenantId = await CreateTenantAsync();
+
+        // One day past expiry — inside the 7-day grace window.
+        await SetTenantValidityAsync(tenantId, DateTime.UtcNow.AddDays(-1));
+
+        var (status, grace) = await ProbeAsync(tenantId);
+
+        status.ShouldNotBe(HttpStatusCode.Forbidden);
+        grace.ShouldNotBeNull("a tenant in the grace window must receive the X-Subscription-Grace header");
+        int.Parse(grace!, CultureInfo.InvariantCulture).ShouldBeInRange(1, 7);
+    }
+
+    [Fact]
+    public async Task ActiveTenant_Should_Not_Emit_GraceHeader()
+    {
+        var tenantId = await CreateTenantAsync();
+
+        var (_, grace) = await ProbeAsync(tenantId);
+
+        grace.ShouldBeNull("an active (non-lapsed) tenant must not receive the grace header");
+    }
+
     private async Task<string> CreateTenantAsync()
     {
         using var adminClient = await _auth.CreateRootAdminClientAsync();
@@ -93,12 +119,24 @@ public sealed class TenantExpiryEnforcementTests
 
     private async Task<HttpStatusCode> TryIssueTokenAsync(string tenantId)
     {
+        var (status, _) = await ProbeAsync(tenantId);
+        return status;
+    }
+
+    // Probes the post-auth guard with an anonymous token-issue request scoped to the tenant header,
+    // returning the response status plus the X-Subscription-Grace header (null when absent). The guard
+    // runs before the token handler, so the grace header is set regardless of the credential outcome.
+    private async Task<(HttpStatusCode Status, string? Grace)> ProbeAsync(string tenantId)
+    {
         using var client = _factory.CreateClient();
         using var request = new HttpRequestMessage(
             HttpMethod.Post, $"{TestConstants.IdentityBasePath}/token/issue");
         request.Headers.Add("tenant", tenantId);
         request.Content = JsonContent.Create(new { email = "nobody@example.com", password = "Wrong-Password-1!" });
         using var response = await client.SendAsync(request);
-        return response.StatusCode;
+        var grace = response.Headers.TryGetValues("X-Subscription-Grace", out var values)
+            ? values.FirstOrDefault()
+            : null;
+        return (response.StatusCode, grace);
     }
 }

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryScanJobTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryScanJobTests.cs
@@ -1,0 +1,120 @@
+using FSH.Framework.Mailing.Services;
+using FSH.Modules.Multitenancy.Data;
+using FSH.Modules.Multitenancy.Domain;
+using FSH.Modules.Multitenancy.Services;
+using Integration.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Integration.Tests.Tests.Multitenancy;
+
+/// <summary>
+/// Coverage for the daily tenant-expiry notification pipeline: the scan job records a dedup notice and
+/// publishes the matching event (which emails the tenant admin), and re-running the scan does not
+/// re-notify the same state for the same validity period. Also covers the invoice-issued email.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class TenantExpiryScanJobTests
+{
+    private const string BillingBasePath = "/api/v1/billing";
+
+    private readonly FshWebApplicationFactory _factory;
+    private readonly AuthHelper _auth;
+
+    public TenantExpiryScanJobTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _auth = new AuthHelper(factory);
+    }
+
+    [Fact]
+    public async Task ScanJob_Should_Record_GraceNotice_Dedup_And_Email()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"scan-{unique}";
+        var adminEmail = $"scan-{unique}@tenant.com";
+        var planKey = await CreatePlanAsync(rootClient, $"scan-m-{unique}", 10m);
+        await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+
+        // Lapse into the grace window (1 day past ValidUpto).
+        var adjust = await rootClient.PostAsJsonAsync(
+            $"{TestConstants.TenantsBasePath}/{tenantId}/adjust-validity",
+            new { tenantId, validUpto = DateTime.UtcNow.AddDays(-1) });
+        adjust.StatusCode.ShouldBe(HttpStatusCode.OK, await adjust.Content.ReadAsStringAsync());
+
+        var mail = (NoOpMailService)_factory.Services.GetRequiredService<IMailService>();
+        mail.Clear();
+
+        await RunScanAsync();
+        (await CountNoticesAsync(tenantId, TenantExpiryNoticeTypes.EnteredGrace))
+            .ShouldBe(1, "the first scan must record one grace notice");
+
+        // Dedup: a second scan must not re-notify the same state for the same validity period.
+        await RunScanAsync();
+        (await CountNoticesAsync(tenantId, TenantExpiryNoticeTypes.EnteredGrace))
+            .ShouldBe(1, "the scan must not re-notify the same state for the same validity period");
+
+        mail.Sent.ShouldContain(
+            m => m.To.Contains(adminEmail) && m.Subject.Contains("grace", StringComparison.OrdinalIgnoreCase),
+            "the grace notice must email the tenant admin");
+    }
+
+    [Fact]
+    public async Task InvoiceIssued_Should_Email_TenantAdmin_OnPaidPlan()
+    {
+        using var rootClient = await _auth.CreateRootAdminClientAsync();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var tenantId = $"inv-{unique}";
+        var adminEmail = $"inv-{unique}@tenant.com";
+        var planKey = await CreatePlanAsync(rootClient, $"inv-m-{unique}", 19m);
+
+        var mail = (NoOpMailService)_factory.Services.GetRequiredService<IMailService>();
+        mail.Clear();
+
+        // Creating a tenant on a paid plan issues the subscription invoice synchronously, which emails the admin.
+        await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+
+        mail.Sent.ShouldContain(
+            m => m.To.Contains(adminEmail) && m.Subject.Contains("Invoice", StringComparison.OrdinalIgnoreCase),
+            "issuing the subscription invoice must email the tenant admin");
+    }
+
+    private async Task RunScanAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var job = scope.ServiceProvider.GetRequiredService<TenantExpiryScanJob>();
+        await job.RunAsync(CancellationToken.None);
+    }
+
+    private async Task<int> CountNoticesAsync(string tenantId, string noticeType)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TenantDbContext>();
+        return await db.TenantExpiryNotices.CountAsync(x => x.TenantId == tenantId && x.NoticeType == noticeType);
+    }
+
+    private static async Task<string> CreatePlanAsync(HttpClient client, string key, decimal monthlyBasePrice)
+    {
+        var resp = await client.PostAsJsonAsync($"{BillingBasePath}/plans",
+            new { key, name = $"Plan {key}", currency = "USD", monthlyBasePrice });
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK, await resp.Content.ReadAsStringAsync());
+        return key;
+    }
+
+    private static async Task CreateTenantAsync(HttpClient rootClient, string tenantId, string adminEmail, string planKey)
+    {
+        var response = await rootClient.PostAsJsonAsync(TestConstants.TenantsBasePath, new
+        {
+            id = tenantId,
+            name = $"Scan {tenantId}",
+            connectionString = (string?)null,
+            adminEmail,
+            adminPassword = TestConstants.DefaultPassword,
+            issuer = $"{tenantId}.issuer",
+            planKey,
+        });
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Created, $"Create tenant failed: {body}");
+    }
+}

--- a/src/Tests/Multitenancy.Tests/Services/TenantServiceRenewClockTests.cs
+++ b/src/Tests/Multitenancy.Tests/Services/TenantServiceRenewClockTests.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Shared.Persistence;
 using FSH.Modules.Multitenancy;
 using FSH.Modules.Multitenancy.Provisioning;
 using FSH.Modules.Multitenancy.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 
@@ -34,7 +35,8 @@ public sealed class TenantServiceRenewClockTests
             dbContext: null!,            // RenewAsync never touches the DbContext
             provisioningService: null!,  // RenewAsync never touches provisioning
             _clock,
-            Options.Create(new TenantBillingOptions()));
+            Options.Create(new TenantBillingOptions()),
+            NullLogger<TenantService>.Instance);
     }
 
     [Fact]

--- a/src/Tests/Multitenancy.Tests/Services/TenantServiceRenewClockTests.cs
+++ b/src/Tests/Multitenancy.Tests/Services/TenantServiceRenewClockTests.cs
@@ -1,0 +1,66 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Framework.Shared.Persistence;
+using FSH.Modules.Multitenancy;
+using FSH.Modules.Multitenancy.Provisioning;
+using FSH.Modules.Multitenancy.Services;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Multitenancy.Tests.Services;
+
+/// <summary>
+/// Guards that <see cref="TenantService.RenewAsync"/> derives "now" from the injected
+/// <see cref="TimeProvider"/> (not <c>DateTime.UtcNow</c>), so the renewal stacking math is
+/// clock-controllable and consistent with the rest of the service.
+/// </summary>
+public sealed class TenantServiceRenewClockTests
+{
+    private readonly IMultiTenantStore<AppTenantInfo> _store = Substitute.For<IMultiTenantStore<AppTenantInfo>>();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly TimeProvider _clock = Substitute.For<TimeProvider>();
+
+    private TenantService CreateSut()
+    {
+        // RefreshTenantCacheAsync resolves IEnumerable<IMultiTenantStore<...>>; return empty so it no-ops.
+        _serviceProvider
+            .GetService(typeof(IEnumerable<IMultiTenantStore<AppTenantInfo>>))
+            .Returns(Array.Empty<IMultiTenantStore<AppTenantInfo>>());
+
+        return new TenantService(
+            _store,
+            Options.Create(new DatabaseOptions { ConnectionString = "Host=localhost;Database=fsh;Username=x;Password=y" }),
+            _serviceProvider,
+            dbContext: null!,            // RenewAsync never touches the DbContext
+            provisioningService: null!,  // RenewAsync never touches provisioning
+            _clock,
+            Options.Create(new TenantBillingOptions()));
+    }
+
+    [Fact]
+    public async Task RenewAsync_Should_DeriveNow_FromInjectedTimeProvider_When_ValidityIsInThePast()
+    {
+        // Arrange: a fixed fake "now" far from the real wall clock so a DateTime.UtcNow regression diverges.
+        var fakeNow = new DateTimeOffset(2031, 3, 15, 0, 0, 0, TimeSpan.Zero);
+        _clock.GetUtcNow().Returns(fakeNow);
+
+        const string tenantId = "acme";
+        var tenant = new AppTenantInfo(tenantId, "Acme", connectionString: null, adminEmail: "admin@acme.test")
+        {
+            Plan = "pro",
+            // Past relative to both the real clock and the fake clock, so periodStart must equal "now".
+            ValidUpto = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        _store.GetAsync(tenantId).Returns(tenant);
+
+        var sut = CreateSut();
+
+        // Act: renew one monthly term.
+        var (periodStart, validUpto, planChanged) = await sut.RenewAsync(tenantId, "pro", termMonths: 1, CancellationToken.None);
+
+        // Assert: stacking starts from the injected clock, not the system clock.
+        periodStart.ShouldBe(fakeNow.UtcDateTime);
+        validUpto.ShouldBe(fakeNow.UtcDateTime.AddMonths(1));
+        planChanged.ShouldBeFalse();
+    }
+}

--- a/src/Tests/Multitenancy.Tests/Services/TenantServiceStatusBoundaryTests.cs
+++ b/src/Tests/Multitenancy.Tests/Services/TenantServiceStatusBoundaryTests.cs
@@ -1,0 +1,58 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Framework.Shared.Persistence;
+using FSH.Modules.Multitenancy;
+using FSH.Modules.Multitenancy.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Multitenancy.Tests.Services;
+
+/// <summary>
+/// Pins the expiry-state transitions in <see cref="TenantService.GetStatusAsync"/> exactly at the
+/// ValidUpto and grace-window boundaries, so the Active → InGrace → Expired badges never drift.
+/// Grace window is fixed at 7 days for these cases.
+/// </summary>
+public sealed class TenantServiceStatusBoundaryTests
+{
+    private const int GraceDays = 7;
+    private static readonly DateTime ValidUpto = new(2031, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly IMultiTenantStore<AppTenantInfo> _store = Substitute.For<IMultiTenantStore<AppTenantInfo>>();
+    private readonly TimeProvider _clock = Substitute.For<TimeProvider>();
+
+    [Theory]
+    [InlineData(0, "Active")]                       // exactly at ValidUpto
+    [InlineData(1, "InGrace")]                      // 1 second past ValidUpto
+    [InlineData(GraceDays * 24 * 3600, "InGrace")]  // exactly at grace end
+    [InlineData(GraceDays * 24 * 3600 + 1, "Expired")] // 1 second past grace end
+    public async Task GetStatusAsync_Should_ResolveExpiryState_AtBoundary(double offsetSecondsFromValidUpto, string expected)
+    {
+        const string tenantId = "acme";
+        var now = ValidUpto.AddSeconds(offsetSecondsFromValidUpto);
+        _clock.GetUtcNow().Returns(new DateTimeOffset(now, TimeSpan.Zero));
+
+        var tenant = new AppTenantInfo(tenantId, "Acme", connectionString: null, adminEmail: "admin@acme.test")
+        {
+            Plan = "pro",
+            ValidUpto = ValidUpto,
+        };
+        _store.GetAsync(tenantId).Returns(tenant);
+
+        var sut = new TenantService(
+            _store,
+            Options.Create(new DatabaseOptions { ConnectionString = "Host=localhost;Database=fsh;Username=x;Password=y" }),
+            serviceProvider: null!,
+            dbContext: null!,
+            provisioningService: null!,
+            _clock,
+            Options.Create(new TenantBillingOptions { GraceWindowDays = GraceDays }),
+            NullLogger<TenantService>.Instance);
+
+        var status = await sut.GetStatusAsync(tenantId, CancellationToken.None);
+
+        status.ExpiryState.ShouldBe(expected);
+        status.GraceEndsUtc.ShouldBe(ValidUpto.AddDays(GraceDays));
+    }
+}

--- a/superpowers/plans/2026-05-28-tenant-billing-production.md
+++ b/superpowers/plans/2026-05-28-tenant-billing-production.md
@@ -1,0 +1,182 @@
+# Tenant Billing — Production Hardening & Completion Implementation Plan
+
+> **For agentic workers:** execute task-by-task with TDD (red→green→commit). Steps use checkbox syntax.
+> Spec: `superpowers/specs/2026-05-28-tenant-billing-production-hardening-design.md`. Read it first.
+
+**Goal:** Complete the tenant-billing SaaS feature to production grade — backend hardening, expiry/renewal
+notifications, PDF invoices, tenant-facing dashboard (view + warnings), and full regression/integration tests.
+
+**Architecture:** Invoice-as-record (no gateway), no proration, event-driven side effects via in-memory
+`IEventBus`, daily Hangfire scan for expiry notifications, on-demand QuestPDF behind `IInvoicePdfRenderer`.
+
+**Tech Stack:** .NET 10, EF Core 10, Mediator, FluentValidation, Hangfire, QuestPDF, xUnit + Shouldly +
+NSubstitute + Testcontainers, React 19 + Vite + TanStack Query + Playwright.
+
+**Conventions (every task):** handlers `public sealed`, `ValueTask<T>`, `.ConfigureAwait(false)` on awaits,
+propagate `CancellationToken`, structured logging, `TreatWarningsAsErrors`. Build clean + green tests
+before each commit. Verify current code before writing a test (the audit had wrong claims — e.g. indexes
+already exist).
+
+---
+
+## Phase A — Backend hardening
+
+### Task A1 — Fix the renewal clock bug
+**Files:** Modify `src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs:203`.
+- [ ] Add/confirm `Multitenancy.Tests` (or integration) test that renewal stacking uses the injected clock:
+      with a `FakeTimeProvider` set to T, renew a tenant whose `ValidUpto < T` ⇒ new `ValidUpto == T + term`.
+- [ ] Replace `var now = DateTime.UtcNow;` with `var now = _timeProvider.GetUtcNow().UtcDateTime;`.
+- [ ] Build + test green. Commit `fix(billing): use injected TimeProvider in TenantService.RenewAsync`.
+
+### Task A2 — `X-Subscription-Grace` response header
+**Files:** Modify `MultitenancyModule.cs` grace branch (~lines 194-202).
+- [ ] Integration test: a non-root tenant with `ValidUpto < now <= ValidUpto+grace` gets a 2xx with header
+      `X-Subscription-Grace` = ceil(days left); an Active tenant has no header; past grace ⇒ 403 (unchanged).
+- [ ] In the grace branch, before `await next`, when `nowUtc <= ValidUpto+grace && nowUtc > ValidUpto`, set
+      `ctx.Response.Headers["X-Subscription-Grace"] = ((int)Math.Ceiling((tenant.ValidUpto.AddDays(graceDays) - nowUtc).TotalDays)).ToString(CultureInfo.InvariantCulture)`.
+      Use `ctx.Response.OnStarting` if headers risk being sent — simplest: set before calling next (guard endpoints don't write before).
+- [ ] Build + test green. Commit `feat(billing): emit X-Subscription-Grace header during grace window`.
+
+### Task A4 — `AdjustTenantValidityCommand` (operator override)
+**Files:**
+- Create `…Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommand.cs` + `…Response.cs`.
+- Create `…Multitenancy/Features/v1/AdjustTenantValidity/{Handler,Validator,Endpoint}.cs`.
+- Add `ITenantService.AdjustValidityAsync` + impl in `TenantService.cs`.
+- Register endpoint in `MultitenancyModule.MapEndpoints`.
+- Test: `Integration.Tests/Tests/Multitenancy/AdjustTenantValidityTests.cs`.
+
+Contract: `record AdjustTenantValidityCommand(string TenantId, DateTime ValidUpto) : ICommand<AdjustTenantValidityCommandResponse>;`
+Response: `record AdjustTenantValidityCommandResponse(string TenantId, DateTime ValidUpto);`
+Service: `Task<DateTime> AdjustValidityAsync(string id, DateTime validUpto, CancellationToken ct)` — load tenant,
+`tenant.ValidUpto = DateTime.SpecifyKind(validUpto, DateTimeKind.Utc)` (direct set ⇒ allows backdating for
+comps/immediate-expire), `UpdateAsync` + `RefreshTenantCacheAsync`, log `[Multitenancy] adjusted validity…`. No event, no invoice.
+Endpoint: `POST /{id}/adjust-validity`, `RequirePermission(MultitenancyPermissions.Tenants.UpgradeSubscription)`
+(reuse — root-only operator validity action), body/route id match guard like RenewTenant.
+Validator: `TenantId` NotEmpty; `ValidUpto` must be a real date (not default).
+- [ ] Tests (red): sets ValidUpto (future + past), no Subscription/Invoice created, root-only (403 for tenant admin), reflected in GetStatus.
+- [ ] Implement contract → service → handler → validator → endpoint → register.
+- [ ] Build + tests green. Commit `feat(billing): operator AdjustTenantValidity override (no invoice)`.
+
+### Task A-E — Backend regression tests (verify-then-fill; many may already exist)
+**Files:** `Integration.Tests/Tests/Multitenancy/*`, `Integration.Tests/Tests/Billing/*`, `Billing.Tests/*`.
+For each, first read the existing test file to confirm it's missing, then add only the gap:
+- [ ] Expiry-state boundaries in `TenantService.GetStatusAsync` (unit, `FakeTimeProvider`): now==ValidUpto⇒Active,
+      now==graceEnds⇒InGrace, now==graceEnds+1s⇒Expired, now==ValidUpto+1s⇒InGrace.
+- [ ] Grace enforcement boundaries (middleware + Identity login): at ValidUpto allowed, at graceEnds allowed,
+      graceEnds+1s ⇒ 403 (middleware) / 401 (login).
+- [ ] Renewal: double-renew stacks ≈2 terms; renew-in-grace starts from now; renew-with-different-plan swaps
+      active subscription (old Cancelled, EndUtc==new.StartUtc) + new subscription invoice + PlanChanged=true.
+- [ ] Single-active-subscription invariant after plan change; forced second active row violates
+      `ux_subscriptions_tenantid_active`.
+- [ ] Event-handler idempotency: redeliver same `TenantSubscribedIntegrationEvent` Id ⇒ one subscription + one invoice.
+- [ ] Plan seeding: `BillingDbInitializer` seeds free/pro/pro-annual w/ correct interval/price; idempotent on re-run.
+- [ ] Invoice state machine at endpoint: Void→mark-paid rejected; Paid→void rejected.
+- [ ] Commit per coherent group `test(billing): …`.
+
+**Phase A gate:** `dotnet build src/FSH.Starter.slnx` clean; `dotnet test` Billing+Multitenancy+Integration green.
+
+---
+
+## Phase B — Notifications (read patterns just-in-time, then implement)
+
+### Task B1 — Integration events
+- [ ] Create in `Multitenancy.Contracts/Events/`: `TenantNearingExpiryIntegrationEvent` (+`int DaysRemaining`),
+      `TenantEnteredGraceIntegrationEvent`, `TenantExpiredIntegrationEvent`. Fields mirror
+      `TenantSubscribedIntegrationEvent` + `TenantName, AdminEmail, PlanKey, ValidUpto, GraceEndsUtc`.
+- [ ] Create in `Billing.Contracts/Events/`: `InvoiceIssuedIntegrationEvent(Id, OccurredOnUtc, TenantId,
+      CorrelationId, Source, InvoiceId, InvoiceNumber, decimal Amount, string Currency, DateTime? DueAtUtc, int PeriodYear, int PeriodMonth)`.
+- [ ] Commit `feat(billing): add expiry + invoice-issued integration events`.
+
+### Task B2 — Publish `InvoiceIssued` from the subscription-invoice handlers
+- [ ] In `BillingService.CreateSubscriptionInvoiceAsync` (or the two integration-event handlers after issue),
+      publish `InvoiceIssuedIntegrationEvent` via the same `IEventBus` already injected. Only when an invoice
+      was actually issued (skip free/zero-price). Integration test asserts publish on subscription invoice.
+- [ ] Commit.
+
+### Task B3 — `TenantExpiryNotice` dedup entity in `TenantDbContext`
+- [ ] Domain entity `Modules.Multitenancy/Domain/TenantExpiryNotice.cs` (`Id, TenantId, NoticeType (string/enum),
+      ValidUptoUtc, CreatedAtUtc`), EF config with unique `(TenantId, NoticeType, ValidUptoUtc)`, `DbSet` on TenantDbContext.
+- [ ] Migration in `FSH.Starter.Migrations.PostgreSQL` (tenant schema). Full-build before `migrations add`.
+- [ ] Commit.
+
+### Task B4 — `TenantExpiryScanJob` (Multitenancy)
+- [ ] `Services/TenantExpiryScanJob.cs` `RunAsync(CancellationToken)`; inject `IMultiTenantStore<AppTenantInfo>`,
+      `IEventBus`, `IOptions<TenantBillingOptions>`, `TenantDbContext`, `TimeProvider`, `ILogger`. For each active
+      non-root tenant compute state; check-or-insert `TenantExpiryNotice`; publish the one matching event; per-tenant try/catch.
+- [ ] Register recurring in `MultitenancyModule.MapEndpoints`: `IRecurringJobManager.AddOrUpdate("tenant-expiry-scan",
+      Job.FromExpression<TenantExpiryScanJob>(j => j.RunAsync(CancellationToken.None)), "0 2 * * *", new RecurringJobOptions{TimeZone=TimeZoneInfo.Utc})`.
+- [ ] Add `TenantBillingOptions.ExpiryNotificationLeadDays = 7`.
+- [ ] Unit tests (NSubstitute `IEventBus`): correct event per state incl. boundaries; root/inactive excluded.
+      Integration: run twice ⇒ dedup prevents second publish.
+- [ ] Commit `feat(billing): daily tenant expiry scan job + dedup ledger`.
+
+### Task B5 — Notifications email handlers
+- [ ] `Modules.Notifications/IntegrationEventHandlers/{Nearing,EnteredGrace,Expired,InvoiceIssued}EmailHandler.cs`
+      (sealed, `IIntegrationEventHandler<T>`), inject `IMailService` + `ILogger`. Build `MailRequest` via private
+      `BillingEmailBodies` helper (subject + HTML). try/catch + warn-log (never throw).
+- [ ] Ensure `Modules.Notifications` references `Multitenancy.Contracts` + `Billing.Contracts`.
+- [ ] Integration test: subscription invoice issue ⇒ `IMailService.SendAsync` received (fake/substitute mail service in the factory).
+- [ ] Commit `feat(notifications): email tenant on expiry states + invoice issued`.
+
+**Phase B gate:** build clean; tests green; `dotnet run --project DbMigrator -- apply` works locally.
+
+---
+
+## Phase C — PDF invoices
+
+### Task C1 — `IInvoicePdfRenderer` + QuestPDF impl
+- [ ] Add QuestPDF package to `Modules.Billing`; set `QuestPDF.Settings.License = LicenseType.Community` at module init.
+- [ ] `Services/IInvoicePdfRenderer.cs` `byte[] Render(InvoiceDto invoice)`; `Services/InvoicePdfRenderer.cs`
+      builds A4: header (number/status/dates), bill-to tenant, period, line-items table, subtotal, notes; 2dp currency.
+- [ ] Register in DI. Unit test: returns non-empty `%PDF`-prefixed bytes for a representative `InvoiceDto`.
+- [ ] Commit `feat(billing): on-demand invoice PDF renderer (QuestPDF)`.
+
+### Task C2 — PDF endpoints
+- [ ] `GET /api/v1/billing/invoices/{id}/pdf` (operator, Billing.View) and `GET …/invoices/me/{id}/pdf`
+      (tenant-self, 404 cross-tenant). Return `Results.File(bytes, "application/pdf", $"{number}.pdf")`.
+- [ ] Integration tests: operator 200 any invoice; tenant-self 200 own, 404 other tenant.
+- [ ] Commit `feat(billing): invoice PDF download endpoints`.
+
+**Phase C gate:** build clean; tests green.
+
+---
+
+## Phase D — Dashboard self-serve + admin glue (read existing FE just-in-time)
+
+### Task D1 — `tenants/me/status` endpoint (backend)
+- [ ] `GET /api/v1/tenants/me/status` resolving the calling tenant from context; returns trimmed status
+      (plan, validUpto, expiryState, graceEndsUtc). Any authenticated tenant user. Integration test + 401 unauth.
+- [ ] Commit.
+
+### Task D2 — Dashboard subscription page + expiry banner + invoice detail + PDF (clients/dashboard)
+- [ ] api/billing.ts: fix `SubscriptionStatus` to `Active|Suspended|Cancelled`; type invoice line items; add
+      `getMyStatus()` + `getMyInvoice(id)` + `invoicePdfUrl(id)`.
+- [ ] `/subscription` page (plan, validity, expiry badge, usage with limits/overage, recent invoices), nav entry, lazy route.
+- [ ] Global expiry/grace banner in AppShell driven by `getMyStatus` (staleTime ~5m); shows for InGrace + within lead days.
+- [ ] Invoice detail page with line items + Download PDF.
+- [ ] Playwright: subscription page renders; banner shows for InGrace + nearing mocks; invoice detail PDF download request.
+- [ ] Commit `feat(dashboard): tenant subscription page + expiry banners + invoice PDF`.
+
+### Task D3 — Admin glue (clients/admin)
+- [ ] Download PDF button on invoice detail (`invoices/{id}/pdf`).
+- [ ] Adjust-validity dialog on tenant detail (date picker → `POST /tenants/{id}/adjust-validity`), root-gated.
+- [ ] Plan-form client validation: non-negative monthlyBasePrice/annualPrice/overage.
+- [ ] Playwright: PDF button request; adjust-validity posts; plan-form rejects negatives.
+- [ ] Commit `feat(admin): invoice PDF download + adjust-validity + plan-form validation`.
+
+**Phase D gate:** `npm run build` + `npx playwright test` green in both apps (route-mocked).
+
+---
+
+## Final
+- [ ] `dotnet build src/FSH.Starter.slnx` (TreatWarningsAsErrors) + full `dotnet test` (Docker up).
+- [ ] Both frontends: typecheck/lint/build + Playwright.
+- [ ] Docs repo (`C:\Users\mukesh\repos\fullstackhero\docs`) + changelog (golden rule #10): new config key,
+      new endpoints, QuestPDF license note, dashboard subscription page + banners, expiry/renewal emails.
+- [ ] Update memory `project_tenant_billing_lifecycle.md` (Phases 3–4 + dashboard + tests done).
+
+## Self-review notes
+- Spec coverage: A1/A2/A4 + A-E (A3 dropped — indexes already exist), B1–B5, C1–C2, D1–D3, Final → all spec
+  sections mapped. No payment-gateway / proration tasks (out of scope, confirmed).
+- Verify-before-write is mandatory: the audit wrongly claimed missing indexes; existing tests
+  (RenewTenantTests, TenantExpiryEnforcementTests, BillingEndpointTests, etc.) cover happy paths — only add gaps.

--- a/superpowers/specs/2026-05-28-tenant-billing-production-hardening-design.md
+++ b/superpowers/specs/2026-05-28-tenant-billing-production-hardening-design.md
@@ -1,0 +1,281 @@
+# Tenant Billing — Production Hardening & Completion (Phases 3–4 + Dashboard + Tests)
+
+**Date:** 2026-05-28
+**Branch:** `feat/tenant-activation-confirm` (current) → new work branch `feat/tenant-billing-production`
+**Status:** Approved (user directed autonomous implementation)
+**Builds on:** `superpowers/specs/2026-05-28-tenant-billing-lifecycle-design.md` (the original lifecycle spec — read it first; this spec is the completion/hardening delta).
+
+## Problem
+
+The tenant billing lifecycle (the SaaS product's headline feature) shipped Phase 1 (core backend) and
+Phase 2 (admin UI) via PR #1269. It is **not yet complete or fully production-grade**:
+
+- Phase 3 (expiry/renewal **notifications**) and Phase 4 (**PDF invoices**) were deferred.
+- The **tenant-facing dashboard** has only a read-only invoice list + a usage widget — no plan/validity
+  view, no expiry/grace warnings, no invoice detail, no PDF, and a `SubscriptionStatus` enum that
+  doesn't match the backend.
+- One real **bug**: `TenantService.RenewAsync` uses `DateTime.UtcNow` instead of the injected
+  `TimeProvider` (clock not controllable; inconsistent with its own handler).
+- **Edge-case test gaps**: event-handler idempotency, grace-window boundaries, double-renew /
+  renew-in-grace, plan seeding, single-active-subscription invariant, invoice state-machine guards at
+  the endpoint, usage-snapshot uniqueness.
+
+This spec completes the feature and hardens it. **Payment model stays invoice-as-record (no gateway);
+no proration; dashboard is view + warnings (operator still renews)** — confirmed with the user.
+
+## Locked decisions (this pass)
+
+1. **Invoice-as-record, no payment gateway** — unchanged. Access is gated by `ValidUpto` + grace, not by
+   payment.
+2. **No proration** — renew/change-plan stacks a full term and issues a full-term invoice.
+3. **Dashboard = view + warnings**; renewal/plan-change remains an operator action in admin.
+4. **PDF engine = QuestPDF**, isolated behind `IInvoicePdfRenderer`. The QuestPDF Community license is
+   free only for orgs < $1M USD/yr revenue — **documented** in the docs repo + changelog; swappable
+   because it sits behind the interface.
+5. **Include `AdjustTenantValidityCommand`** — operator validity override for comps/support (no invoice,
+   no event, audit-noted).
+6. **Notifications push = email** (`IMailService`, hand-built HTML). The dashboard banner is the pull
+   side. No cross-resolving Identity user IDs for in-app expiry toasts in this pass.
+
+## Workstream A — Backend hardening
+
+### A1. Clock fix (`TenantService.RenewAsync`)
+`src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs:203` — replace
+`var now = DateTime.UtcNow;` with `var now = _timeProvider.GetUtcNow().UtcDateTime;`. The
+`TimeProvider` is already injected (line 26/45). No behavior change in prod; makes the stacking logic
+clock-controllable for tests and consistent with `GetStatusAsync` / the handler.
+
+### A2. `X-Subscription-Grace` response header
+`MultitenancyModule` post-auth guard (the existing expiry block): when a non-root tenant is **past
+`ValidUpto` but within grace**, add response header `X-Subscription-Grace: <daysLeft>` (integer,
+ceil of remaining days). Hard-block (403) past grace stays as-is. Active tenants get no header. This is
+a cheap signal for clients; the dashboard banner does not depend on it (it uses `tenants/me/status`).
+
+### A3. Indexes (one Billing migration)
+- `UsageSnapshot`: **unique** index on `(TenantId, PeriodYear, PeriodMonth, Resource)` — promotes the
+  current app-only idempotency to a DB invariant.
+- `Subscription`: **non-unique** index on `(TenantId, Status)` — speeds the "find active subscription"
+  lookup used by the replace flow + monthly job. Deliberately **not** a partial-unique index on active:
+  the cancel-old/create-new replace runs in one `SaveChanges` and Postgres checks unique constraints
+  per-statement, so a unique-active index could trip transiently. The single-active invariant is
+  enforced by app logic + asserted by an integration test (E).
+
+Migration lives in `FSH.Starter.Migrations.PostgreSQL` under the Billing folder. Full-build before
+`migrations add` (the snapshot footgun). No tenant-store schema change.
+
+### A4. `AdjustTenantValidityCommand` (operator override)
+- Contract: `Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommand.cs`
+  `record AdjustTenantValidityCommand(string TenantId, DateTime ValidUpto) : ICommand<...Response>`.
+- Handler: load tenant, `tenant.SetValidity(validUpto)` (forward-only — see
+  `[[project_apptenantinfo_setvalidity_forward_only]]`; if a backdate is required, set the property
+  directly with a guard + log), `UpdateAsync`, refresh cache. **No** event, **no** invoice.
+- Validator: `TenantId` NotEmpty; `ValidUpto` must be UTC-specifiable.
+- Endpoint: `POST /api/v1/tenants/{id}/adjust-validity`, root-operator permission only (mirror the
+  RenewTenant permission/guard).
+- Admin UI action (Workstream D-admin): a small "Adjust validity" action on the tenant detail page.
+
+## Workstream B — Phase 3: Notifications
+
+### B1. New integration events
+In `Modules.Multitenancy.Contracts/Events/` (tenant lifecycle owns these; the scan job lives in
+Multitenancy):
+- `TenantNearingExpiryIntegrationEvent` — `+ int DaysRemaining`.
+- `TenantEnteredGraceIntegrationEvent`.
+- `TenantExpiredIntegrationEvent`.
+
+Common fields (mirror `TenantSubscribedIntegrationEvent`): `Id, OccurredOnUtc, TenantId, CorrelationId,
+Source, TenantName, AdminEmail, PlanKey, ValidUpto, GraceEndsUtc`.
+
+In `Modules.Billing.Contracts/Events/`:
+- `InvoiceIssuedIntegrationEvent` — `Id, OccurredOnUtc, TenantId, CorrelationId, Source, InvoiceId,
+  InvoiceNumber, decimal Amount, string Currency, DateTime? DueAtUtc, int PeriodYear, int PeriodMonth`.
+
+### B2. `TenantExpiryScanJob` (Multitenancy)
+- `src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs`, `RunAsync(CancellationToken)`.
+- Injects `IMultiTenantStore<AppTenantInfo>`, `IEventBus`, `IOptions<TenantBillingOptions>`,
+  `TimeProvider`, `ILogger`.
+- Daily recurring job registered in `MultitenancyModule.MapEndpoints` via `IRecurringJobManager.AddOrUpdate`
+  (`"0 2 * * *"`, `TimeZoneInfo.Utc`, id `"tenant-expiry-scan"`).
+- For each **active, non-root** tenant, compute state from `now` vs `ValidUpto` and
+  `graceEnds = ValidUpto + GraceWindowDays`:
+  - `now > graceEnds` → publish `TenantExpired`.
+  - `ValidUpto < now <= graceEnds` → publish `TenantEnteredGrace`.
+  - `ValidUpto - ExpiryNotificationLeadDays <= now <= ValidUpto` → publish `TenantNearingExpiry`
+    (`DaysRemaining = ceil((ValidUpto - now).TotalDays)`).
+  - else → no event.
+- Per-tenant try/catch (one failure doesn't block others), structured logging. Publishes via `IEventBus`
+  (direct, in-memory) — matching the create/renew pattern, **not** the Outbox.
+
+### B3. Dedup ownership + Notifications email handlers
+**Where dedup lives (decided after self-review):** the scan job fires **daily**, so a fresh event Id
+each day defeats inbox dedup → without a ledger the tenant gets a grace/expired email every day. The
+ledger must therefore be keyed by `(tenant, state, ValidUpto)`, not by event Id. It **cannot** live in
+`NotificationsDbContext`: that's a tenant-filtered `BaseDbContext`, but the expiry events are published
+from a background job with **no tenant context**, and Notifications may not reference Multitenancy's
+runtime to borrow a cross-tenant context (module boundary). So:
+
+- **Dedup is owned by the scan job**, in a new `TenantExpiryNotice` entity in Multitenancy's
+  `TenantDbContext` (which is Finbuckle's `EFCoreStoreDbContext<AppTenantInfo>` — already cross-tenant,
+  **not** tenant-filtered, so no tenant-context dance and not subject to the `BaseDbContext`
+  tenant-isolation rule). Fields: `Id, TenantId, NoticeType, ValidUptoUtc, CreatedAtUtc`; **unique**
+  index `(TenantId, NoticeType, ValidUptoUtc)`. The job does check-or-insert **before** publishing, so a
+  given `(tenant, state, validity-period)` is published exactly once; renewal moves `ValidUpto` and
+  re-arms all states. Migration in the PostgreSQL project under the tenant/Multitenancy folder.
+- **Notifications handlers stay pure senders.** New `sealed` `IIntegrationEventHandler<T>` in
+  `Modules.Notifications/IntegrationEventHandlers/` for each of the 4 events (3 expiry + `InvoiceIssued`),
+  auto-registered by the existing `AddIntegrationEventHandlers(typeof(NotificationsModule).Assembly)`
+  scan. Each builds a `MailRequest` (subject + hand-built HTML body via a private `EmailBodies` helper)
+  and `await _mailService.SendAsync(...)` inside try/catch + warn-log (email failure must not throw —
+  matches `UserRegisteredEmailHandler`). The in-memory bus inbox dedups same-event-Id redelivery.
+- **`InvoiceIssued`** needs no ledger — it's one-shot per invoice issue, and inbox dedups redelivery.
+
+**Tradeoff (stated explicitly):** push email is **best-effort once per state per validity period** — a
+transient send failure is logged but not re-attempted until `ValidUpto` changes. This is acceptable
+because the **dashboard banner (Workstream D) is the always-accurate pull side**: a tenant in grace
+always sees the banner on load regardless of email delivery. Push + pull together cover the case.
+
+### B4. Config
+`TenantBillingOptions.ExpiryNotificationLeadDays` (default 7), bound from the existing `"Billing"`
+section. Document the key.
+
+## Workstream C — Phase 4: PDF invoices
+
+- Add `QuestPDF` NuGet to `Modules.Billing` (pin a current version; `QuestPDF.Settings.License =
+  LicenseType.Community` set once at module init).
+- `IInvoicePdfRenderer` (Billing service) — `byte[] Render(InvoiceDto invoice)`. Implementation
+  `InvoicePdfRenderer` builds a clean A4 invoice: header (invoice #, status, dates), bill-to (tenant),
+  period, line-items table (kind, description, qty, unit price, amount), subtotal, notes. Currency-aware
+  formatting; decimals match the stored `18,4` → display 2dp.
+- Endpoints (mirror the existing permission split):
+  - `GET /api/v1/billing/invoices/{id}/pdf` — operator (Billing.View), any tenant's invoice.
+  - `GET /api/v1/billing/invoices/me/{id}/pdf` — tenant-self, only the caller's own invoice (404 on
+    cross-tenant, no leak — mirror `GetInvoiceById`/`GetMyInvoices`).
+  - Both return `FileContentResult`/`Results.File(bytes, "application/pdf", "{invoiceNumber}.pdf")`.
+- On-demand only (no stored artifact); persisting to the Files module is a future option.
+
+## Workstream D — Dashboard self-serve (view + warnings) + admin glue
+
+### D-dashboard (`clients/dashboard`)
+- **`GET /api/v1/tenants/me/status`** (new tenant-self endpoint in Multitenancy): returns a trimmed
+  `TenantStatusDto` for the **calling** tenant (resolved from the tenant context, not a route id) —
+  `plan, validUpto, expiryState, graceEndsUtc`. Permission: any authenticated tenant user.
+- **Subscription page** at `/subscription` (the existing `/invoices` list stays; this is the
+  plan/usage view): current plan, validity date, expiry badge (Active/InGrace/Expired), usage snapshots
+  with limit + overage, recent invoices (link to detail). Reuses the dashboard's existing card/table
+  primitives. Add a nav entry.
+- **Global expiry/grace banner** in the dashboard `AppShell`: query `tenants/me/status` (staleTime ~5m);
+  show a warning bar when `InGrace` ("subscription expired — N days of grace left, contact your
+  operator") or when `Active` within `ExpiryNotificationLeadDays` ("expires in N days"). Dismissible per
+  session; reappears on reload while the condition holds.
+- **Invoice detail page** (new): line items, totals, status, dates, **Download PDF** button
+  (`invoices/me/{id}/pdf`).
+- Fix `clients/dashboard/src/api/billing.ts` `SubscriptionStatus` to match backend
+  (`Active`/`Suspended`/`Cancelled`); align invoice line-item typing (currently `unknown[]`).
+- Register lazy routes; the dashboard has no per-route permission system (tenant-scoped), so guarding is
+  by auth only.
+
+### D-admin (`clients/admin`) glue
+- **Download PDF** button on the admin invoice detail page (`invoices/{id}/pdf`).
+- **Adjust validity** action on the tenant detail page (calls A4 endpoint) — small dialog with a date
+  picker; root-operator only (mirror the Renew action's permission gate).
+- Plan-form validation: enforce non-negative `monthlyBasePrice`/`annualPrice`/overage rates client-side
+  (currently relies on server rejection).
+
+## Workstream E — Tests
+
+### Unit (`Billing.Tests`, `Multitenancy.Tests`)
+- `GetStatusAsync` expiry-state boundaries: `now == ValidUpto` (Active), `now == graceEnds` (InGrace),
+  `now == graceEnds + 1s` (Expired), `now == ValidUpto + 1s` (InGrace). Drive via `FakeTimeProvider`.
+- `TenantExpiryScanJob` state selection: nearing / grace / expired / no-event, including boundaries;
+  root + inactive tenants excluded. (Use `Substitute.For<IEventBus>()`, assert exact event type +
+  `Received(1)`.)
+- Email body builders produce expected subject + key fields (smoke).
+- `InvoicePdfRenderer.Render` returns a non-empty `%PDF`-prefixed byte[] for a representative invoice.
+
+### Integration (`Integration.Tests`, Testcontainers)
+- **Event-handler idempotency:** publish `TenantSubscribed` twice (same `Id`) → exactly one subscription
+  + one subscription invoice (inbox dedup) — and a *distinct* redelivery via the invoice-number guard.
+- **Grace boundaries (middleware + login):** request/login at `ValidUpto` (allowed), within grace
+  (allowed, `X-Subscription-Grace` present), at `graceEnds` (allowed), `graceEnds + 1s` (403/401).
+- **Renewal:** double-renew stacks (≈ 2 terms from now); renew while in grace (starts from `now`, since
+  `ValidUpto < now`); renew with a different plan key swaps the active subscription + issues a new
+  subscription invoice + `PlanChanged=true`; renew when `ValidUpto` is in the future stacks from
+  `ValidUpto`.
+- **Plan seeding:** `BillingDbInitializer` seeds `free`/`pro`/`pro-annual` with correct interval/price
+  on an empty plans table; idempotent (no duplication on re-run).
+- **Single-active-subscription invariant:** after a plan change, exactly one `Active` subscription for
+  the tenant; the prior is `Cancelled` with `EndUtc == new.StartUtc`.
+- **Invoice state-machine at the endpoint:** `Void → mark-paid` rejected (409/400); `Paid → void`
+  rejected; issue twice idempotent/rejected as designed.
+- **Usage-snapshot uniqueness:** second capture for the same `(tenant, period, resource)` does not
+  duplicate (app idempotency) and the DB unique index rejects a forced duplicate insert.
+- **`TenantExpiryScanJob` end-to-end:** seed tenants in each state, run job, assert correct events
+  emitted; run twice → dedup ledger prevents a second email per state/period.
+- **`InvoiceIssued` → email:** subscription invoice issue triggers the Notifications handler (assert via
+  a captured/fake `IMailService`).
+- **PDF endpoints:** operator gets 200 `application/pdf` for any invoice; tenant-self gets 200 for own,
+  404 for another tenant's (no leak).
+- **`tenants/me/status`:** returns the caller's plan/expiryState/grace; 401 unauthenticated.
+- **`AdjustTenantValidity`:** sets `ValidUpto`, no invoice/subscription created, root-only (403 for
+  tenant admin), validity reflected in `GetStatus`.
+
+### Architecture (`Architecture.Tests`)
+- `TenantExpiryNotice` lives in `TenantDbContext` (Finbuckle `EFCoreStoreDbContext`, **not** a
+  `BaseDbContext`), so the tenant-isolation NetArchTest (which targets `BaseDbContext`-derived contexts)
+  does not apply — confirm it isn't flagged. No new tenant-isolated entity is introduced in this pass.
+
+### Frontend (Playwright, route-mocked) — `clients/dashboard` + `clients/admin`
+- Dashboard: subscription page renders plan/usage/invoices; expiry banner shows for InGrace and
+  nearing-expiry mocks; invoice detail renders line items + triggers the PDF download request.
+- Admin: PDF button on invoice detail issues the `/pdf` request; Adjust-validity dialog posts the
+  command; plan-form rejects negative prices client-side.
+
+## Module wiring checklist
+
+- **No new module** ⇒ no change to the four Mediator/`moduleAssemblies` wire points.
+- Billing: `IInvoicePdfRenderer` DI registration; QuestPDF license init; publish `InvoiceIssued` from the
+  two subscription-invoice handlers; new PDF endpoints in `MapEndpoints`.
+- Multitenancy: register `TenantExpiryScanJob` recurring job in `MapEndpoints`; new events in Contracts;
+  `tenants/me/status` + `adjust-validity` endpoints/handlers/validators; bind
+  `ExpiryNotificationLeadDays`.
+- Notifications: new handlers (auto-scanned). No DbContext change (dedup lives in Multitenancy).
+  Ensure `Modules.Notifications` references `Modules.Multitenancy.Contracts` + `Modules.Billing.Contracts`
+  for the new event types (add the refs if missing).
+- Multitenancy: `TenantExpiryNotice` entity + EF config in `TenantDbContext`.
+- Migrations: one Billing migration (indexes), one Multitenancy/tenant migration (`TenantExpiryNotice`).
+  DbMigrator picks them up; run `apply` in dev. Full-build before each `migrations add` (snapshot footgun).
+
+## Error handling
+
+- Email send failure → caught + warn-logged in the handler; never throws (don't break the scan job /
+  invoice issue). The dedup row is written by the scan job **before** publishing (to prevent daily
+  spam), so a transient send failure is **not** auto-retried within the same validity period — the
+  always-accurate dashboard banner (D) is the fallback for the logged-in tenant; an operator can re-emit
+  by clearing the `TenantExpiryNotice` row if ever needed.
+- PDF render failure → 500 via the global handler; no partial file. Cross-tenant PDF → 404 (no leak).
+- `AdjustTenantValidity` backdating → `SetValidity` is forward-only; if a backdate is explicitly needed,
+  set the property directly behind a guard + audit log (documented in the handler).
+- Scan job: per-tenant try/catch; job-level failure surfaces in the Hangfire dashboard + retry.
+
+## Out of scope (unchanged)
+
+Payment gateway, self-service checkout/renewal, auto-renew, mid-term proration, multi-currency
+conversion, dunning beyond the single grace window, in-app (SignalR) expiry toasts resolved to Identity
+user IDs (dashboard banner covers the logged-in case via pull).
+
+## Docs (golden rule #10)
+
+Update the separate docs repo (`github.com/fullstackhero/docs`) + changelog once behavior lands:
+new config key `Billing:ExpiryNotificationLeadDays`; new endpoints (`tenants/me/status`,
+`tenants/{id}/adjust-validity`, invoice `/pdf` x2); the **QuestPDF license note** for downstream
+commercial users; the dashboard subscription page + expiry banner; expiry/renewal emails.
+
+## Phasing (implementation order)
+
+1. **A** — backend hardening (clock fix, header, indexes migration, AdjustTenantValidity) + its tests.
+2. **B** — notifications (events, scan job, handlers, ledger, config) + tests.
+3. **C** — PDF (renderer, endpoints) + tests.
+4. **D** — dashboard + admin glue (status endpoint first, then UI) + Playwright tests.
+5. **E** — fill any remaining cross-cutting integration/regression tests; full build + `dotnet test`.
+
+Each phase: build clean (`TreatWarningsAsErrors`) and green tests before the next.

--- a/superpowers/specs/2026-05-28-tenant-billing-production-hardening-design.md
+++ b/superpowers/specs/2026-05-28-tenant-billing-production-hardening-design.md
@@ -51,17 +51,18 @@ clock-controllable for tests and consistent with `GetStatusAsync` / the handler.
 ceil of remaining days). Hard-block (403) past grace stays as-is. Active tenants get no header. This is
 a cheap signal for clients; the dashboard banner does not depend on it (it uses `tenants/me/status`).
 
-### A3. Indexes (one Billing migration)
-- `UsageSnapshot`: **unique** index on `(TenantId, PeriodYear, PeriodMonth, Resource)` — promotes the
-  current app-only idempotency to a DB invariant.
-- `Subscription`: **non-unique** index on `(TenantId, Status)` — speeds the "find active subscription"
-  lookup used by the replace flow + monthly job. Deliberately **not** a partial-unique index on active:
-  the cancel-old/create-new replace runs in one `SaveChanges` and Postgres checks unique constraints
-  per-statement, so a unique-active index could trip transiently. The single-active invariant is
-  enforced by app logic + asserted by an integration test (E).
+### A3. Indexes — ALREADY DONE (verified during planning; audit was wrong)
+Reading the EF configs shows both indexes the audit claimed were missing already exist:
+- `UsageSnapshotConfiguration` has a **unique** index `ux_usage_snapshots_tenant_period_resource` on
+  `(TenantId, PeriodYear, PeriodMonth, Resource)`.
+- `SubscriptionConfiguration` has `(TenantId, Status)` **and** a **partial-unique**
+  `ux_subscriptions_tenantid_active` (`TenantId` WHERE `Status = Active`) — the single-active invariant
+  is already a DB constraint.
 
-Migration lives in `FSH.Starter.Migrations.PostgreSQL` under the Billing folder. Full-build before
-`migrations add` (the snapshot footgun). No tenant-store schema change.
+**No index migration needed.** The replace flow (cancel-old → create-new in one `SaveChanges`) works
+against the partial-unique index in prod (EF emits the UPDATE-to-Cancelled before the INSERT). E still
+adds an integration test asserting the invariant + that the unique-active index rejects a forced second
+active row, to lock the behavior against regressions.
 
 ### A4. `AdjustTenantValidityCommand` (operator override)
 - Contract: `Modules.Multitenancy.Contracts/v1/AdjustTenantValidity/AdjustTenantValidityCommand.cs`


### PR DESCRIPTION
## Summary

Completes the SaaS tenant billing feature end-to-end and bundles a few pre-existing tenant activation / impersonation fixes that were already on this branch.

**Billing completion (the main feature):**
- **Hardening** — `TenantService.RenewAsync` now uses the injected `TimeProvider` (was `DateTime.UtcNow`); `X-Subscription-Grace: <daysLeft>` response header during the grace window (set via `Response.OnStarting` so it survives error responses); new operator-only `AdjustTenantValidityCommand` (`POST /tenants/{id}/adjust-validity`) to set a tenant's expiry directly with no invoice (comps/corrections, backdating allowed).
- **Notifications** — daily `tenant-expiry-scan` Hangfire job (02:00 UTC) classifies each active tenant as *nearing expiry* / *in grace* / *expired* and emails the tenant admin, deduped once per state per validity window (re-arms on renewal) via a `TenantExpiryNotice` ledger. Issuing an invoice also emails the tenant. New config key `Billing:ExpiryNotificationLeadDays` (default 7).
- **PDF invoices** — `IInvoicePdfRenderer` (QuestPDF, Community license set, swappable behind the interface) + tenant-scoped `GET /api/v1/billing/invoices/{id}/pdf` (404 cross-tenant; one endpoint serves both operator console and tenant self-service).
- **Frontend** — `GET /api/v1/tenants/me/status`; dashboard `/subscription` page (plan, validity, usage, recent invoices), global expiry/grace warning banner, invoice detail + PDF download; admin invoice-PDF button, client-side plan-form validation, and an Adjust-validity operator dialog.

**Production bug fixed along the way:** background-published integration events crashed the generic webhook fan-out (it captures the ambient tenant at DbContext construction, which is null in a no-HTTP scope). Background publishers now install the Finbuckle tenant context before publishing.

**Also on this branch (pre-existing, unrelated):** admin tenant activate/deactivate confirmation + redundant tenant-chip removal, dashboard permission-gating of admin-only nav, and end-impersonation-on-cross-app-handoff fixes.

## Test plan

- [ ] Backend build clean with `TreatWarningsAsErrors`
- [ ] Integration.Tests green (expiry/grace boundaries, double-renew, renew-while-lapsed, scan dedup, event idempotency, cross-tenant PDF/invoice 404, backdating)
- [ ] Billing.Tests + Multitenancy.Tests + Architecture.Tests green
- [ ] Both React apps: build + lint + Playwright (dashboard subscription/banner/invoice specs, admin billing/tenant specs)
- [ ] Docs updated in the separate docs repo (billing module page + changelog) — golden rule #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)