### PR TITLE
chore(release): publish only the CLI + template to NuGet (source-ownership)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -359,30 +359,11 @@ jobs:
           dotnet restore src/FSH.Starter.slnx
           dotnet build src/FSH.Starter.slnx -c Release --no-restore -p:Version=${{ steps.version.outputs.version }}
 
-      - name: Pack BuildingBlocks
-        run: |
-          dotnet pack src/BuildingBlocks/Core/Core.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Shared/Shared.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Persistence/Persistence.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Caching/Caching.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Mailing/Mailing.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Jobs/Jobs.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Storage/Storage.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Eventing/Eventing.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Eventing.Abstractions/Eventing.Abstractions.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/BuildingBlocks/Web/Web.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-
-      - name: Pack Modules
-        run: |
-          dotnet pack src/Modules/Auditing/Modules.Auditing.Contracts/Modules.Auditing.Contracts.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Auditing/Modules.Auditing/Modules.Auditing.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Identity/Modules.Identity.Contracts/Modules.Identity.Contracts.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Identity/Modules.Identity/Modules.Identity.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Modules.Multitenancy.Contracts.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Multitenancy/Modules.Multitenancy/Modules.Multitenancy.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Webhooks/Modules.Webhooks.Contracts/Modules.Webhooks.Contracts.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack src/Modules/Webhooks/Modules.Webhooks/Modules.Webhooks.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
-
+      # Distribution model is source-ownership: consumers get the FULL source via the
+      # `dotnet new fsh` template (below), NOT per-module/BuildingBlocks NuGet packages.
+      # Only two artifacts publish to NuGet — the `fsh` global CLI tool and the template.
+      # (The previous per-module packs were incomplete — 4 of 10 modules — and contradicted
+      # the locked source-ownership model, so they were removed.)
       - name: Pack CLI Tool
         run: dotnet pack src/Tools/CLI/FSH.CLI.csproj -c Release --no-build -o ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
 

--- a/templates/FullStackHero.NET.StarterKit.csproj
+++ b/templates/FullStackHero.NET.StarterKit.csproj
@@ -31,7 +31,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <!-- NU5128: template pack has content but no dependencies/lib (by design).
+         NU5110/NU5111: bundled deploy.ps1 scripts are template CONTENT, not NuGet install
+         scripts — they must not be moved to tools/ or renamed; the warnings are noise. -->
+    <NoWarn>$(NoWarn);NU5128;NU5110;NU5111</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
     <EnableDefaultItems>false</EnableDefaultItems>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>


### PR DESCRIPTION
Re-applies the release-packaging fix that missed the #1271 merge window (the PR was merged at its 2nd commit, before this fix was pushed).

The `publish-release` job packed per-module / BuildingBlocks NuGets (only **4 of 10** modules, inconsistently) and pushed them to NuGet.org — contradicting the **locked source-ownership** distribution model, where consumers get the full source via `dotnet new fsh`, not runtime packages. Now **only two artifacts publish**: the `fsh` global CLI tool and the `dotnet new` template.

Also suppresses `NU5110`/`NU5111` on the template pack — the bundled Terraform `deploy.ps1` files are template **content**, not NuGet install scripts, and must not be moved to `tools/` or renamed.

Verified by scaffolding `DemoPush` from the template and confirming it packs clean and builds (0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)