### PR TITLE
chore: NuGet launch hardening — enforce 2-package source-ownership model, security + perf fixes

### DIFF
--- a/src/BuildingBlocks/Caching/Caching.csproj
+++ b/src/BuildingBlocks/Caching/Caching.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Caching</RootNamespace>
 		<AssemblyName>FSH.Framework.Caching</AssemblyName>
-		<PackageId>FullStackHero.Framework.Caching</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/BuildingBlocks/Core/Core.csproj
+++ b/src/BuildingBlocks/Core/Core.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
 	    <RootNamespace>FSH.Framework.Core</RootNamespace>
 	    <AssemblyName>FSH.Framework.Core</AssemblyName>
-	    <PackageId>FullStackHero.Framework.Core</PackageId>
     </PropertyGroup>
 
 	<ItemGroup>

--- a/src/BuildingBlocks/Eventing.Abstractions/Eventing.Abstractions.csproj
+++ b/src/BuildingBlocks/Eventing.Abstractions/Eventing.Abstractions.csproj
@@ -6,7 +6,6 @@
 		<Nullable>enable</Nullable>
 		<RootNamespace>FSH.Framework.Eventing.Abstractions</RootNamespace>
 		<AssemblyName>FSH.Framework.Eventing.Abstractions</AssemblyName>
-		<PackageId>FullStackHero.Framework.Eventing.Abstractions</PackageId>
 		<Description>Lightweight abstractions for FSH eventing - interfaces only, no implementation dependencies</Description>
 		<NoWarn>$(NoWarn);CA1711;CA1716</NoWarn>
 	</PropertyGroup>

--- a/src/BuildingBlocks/Eventing/Eventing.csproj
+++ b/src/BuildingBlocks/Eventing/Eventing.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <RootNamespace>FSH.Framework.Eventing</RootNamespace>
     <AssemblyName>FSH.Framework.Eventing</AssemblyName>
-    <PackageId>FullStackHero.Framework.Eventing</PackageId>
     <NoWarn>$(NoWarn);CA1711;CA1716;CA1031;S2139;S1066</NoWarn>
   </PropertyGroup>
 

--- a/src/BuildingBlocks/Eventing/InMemory/InMemoryEventBus.cs
+++ b/src/BuildingBlocks/Eventing/InMemory/InMemoryEventBus.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Eventing.Abstractions;
 using FSH.Framework.Eventing.Inbox;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace FSH.Framework.Eventing.InMemory;
@@ -15,11 +16,26 @@ public sealed partial class InMemoryEventBus : IEventBus
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<InMemoryEventBus> _logger;
 
+    // The closed handler interface type and its HandleAsync method are stable per event type, so
+    // they are resolved once and cached rather than recomputing reflection on every published event.
+    private static readonly ConcurrentDictionary<Type, HandlerDispatch> DispatchCache = new();
+
+    private readonly record struct HandlerDispatch(Type HandlerInterfaceType, MethodInfo HandleMethod);
+
     public InMemoryEventBus(IServiceProvider serviceProvider, ILogger<InMemoryEventBus> logger)
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
     }
+
+    private static HandlerDispatch GetDispatch(Type eventType)
+        => DispatchCache.GetOrAdd(eventType, static et =>
+        {
+            var handlerInterfaceType = typeof(IIntegrationEventHandler<>).MakeGenericType(et);
+            var method = handlerInterfaceType.GetMethod(nameof(IIntegrationEventHandler<IIntegrationEvent>.HandleAsync))
+                ?? throw new InvalidOperationException($"IIntegrationEventHandler<{et.Name}> does not declare HandleAsync.");
+            return new HandlerDispatch(handlerInterfaceType, method);
+        });
 
     public Task PublishAsync(IIntegrationEvent @event, CancellationToken ct = default)
         => PublishAsync(new[] { @event }, ct);
@@ -39,10 +55,12 @@ public sealed partial class InMemoryEventBus : IEventBus
         var eventType = @event.GetType();
         LogPublishingEvent(eventType.FullName, @event.Id);
 
+        var dispatch = GetDispatch(eventType);
+
         using var scope = _serviceProvider.CreateScope();
         var provider = scope.ServiceProvider;
 
-        var handlers = ResolveHandlers(provider, eventType);
+        var handlers = ResolveHandlers(provider, dispatch.HandlerInterfaceType);
         if (handlers.Length == 0)
         {
             LogNoHandlers(eventType.FullName);
@@ -50,23 +68,19 @@ public sealed partial class InMemoryEventBus : IEventBus
         }
 
         var inbox = provider.GetService<IInboxStore>();
-        var handlerInterfaceType = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
 
         foreach (var handler in handlers)
         {
-            await InvokeHandlerAsync(handler, handlerInterfaceType, eventType, @event, inbox, ct);
+            await InvokeHandlerAsync(handler, dispatch.HandleMethod, eventType, @event, inbox, ct).ConfigureAwait(false);
         }
     }
 
-    private static object[] ResolveHandlers(IServiceProvider provider, Type eventType)
-    {
-        var handlerInterfaceType = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
-        return provider.GetServices(handlerInterfaceType).Where(h => h is not null).ToArray()!;
-    }
+    private static object[] ResolveHandlers(IServiceProvider provider, Type handlerInterfaceType)
+        => provider.GetServices(handlerInterfaceType).Where(h => h is not null).ToArray()!;
 
     private async Task InvokeHandlerAsync(
         object handler,
-        Type handlerInterfaceType,
+        MethodInfo handleMethod,
         Type eventType,
         IIntegrationEvent @event,
         IInboxStore? inbox,
@@ -74,20 +88,13 @@ public sealed partial class InMemoryEventBus : IEventBus
     {
         var handlerName = handler.GetType().FullName ?? handler.GetType().Name;
 
-        if (await ShouldSkipProcessedEventAsync(inbox, @event.Id, handlerName, ct))
+        if (await ShouldSkipProcessedEventAsync(inbox, @event.Id, handlerName, ct).ConfigureAwait(false))
         {
             LogSkippingProcessed(@event.Id, handlerName);
             return;
         }
 
-        var method = handlerInterfaceType.GetMethod(nameof(IIntegrationEventHandler<IIntegrationEvent>.HandleAsync));
-        if (method == null)
-        {
-            _logger.LogWarning("Handler {Handler} does not implement HandleAsync correctly for {EventType}", handlerName, eventType.FullName);
-            return;
-        }
-
-        await ExecuteHandlerAsync(handler, method, @event, eventType, handlerName, inbox, ct);
+        await ExecuteHandlerAsync(handler, handleMethod, @event, eventType, handlerName, inbox, ct).ConfigureAwait(false);
     }
 
     private static async Task<bool> ShouldSkipProcessedEventAsync(IInboxStore? inbox, Guid eventId, string handlerName, CancellationToken ct)

--- a/src/BuildingBlocks/Eventing/Inbox/InboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Inbox/InboxMessage.cs
@@ -25,7 +25,7 @@ public class InboxMessage : IGlobalEntity
     public string? TenantId { get; set; }
 }
 
-public class InboxMessageConfiguration : IEntityTypeConfiguration<InboxMessage>
+public sealed class InboxMessageConfiguration : IEntityTypeConfiguration<InboxMessage>
 {
     private readonly string _schema;
 

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
@@ -35,7 +35,7 @@ public class OutboxMessage : IGlobalEntity
     public bool IsDead { get; set; }
 }
 
-public class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>
+public sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>
 {
     private readonly string _schema;
 

--- a/src/BuildingBlocks/Eventing/Serialization/JsonEventSerializer.cs
+++ b/src/BuildingBlocks/Eventing/Serialization/JsonEventSerializer.cs
@@ -1,4 +1,5 @@
 using FSH.Framework.Eventing.Abstractions;
+using System.Collections.Concurrent;
 using System.Text.Json;
 
 namespace FSH.Framework.Eventing.Serialization;
@@ -14,6 +15,11 @@ public sealed class JsonEventSerializer : IEventSerializer
         WriteIndented = false
     };
 
+    // Resolving an event type from its name repeats constantly on the outbox and inbox path, and the
+    // underlying reflection lookup parses the assembly qualified name and scans loaded assemblies each
+    // time, so the resolved result for each distinct name is cached here.
+    private static readonly ConcurrentDictionary<string, Type?> TypeCache = new(StringComparer.Ordinal);
+
     public string Serialize(IIntegrationEvent @event)
     {
         ArgumentNullException.ThrowIfNull(@event);
@@ -25,7 +31,7 @@ public sealed class JsonEventSerializer : IEventSerializer
         ArgumentNullException.ThrowIfNull(payload);
         ArgumentNullException.ThrowIfNull(eventTypeName);
 
-        var type = Type.GetType(eventTypeName, throwOnError: false);
+        var type = TypeCache.GetOrAdd(eventTypeName, static n => Type.GetType(n, throwOnError: false));
         if (type is null)
         {
             return null;

--- a/src/BuildingBlocks/Jobs/Jobs.csproj
+++ b/src/BuildingBlocks/Jobs/Jobs.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Jobs</RootNamespace>
 		<AssemblyName>FSH.Framework.Jobs</AssemblyName>
-		<PackageId>FullStackHero.Framework.Jobs</PackageId>
 		<NoWarn>$(NoWarn);CA1031;S3376;S3993</NoWarn>
 	</PropertyGroup>
 	

--- a/src/BuildingBlocks/Mailing/Extensions.cs
+++ b/src/BuildingBlocks/Mailing/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using FSH.Framework.Mailing.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using SendGrid;
 
 namespace FSH.Framework.Mailing;
 
@@ -12,12 +13,23 @@ public static class Extensions
             .BindConfiguration(nameof(MailOptions))
             .ValidateOnStart();
 
+        // One SendGrid client (and its underlying HttpClient) shared process-wide.
+        // Constructing it per-send leaks sockets / exhausts ephemeral ports under load.
+        // The factory is lazy, so the client is only built when SendGrid is actually used.
+        services.AddSingleton<ISendGridClient>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<MailOptions>>().Value;
+            return new SendGridClient(options.SendGrid?.ApiKey ?? string.Empty);
+        });
+
         services.AddTransient<IMailService>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<MailOptions>>().Value;
             if (options.UseSendGrid)
             {
-                return new SendGridMailService(sp.GetRequiredService<IOptions<MailOptions>>());
+                return new SendGridMailService(
+                    sp.GetRequiredService<IOptions<MailOptions>>(),
+                    sp.GetRequiredService<ISendGridClient>());
             }
             return new SmtpMailService(sp.GetRequiredService<IOptions<MailOptions>>(), sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<SmtpMailService>>());
         });

--- a/src/BuildingBlocks/Mailing/Mailing.csproj
+++ b/src/BuildingBlocks/Mailing/Mailing.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Mailing</RootNamespace>
 		<AssemblyName>FSH.Framework.Mailing</AssemblyName>
-		<PackageId>FullStackHero.Framework.Mailing</PackageId>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/BuildingBlocks/Mailing/Services/SendGridMailService.cs
+++ b/src/BuildingBlocks/Mailing/Services/SendGridMailService.cs
@@ -6,14 +6,17 @@ using System.Threading.Tasks;
 
 namespace FSH.Framework.Mailing.Services;
 
-public class SendGridMailService : IMailService
+public sealed class SendGridMailService : IMailService
 {
     private readonly MailOptions _settings;
+    private readonly ISendGridClient _client;
 
-    public SendGridMailService(IOptions<MailOptions> settings)
+    public SendGridMailService(IOptions<MailOptions> settings, ISendGridClient client)
     {
         ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(client);
         _settings = settings.Value;
+        _client = client;
     }
 
     public async Task SendAsync(MailRequest request, CancellationToken ct)
@@ -21,7 +24,11 @@ public class SendGridMailService : IMailService
         ArgumentNullException.ThrowIfNull(request);
         ValidateConfiguration();
 
-        var client = new SendGridClient(_settings.SendGrid!.ApiKey!);
+        if (request.To is null or { Count: 0 })
+        {
+            throw new InvalidOperationException("At least one recipient is required.");
+        }
+
         var from = CreateFromAddress(request);
         var msg = MailHelper.CreateSingleEmail(
             from,
@@ -33,7 +40,7 @@ public class SendGridMailService : IMailService
         ConfigureRecipients(msg, request);
         AddAttachments(msg, request);
 
-        await client.SendEmailAsync(msg, ct);
+        await _client.SendEmailAsync(msg, ct).ConfigureAwait(false);
     }
 
     private void ValidateConfiguration()

--- a/src/BuildingBlocks/Persistence/Inteceptors/DomainEventsInterceptor.cs
+++ b/src/BuildingBlocks/Persistence/Inteceptors/DomainEventsInterceptor.cs
@@ -25,21 +25,6 @@ public sealed class DomainEventsInterceptor : SaveChangesInterceptor
     }
 
     /// <summary>
-    /// Called before changes are saved to the database.
-    /// </summary>
-    /// <param name="eventData">Contextual information about the DbContext being saved.</param>
-    /// <param name="result">The result to be returned from SaveChanges.</param>
-    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
-        DbContextEventData eventData,
-        InterceptionResult<int> result,
-        CancellationToken cancellationToken = default)
-    {
-        return await base.SavingChangesAsync(eventData, result, cancellationToken);
-    }
-
-    /// <summary>
     /// Called after changes have been saved to the database. Publishes all domain events from tracked entities.
     /// </summary>
     /// <param name="eventData">Contextual information about the completed save operation.</param>
@@ -55,7 +40,7 @@ public sealed class DomainEventsInterceptor : SaveChangesInterceptor
         ArgumentNullException.ThrowIfNull(eventData);
         var context = eventData.Context;
         if (context == null)
-            return await base.SavedChangesAsync(eventData, result, cancellationToken);
+            return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
 
         var domainEvents = context.ChangeTracker
             .Entries<IHasDomainEvents>()
@@ -68,7 +53,7 @@ public sealed class DomainEventsInterceptor : SaveChangesInterceptor
             .ToArray();
 
         if (domainEvents.Length == 0)
-            return await base.SavedChangesAsync(eventData, result, cancellationToken);
+            return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -90,6 +75,6 @@ public sealed class DomainEventsInterceptor : SaveChangesInterceptor
             }
         }
 
-        return await base.SavedChangesAsync(eventData, result, cancellationToken);
+        return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/BuildingBlocks/Persistence/Persistence.csproj
+++ b/src/BuildingBlocks/Persistence/Persistence.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Persistence</RootNamespace>
 		<AssemblyName>FSH.Framework.Persistence</AssemblyName>
-		<PackageId>FullStackHero.Framework.Persistence</PackageId>
 		<NoWarn>$(NoWarn);S4144;CS0618</NoWarn>
 	</PropertyGroup>
 

--- a/src/BuildingBlocks/Quota/Quota.csproj
+++ b/src/BuildingBlocks/Quota/Quota.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Quota</RootNamespace>
 		<AssemblyName>FSH.Framework.Quota</AssemblyName>
-		<PackageId>FullStackHero.Framework.Quota</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/BuildingBlocks/Shared/Shared.csproj
+++ b/src/BuildingBlocks/Shared/Shared.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Shared</RootNamespace>
 		<AssemblyName>FSH.Framework.Shared</AssemblyName>
-		<PackageId>FullStackHero.Framework.Shared</PackageId>
 		<NoWarn>$(NoWarn);CA1716;CA1711;CA1019;CA1305;CA1002;CA2227</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/BuildingBlocks/Shared/Storage/FileUploadRequest.cs
+++ b/src/BuildingBlocks/Shared/Storage/FileUploadRequest.cs
@@ -3,7 +3,7 @@ namespace FSH.Framework.Shared.Storage;
 /// <summary>
 /// Represents a file upload request with filename, content type, and data.
 /// </summary>
-public class FileUploadRequest
+public sealed class FileUploadRequest
 {
     public string FileName { get; set; } = default!;
     public string ContentType { get; set; } = default!;

--- a/src/BuildingBlocks/Storage/FileType.cs
+++ b/src/BuildingBlocks/Storage/FileType.cs
@@ -7,7 +7,7 @@ public enum FileType
     Pdf
 }
 
-public class FileValidationRules
+public sealed class FileValidationRules
 {
     public IReadOnlyList<string> AllowedExtensions { get; init; } = Array.Empty<string>();
     public int MaxSizeInMB { get; init; } = 5;

--- a/src/BuildingBlocks/Storage/Local/LocalStorageService.cs
+++ b/src/BuildingBlocks/Storage/Local/LocalStorageService.cs
@@ -4,12 +4,20 @@ using FSH.Framework.Storage.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.StaticFiles;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace FSH.Framework.Storage.Local;
 
-public class LocalStorageService : IStorageService
+public sealed partial class LocalStorageService : IStorageService
 {
     private const string UploadBasePath = "uploads";
+
+    // Source-generated, compiled once — the inline Regex.Replace calls re-parsed the pattern on every upload.
+    [GeneratedRegex("[^a-z0-9]")]
+    private static partial Regex FolderSanitizer();
+
+    [GeneratedRegex(@"[^a-zA-Z0-9_\.-]")]
+    private static partial Regex FileNameSanitizer();
     private readonly string _rootPath;
     private readonly FileExtensionContentTypeProvider _contentTypeProvider;
 
@@ -42,7 +50,7 @@ public class LocalStorageService : IStorageService
         }
 
 #pragma warning disable CA1308 // folder names are intentionally lower-case for URLs/paths
-        var folder = Regex.Replace(typeof(T).Name.ToLowerInvariant(), @"[^a-z0-9]", "_");
+        var folder = FolderSanitizer().Replace(typeof(T).Name.ToLowerInvariant(), "_");
 #pragma warning restore CA1308
         var safeFileName = $"{Guid.NewGuid():N}_{SanitizeFileName(request.FileName)}";
         var relativePath = Path.Combine(UploadBasePath, folder, safeFileName);
@@ -136,14 +144,14 @@ public class LocalStorageService : IStorageService
 
     private static string SanitizeFileName(string fileName)
     {
-        return Regex.Replace(fileName, @"[^a-zA-Z0-9_\.-]", "_");
+        return FileNameSanitizer().Replace(fileName, "_");
     }
 
     // Local presigning is a development fallback when Storage:Provider != s3. Production deployments
     // use S3StorageService. The token store is process-static so the dev middleware (registered in
     // the host when Provider=local) can consume the token without re-resolving DI scope.
     private static LocalPresignTokenStore? _staticTokenStore;
-    public static LocalPresignTokenStore SharedTokenStore => _staticTokenStore ??= new LocalPresignTokenStore();
+    public static LocalPresignTokenStore SharedTokenStore => LazyInitializer.EnsureInitialized(ref _staticTokenStore);
 
     public Task<PresignedUploadUrl> GenerateUploadUrlAsync(
         string storageKey, string contentType, long maxBytes, TimeSpan ttl,

--- a/src/BuildingBlocks/Storage/S3/S3StorageService.cs
+++ b/src/BuildingBlocks/Storage/S3/S3StorageService.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace FSH.Framework.Storage.S3;
 
-internal sealed class S3StorageService : IStorageService
+internal sealed partial class S3StorageService : IStorageService
 {
     private readonly IAmazonS3 _s3;
     private readonly S3StorageOptions _options;
@@ -18,6 +18,13 @@ internal sealed class S3StorageService : IStorageService
     private readonly FileExtensionContentTypeProvider _contentTypeProvider;
 
     private const string UploadBasePath = "uploads";
+
+    // Source-generated, compiled once — the inline Regex.Replace calls re-parsed the pattern on every upload.
+    [GeneratedRegex("[^a-z0-9]")]
+    private static partial Regex FolderSanitizer();
+
+    [GeneratedRegex(@"[^a-zA-Z0-9_\.-]")]
+    private static partial Regex FileNameSanitizer();
 
     public S3StorageService(IAmazonS3 s3, IOptions<S3StorageOptions> options, ILogger<S3StorageService> logger)
     {
@@ -349,7 +356,7 @@ internal sealed class S3StorageService : IStorageService
 
     private string BuildKey<T>(string fileName) where T : class
     {
-        var folder = Regex.Replace(typeof(T).Name.ToLowerInvariant(), @"[^a-z0-9]", "_");
+        var folder = FolderSanitizer().Replace(typeof(T).Name.ToLowerInvariant(), "_");
         var relativePath = Path.Combine(UploadBasePath, folder, $"{Guid.NewGuid():N}_{fileName}").Replace("\\", "/", StringComparison.Ordinal);
         if (!string.IsNullOrWhiteSpace(_options.Prefix))
         {
@@ -413,6 +420,6 @@ internal sealed class S3StorageService : IStorageService
 
     private static string SanitizeFileName(string fileName)
     {
-        return Regex.Replace(fileName, @"[^a-zA-Z0-9_\.-]", "_");
+        return FileNameSanitizer().Replace(fileName, "_");
     }
 }

--- a/src/BuildingBlocks/Storage/Storage.csproj
+++ b/src/BuildingBlocks/Storage/Storage.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Storage</RootNamespace>
 		<AssemblyName>FSH.Framework.Storage</AssemblyName>
-		<PackageId>FullStackHero.Framework.Storage</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1056;CA1002;CA2227;CA1812;CA1308;CA1062</NoWarn>
 	</PropertyGroup>
 	

--- a/src/BuildingBlocks/Web/Mediator/Behaviors/ValidationBehavior.cs
+++ b/src/BuildingBlocks/Web/Mediator/Behaviors/ValidationBehavior.cs
@@ -1,12 +1,18 @@
 ﻿using FluentValidation;
+using FluentValidation.Results;
 using Mediator;
 
 namespace FSH.Framework.Web.Mediator.Behaviors;
 
-public sealed class ValidationBehavior<TMessage, TResponse>(IEnumerable<IValidator<TMessage>> validators) : IPipelineBehavior<TMessage, TResponse>
+public sealed class ValidationBehavior<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
     where TMessage : IMessage
 {
-    private readonly IEnumerable<IValidator<TMessage>> _validators = validators;
+    // Materialize once; this behavior runs for every command/query in the system and the common
+    // case is zero or one validator, so avoid the per-request Task.WhenAll array allocation.
+    private readonly IValidator<TMessage>[] _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TMessage>> validators)
+        => _validators = validators as IValidator<TMessage>[] ?? validators.ToArray();
 
     public async ValueTask<TResponse> Handle(
         TMessage message,
@@ -16,15 +22,26 @@ public sealed class ValidationBehavior<TMessage, TResponse>(IEnumerable<IValidat
     {
         ArgumentNullException.ThrowIfNull(next);
 
-        if (_validators.Any())
+        if (_validators.Length > 0)
         {
             var context = new ValidationContext<TMessage>(message);
-            var validationResults = await Task.WhenAll(_validators.Select(v => v.ValidateAsync(context, cancellationToken)));
-            var failures = validationResults.SelectMany(r => r.Errors).Where(f => f != null).ToList();
+            List<ValidationFailure> failures;
+
+            if (_validators.Length == 1)
+            {
+                var result = await _validators[0].ValidateAsync(context, cancellationToken).ConfigureAwait(false);
+                failures = result.Errors;
+            }
+            else
+            {
+                var results = await Task.WhenAll(_validators.Select(v => v.ValidateAsync(context, cancellationToken))).ConfigureAwait(false);
+                failures = results.SelectMany(r => r.Errors).ToList();
+            }
 
             if (failures.Count > 0)
                 throw new ValidationException(failures);
         }
-        return await next(message, cancellationToken);
+
+        return await next(message, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/BuildingBlocks/Web/Web.csproj
+++ b/src/BuildingBlocks/Web/Web.csproj
@@ -1,23 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Framework.Web</RootNamespace>
 		<AssemblyName>FSH.Framework.Web</AssemblyName>
-		<PackageId>FullStackHero.Framework.Web</PackageId>
 		<NoWarn>$(NoWarn);CA1805;CA1307;CA1308;S1854;CA1812;CA1305;CA2000</NoWarn>
 	</PropertyGroup>
-
-	<ItemGroup>
-	  <Compile Remove="Observability\Metrics\**" />
-	  <Compile Remove="Observability\Traces\**" />
-	  <Compile Remove="ProblemDetails\**" />
-	  <EmbeddedResource Remove="Observability\Metrics\**" />
-	  <EmbeddedResource Remove="Observability\Traces\**" />
-	  <EmbeddedResource Remove="ProblemDetails\**" />
-	  <None Remove="Observability\Metrics\**" />
-	  <None Remove="Observability\Traces\**" />
-	  <None Remove="ProblemDetails\**" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -50,10 +37,6 @@
 		<PackageReference Include="Serilog.Enrichers.Span" />
 		<PackageReference Include="Serilog.Enrichers.Thread" />
 		<PackageReference Include="Serilog.Sinks.OpenTelemetry" />
-	</ItemGroup>
-	
-	<ItemGroup>
-	  <Folder Include="RateLimiting\" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
 		<!-- Suppress warning about missing XML docs -->
 
 		<!-- Container tags (if using container builds) -->
-		<ContainerImageTags>10.0.0-rc;latest</ContainerImageTags>
+		<ContainerImageTags>10.0.0;latest</ContainerImageTags>
 
 		<!-- Prevent MSBuild from excluding common folders (optional) -->
 		<NoDefaultExcludes>true</NoDefaultExcludes>
@@ -49,12 +49,31 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://fullstackhero.net</PackageProjectUrl>
 		<Description>FullStackHero .NET Starter Kit - A production-ready modular .NET framework for building enterprise applications</Description>
-		<!-- Enable NuGet pack globally (overridden in Host/Tests) -->
-		<IsPackable>true</IsPackable>
+		<!--
+		  Distribution model = SOURCE OWNERSHIP. Only TWO packages ship to NuGet.org:
+		  FullStackHero.NET.StarterKit (template, in templates/) and FullStackHero.CLI
+		  (src/Tools/CLI). The template scaffolds full, owned source; modules/framework
+		  are consumed via ProjectReference, never as binary NuGets. So pack is OFF by
+		  default here and explicitly re-enabled ONLY on the CLI. This prevents the 33
+		  module/framework projects from accidentally emitting orphan, mutually-
+		  unresolvable binary packages. CI (backend.yml) packs only those two projects.
+		-->
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<!-- Include root README.md in NuGet packages -->
+	<!-- Reproducible, debuggable packages for the projects that DO ship (CLI). -->
+	<PropertyGroup Condition="'$(IsPackable)' == 'true'">
+		<Deterministic>true</Deterministic>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
 	<ItemGroup Condition="'$(IsPackable)' == 'true'">
+		<!-- Include root README.md in NuGet packages -->
 		<None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="/" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <IsPublishable>true</IsPublishable>
-    <IsPackable>true</IsPackable>
+    <!-- Pack default lives in Directory.Build.props (false; source-ownership model). -->
   </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
   <ItemGroup Label="Aspire">
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
@@ -88,7 +91,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
-    <PackageVersion Include="Serilog" Version="4.3.2-dev-02419" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />

--- a/src/Host/FSH.Starter.Api/appsettings.Development.json
+++ b/src/Host/FSH.Starter.Api/appsettings.Development.json
@@ -26,10 +26,14 @@
   "JwtOptions": {
     "SigningKey": "fsh-dev-only-do-not-use-in-prod-32+chars-min"
   },
+  "HangfireOptions": {
+    "Username": "admin",
+    "Password": "admin"
+  },
   "MailOptions": {
     "SMTP": {
-      "UserName": "anderson22@ethereal.email",
-      "Password": "rqD44sq5P6U2UDCqD1"
+      "UserName": "",
+      "Password": ""
     }
   }
 }

--- a/src/Host/FSH.Starter.Api/appsettings.json
+++ b/src/Host/FSH.Starter.Api/appsettings.json
@@ -68,8 +68,8 @@
     "Redis": ""
   },
   "HangfireOptions": {
-    "Username": "admin",
-    "Password": "Secure1234!Me",
+    "Username": "",
+    "Password": "",
     "Route": "/jobs"
   },
   "PasswordPolicy": {

--- a/src/Modules/Auditing/Modules.Auditing.Contracts/Modules.Auditing.Contracts.csproj
+++ b/src/Modules/Auditing/Modules.Auditing.Contracts/Modules.Auditing.Contracts.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Auditing.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Auditing.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Auditing.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Modules/Auditing/Modules.Auditing/Modules.Auditing.csproj
+++ b/src/Modules/Auditing/Modules.Auditing/Modules.Auditing.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Auditing</RootNamespace>
 		<AssemblyName>FSH.Modules.Auditing</AssemblyName>
-		<PackageId>FullStackHero.Modules.Auditing</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1308;CA1812;CA1859;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Billing/Modules.Billing.Contracts/Modules.Billing.Contracts.csproj
+++ b/src/Modules/Billing/Modules.Billing.Contracts/Modules.Billing.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Billing.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Billing.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Billing.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
+++ b/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Billing</RootNamespace>
 		<AssemblyName>FSH.Modules.Billing</AssemblyName>
-		<PackageId>FullStackHero.Modules.Billing</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Catalog/Modules.Catalog.Contracts/Modules.Catalog.Contracts.csproj
+++ b/src/Modules/Catalog/Modules.Catalog.Contracts/Modules.Catalog.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Catalog.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Catalog.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Catalog.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Catalog/Modules.Catalog/Modules.Catalog.csproj
+++ b/src/Modules/Catalog/Modules.Catalog/Modules.Catalog.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Catalog</RootNamespace>
 		<AssemblyName>FSH.Modules.Catalog</AssemblyName>
-		<PackageId>FullStackHero.Modules.Catalog</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Chat/Modules.Chat.Contracts/Modules.Chat.Contracts.csproj
+++ b/src/Modules/Chat/Modules.Chat.Contracts/Modules.Chat.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Chat.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Chat.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Chat.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
@@ -33,24 +33,26 @@ public sealed class ListMyChannelsQueryHandler(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Batch the unread counts in a single query to avoid N+1.
+        // Single round-trip: for each channel in the page, count this user's unread messages with a
+        // correlated subquery instead of issuing one CountAsync per channel (was N+1, up to 200 round-trips).
+        // Same shape as SearchTicketsQueryHandler's CommentCount subquery.
         var channelIds = channels.Select(c => c.Id).ToList();
-        var unreadByChannel = await db.Channels.AsNoTracking()
+        var unread = await db.Channels.AsNoTracking()
             .Where(c => channelIds.Contains(c.Id))
-            .SelectMany(c => c.Members.Where(m => m.UserId == currentUserId), (c, m) => new { c.Id, LastRead = m.LastReadMessageId })
+            .SelectMany(
+                c => c.Members.Where(m => m.UserId == currentUserId),
+                (c, m) => new
+                {
+                    c.Id,
+                    Unread = db.Messages.Count(msg =>
+                        msg.ChannelId == c.Id
+                        && msg.DeletedAtUtc == null
+                        && (m.LastReadMessageId == null || msg.Id.CompareTo(m.LastReadMessageId.Value) > 0)),
+                })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var unreadMap = new Dictionary<Guid, int>();
-        foreach (var row in unreadByChannel)
-        {
-            unreadMap[row.Id] = await db.Messages.AsNoTracking()
-                .Where(msg => msg.ChannelId == row.Id
-                    && msg.DeletedAtUtc == null
-                    && (row.LastRead == null || msg.Id.CompareTo(row.LastRead.Value) > 0))
-                .CountAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        var unreadMap = unread.ToDictionary(x => x.Id, x => x.Unread);
 
         return channels.Select(c => c.ToDto(unreadMap.GetValueOrDefault(c.Id))).ToList().AsReadOnly();
     }

--- a/src/Modules/Chat/Modules.Chat/Modules.Chat.csproj
+++ b/src/Modules/Chat/Modules.Chat/Modules.Chat.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Chat</RootNamespace>
 		<AssemblyName>FSH.Modules.Chat</AssemblyName>
-		<PackageId>FullStackHero.Modules.Chat</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Files/Modules.Files.Contracts/Modules.Files.Contracts.csproj
+++ b/src/Modules/Files/Modules.Files.Contracts/Modules.Files.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Files.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Files.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Files.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Files/Modules.Files/Modules.Files.csproj
+++ b/src/Modules/Files/Modules.Files/Modules.Files.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Files</RootNamespace>
 		<AssemblyName>FSH.Modules.Files</AssemblyName>
-		<PackageId>FullStackHero.Modules.Files</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Identity/Modules.Identity.Contracts/Modules.Identity.Contracts.csproj
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Modules.Identity.Contracts.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Identity.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Identity.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Identity.Contracts</PackageId>
 		<NoWarn>$(NoWarn);CA1002;CA1056;CS1572;S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/SearchUsers/SearchUsersQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/SearchUsers/SearchUsersQueryHandler.cs
@@ -84,28 +84,14 @@ public sealed class SearchUsersQueryHandler : IQueryHandler<SearchUsersQuery, Pa
 
         var pagedResult = await projected.ToPagedResponseAsync(query, cancellationToken).ConfigureAwait(false);
 
-        // Resolve image URLs for items
-        var items = pagedResult.Items.Select(u => new UserDto
+        // Resolve image URLs in place — the page is already-materialized UserDto instances we own,
+        // so there is no need to allocate a second full list reconstructing every DTO.
+        foreach (var u in pagedResult.Items)
         {
-            Id = u.Id,
-            UserName = u.UserName,
-            FirstName = u.FirstName,
-            LastName = u.LastName,
-            Email = u.Email,
-            IsActive = u.IsActive,
-            EmailConfirmed = u.EmailConfirmed,
-            PhoneNumber = u.PhoneNumber,
-            ImageUrl = ResolveImageUrl(u.ImageUrl)
-        }).ToList();
+            u.ImageUrl = ResolveImageUrl(u.ImageUrl);
+        }
 
-        return new PagedResponse<UserDto>
-        {
-            Items = items,
-            PageNumber = pagedResult.PageNumber,
-            PageSize = pagedResult.PageSize,
-            TotalCount = pagedResult.TotalCount,
-            TotalPages = pagedResult.TotalPages
-        };
+        return pagedResult;
     }
 
     private static readonly Dictionary<string, Expression<Func<FshUser, object?>>> SortableFields = new(StringComparer.OrdinalIgnoreCase)

--- a/src/Modules/Identity/Modules.Identity/Modules.Identity.csproj
+++ b/src/Modules/Identity/Modules.Identity/Modules.Identity.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Identity</RootNamespace>
 		<AssemblyName>FSH.Modules.Identity</AssemblyName>
-		<PackageId>FullStackHero.Modules.Identity</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1812;CA2208;S3267;S3928;CA1062;CA1304;CA1308;CA1311;CA1862;CA2227</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Modules.Multitenancy.Contracts.csproj
+++ b/src/Modules/Multitenancy/Modules.Multitenancy.Contracts/Modules.Multitenancy.Contracts.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Multitenancy.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Multitenancy.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Multitenancy.Contracts</PackageId>
 		<NoWarn>$(NoWarn);CA1056;S2094</NoWarn>
 	</PropertyGroup>
   <ItemGroup>

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Modules.Multitenancy.csproj
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Modules.Multitenancy.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Multitenancy</RootNamespace>
 		<AssemblyName>FSH.Modules.Multitenancy</AssemblyName>
-		<PackageId>FullStackHero.Modules.Multitenancy</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1056;CA1008;CA1716;CA1812;S1135;S2139;S6667;S3267;S1172</NoWarn>
 	</PropertyGroup>
   <ItemGroup>

--- a/src/Modules/Notifications/Modules.Notifications.Contracts/Modules.Notifications.Contracts.csproj
+++ b/src/Modules/Notifications/Modules.Notifications.Contracts/Modules.Notifications.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Notifications.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Notifications.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Notifications.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
+++ b/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Notifications</RootNamespace>
 		<AssemblyName>FSH.Modules.Notifications</AssemblyName>
-		<PackageId>FullStackHero.Modules.Notifications</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Tickets/Modules.Tickets.Contracts/Modules.Tickets.Contracts.csproj
+++ b/src/Modules/Tickets/Modules.Tickets.Contracts/Modules.Tickets.Contracts.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Tickets.Contracts</RootNamespace>
 		<AssemblyName>FSH.Modules.Tickets.Contracts</AssemblyName>
-		<PackageId>FullStackHero.Modules.Tickets.Contracts</PackageId>
 		<NoWarn>$(NoWarn);S2094</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Tickets/Modules.Tickets/Domain/TicketMappings.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Domain/TicketMappings.cs
@@ -4,24 +4,6 @@ namespace FSH.Modules.Tickets.Domain;
 
 internal static class TicketMappings
 {
-    public static TicketDto ToDto(this Ticket t) => new(
-        t.Id,
-        t.Number,
-        t.Title,
-        t.Description,
-        t.Status,
-        t.Priority,
-        t.ReporterUserId,
-        t.AssignedToUserId,
-        t.ResolutionNote,
-        t.CreatedAtUtc,
-        t.UpdatedAtUtc,
-        t.ResolvedAtUtc,
-        t.ClosedAtUtc,
-        t.Comments.Count,
-        t.DeletedOnUtc,
-        t.DeletedBy);
-
     public static TicketDto ToDto(this Ticket t, int commentCount) => new(
         t.Id,
         t.Number,

--- a/src/Modules/Tickets/Modules.Tickets/Modules.Tickets.csproj
+++ b/src/Modules/Tickets/Modules.Tickets/Modules.Tickets.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Tickets</RootNamespace>
 		<AssemblyName>FSH.Modules.Tickets</AssemblyName>
-		<PackageId>FullStackHero.Modules.Tickets</PackageId>
 		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267</NoWarn>
 	</PropertyGroup>
 

--- a/src/Modules/Webhooks/Modules.Webhooks.Contracts/Modules.Webhooks.Contracts.csproj
+++ b/src/Modules/Webhooks/Modules.Webhooks.Contracts/Modules.Webhooks.Contracts.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <RootNamespace>FSH.Modules.Webhooks.Contracts</RootNamespace>
     <AssemblyName>FSH.Modules.Webhooks.Contracts</AssemblyName>
-    <PackageId>FullStackHero.Modules.Webhooks.Contracts</PackageId>
     <NoWarn>$(NoWarn);CA1054;CA1056;S2094</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Modules/Webhooks/Modules.Webhooks/Modules.Webhooks.csproj
+++ b/src/Modules/Webhooks/Modules.Webhooks/Modules.Webhooks.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <RootNamespace>FSH.Modules.Webhooks</RootNamespace>
     <AssemblyName>FSH.Modules.Webhooks</AssemblyName>
-    <PackageId>FullStackHero.Modules.Webhooks</PackageId>
     <NoWarn>$(NoWarn);CA1031;CA1054;CA1056;CA1308;CA1812;CA1859;S3267</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/CLI/FSH.CLI.csproj
+++ b/src/Tools/CLI/FSH.CLI.csproj
@@ -9,6 +9,9 @@
     <ToolCommandName>fsh</ToolCommandName>
     <PackageId>FullStackHero.CLI</PackageId>
     <Description>CLI tool for scaffolding and managing FullStackHero .NET projects.</Description>
+    <PackageIcon>icon.png</PackageIcon>
+    <!-- The CLI exposes no public API surface; an empty XML doc file is dead weight. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <!-- Strip pre-release suffix for AssemblyVersion (requires major.minor.build.revision format) -->
     <AssemblyVersion>10.0.0.0</AssemblyVersion>
@@ -28,6 +31,11 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Spectre.Console.Cli" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Gallery icon for the published tool package. -->
+    <None Include="..\..\..\.template.config\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/templates/FullStackHero.NET.StarterKit.csproj
+++ b/templates/FullStackHero.NET.StarterKit.csproj
@@ -27,6 +27,7 @@
     <RepositoryUrl>https://github.com/fullstackhero/dotnet-starter-kit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>icon.png</PackageIcon>
 
     <TargetFramework>net10.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -53,6 +54,8 @@
              Pack="true"
              PackagePath="content" />
     <Compile Remove="**\*" />
+    <!-- Gallery icon at package root (separate from the .template.config content copy). -->
+    <None Include="..\.template.config\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@
## Why

Pre-publish audit for the **10.0.0 GA launch**. The headline finding: the repo carried two contradictory distribution models — CI publishes only `FullStackHero.CLI` + the template (the locked **source-ownership** model), yet `IsPackable` defaulted `true` and all 33 module/framework projects declared a `PackageId`, so a manual `dotnet pack` emitted orphan, mutually-unresolvable binary packages. This PR makes the build enforce the 2-package reality and hardens everything that actually ships.

## What

**Packaging / distribution model**
- `IsPackable=false` default in `Directory.Build.props`; re-enabled only on the CLI. Stripped 31 vestigial `PackageId`s. → `dotnet pack` of the solution now emits **only `FullStackHero.CLI`**.
- Pinned `Serilog 4.3.2-dev-02419` (a dev-feed build) → stable `4.3.1`, fixing an `NU5104` pack failure for every runtime module under `TreatWarningsAsErrors`.
- Added SourceLink, deterministic + CI builds, symbols (snupkg), and the previously-unused `icon.png` as `PackageIcon` to the shippable packages.
- GA `10.0.0`: container tags moved off `-rc`.

**Security** (these shipped inside the public template)
- Blanked the committed Ethereal SMTP credential and the default Hangfire dashboard password. The Hangfire auth filter is fail-safe; working dev creds moved to `appsettings.Development.json`.

**Performance / dead code**
- SendGrid: singleton `ISendGridClient` instead of per-send construction (socket exhaustion).
- Chat `ListMyChannels`: N+1 unread `CountAsync` → single correlated subquery.
- Eventing: cached handler reflection + `Type.GetType` resolution.
- `ValidationBehavior` (runs on every message): de-allocated 0/1-validator fast paths.
- Storage: source-generated regexes; thread-safe lazy token store.
- Removed dead `Ticket.ToDto()` overload, no-op interceptor override, stale `Web.csproj` globs; sealed 4 types; library `ConfigureAwait(false)` gaps.

## Verification
- Release build clean under `TreatWarningsAsErrors`.
- `dotnet pack` → only `FullStackHero.CLI` (no `NU5104`); template packs clean.
- **Tests: 1,769 passed, 1 skipped (pre-existing), 0 failed** — incl. all Postgres-backed `Integration.Tests` (exercise the rewritten chat query) and `Architecture.Tests`.

## Follow-ups (deferred)
- Changelog + docs for GA in the separate docs repo (golden rule #10).
- Cosmetic polish: internalize infra types, `Extensions`-class renames, XML-doc pass, contract-level allocation changes (`FileUploadRequest`, Outbox batching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@