### PR TITLE
chore(deps): update Aspire to 13.4.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.4.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -96,7 +96,7 @@
     <PackageVersion Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="UAParser" Version="3.1.47" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/src/Host/FSH.Starter.AppHost/FSH.Starter.AppHost.csproj
+++ b/src/Host/FSH.Starter.AppHost/FSH.Starter.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
@
Updates .NET Aspire from 13.3.5 to **13.4.0**.

- `Aspire.AppHost.Sdk` (AppHost `Sdk` attribute) and `Aspire.Hosting.{JavaScript,PostgreSQL,Redis}` → 13.4.0.
- `StackExchange.Redis` 2.11.0 → 2.13.17 — `Aspire.Hosting.Redis 13.4.0` requires `>= 2.13.1` (NU1109 downgrade otherwise).

`global.json` only pins the .NET SDK and is unchanged.

## Verification
- Release build clean (0 errors).
- Full suite: **1,769 passed, 1 skipped (pre-existing), 0 failed**, including `Caching.Tests` and the Redis-backed `Integration.Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@