### PR TITLE
fix: dashboard UX, auditing, identity, chat, and platform fixes

### DIFF
--- a/clients/admin/index.html
+++ b/clients/admin/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Figtree:wght@300..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Outfit:wght@100..900&display=swap"
     />
-    <title>FullStackHero — Admin</title>
+    <title>fullstackhero - Admin</title>
   </head>
   <body class="h-full bg-background text-foreground antialiased">
     <div id="root" class="h-full"></div>

--- a/clients/dashboard/index.html
+++ b/clients/dashboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FullStackHero — Dashboard</title>
+    <title>fullstackhero - Dashboard</title>
 
     <!-- Fonts — only the steady-state three are loaded eagerly:
          Figtree (body), Outfit (display), JetBrains Mono (mono/code).

--- a/clients/dashboard/src/api/audits.ts
+++ b/clients/dashboard/src/api/audits.ts
@@ -142,6 +142,8 @@ export type ListAuditsQuery = {
   tenantId?: string;
   userId?: string;
   eventType?: AuditEventType;
+  /** Hide a single event type (e.g. "Activity" to drop system-level HTTP noise). */
+  excludeEventType?: AuditEventType;
   severity?: AuditSeverity;
   /** Bitmask of AuditTag values. */
   tags?: number;
@@ -166,6 +168,90 @@ function toQueryString(query: Record<string, unknown>): string {
 
 function toPascal(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Human-readable summaries — turn the terse `source` (e.g. "api.chat.ListMyChannels"
+// or "IdentityDbContext") into a plain-English predicate so rows read like an
+// activity feed ("Mukesh · viewed chat channels") without opening the details.
+// The list DTO carries no field-level before/after, so entity changes summarize
+// at the record level; the detail drawer still shows the full payload.
+// ────────────────────────────────────────────────────────────────────────
+
+// Past-tense verb for the leading word of a PascalCase action name.
+const ACTION_VERBS: Record<string, string> = {
+  list: "viewed", get: "viewed", fetch: "viewed", read: "viewed", search: "searched", export: "exported",
+  create: "created", add: "added", register: "registered", invite: "invited", upload: "uploaded", generate: "generated",
+  update: "updated", edit: "updated", set: "updated", change: "changed", adjust: "adjusted", rename: "renamed", reorder: "reordered", renew: "renewed",
+  delete: "deleted", remove: "removed", revoke: "revoked", void: "voided", purge: "purged",
+  assign: "assigned", toggle: "toggled", mark: "marked", confirm: "confirmed", resend: "re-sent",
+  issue: "issued", refresh: "refreshed", enroll: "enrolled in", disable: "disabled", enable: "enabled",
+  restore: "restored", pin: "pinned", unpin: "unpinned", join: "joined", leave: "left", react: "reacted to",
+  impersonate: "impersonated", start: "started", end: "ended", download: "downloaded", capture: "captured",
+};
+
+// Whole-action phrases that don't decompose into a clean verb + object.
+const ACTION_OVERRIDES: Record<string, string> = {
+  IssueJwtToken: "signed in",
+  RefreshToken: "refreshed their session",
+  SseToken: "connected to the live stream",
+  GetUnreadNotificationCount: "checked notifications",
+  ListMyChannels: "opened chat",
+};
+
+function splitPascal(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/[\s._-]+/)
+    .filter(Boolean);
+}
+
+function pastTense(verb: string): string {
+  if (ACTION_VERBS[verb]) return ACTION_VERBS[verb];
+  if (verb.endsWith("e")) return `${verb}d`;
+  if (verb.endsWith("y")) return `${verb.slice(0, -1)}ied`;
+  return `${verb}ed`;
+}
+
+function humanizeAction(action: string, area?: string): string {
+  if (ACTION_OVERRIDES[action]) return ACTION_OVERRIDES[action];
+  const words = splitPascal(action);
+  if (words.length === 0) return area ? `accessed ${area}` : "performed an action";
+  const verb = pastTense(words[0].toLowerCase());
+  const object = words
+    .slice(1)
+    .filter((w) => w.toLowerCase() !== "my")
+    .join(" ")
+    .toLowerCase();
+  const target = object || area || "";
+  return target ? `${verb} ${target}` : verb;
+}
+
+/** Plain-English predicate for an audit row — pairs with the actor shown alongside
+ *  it: `${actor} ${auditPredicate(row)}` → "Mukesh signed in". */
+export function auditPredicate(row: Pick<AuditSummaryDto, "eventType" | "source">): string {
+  const src = (row.source ?? "").trim();
+
+  if (row.eventType === AuditEventType.Exception) {
+    const parts = src.replace(/^api\./i, "").split(".").filter(Boolean);
+    const where = parts.length ? splitPascal(parts[parts.length - 1]).join(" ").toLowerCase() : "";
+    return where ? `hit an error in ${where}` : "hit an error";
+  }
+
+  if (row.eventType === AuditEventType.EntityChange) {
+    const area = src.replace(/DbContext$/i, "").trim();
+    const label = area ? splitPascal(area).join(" ").toLowerCase() : "some";
+    return `changed ${label} records`;
+  }
+
+  // Activity / Security — "api.<area>.<Action>" (or a single segment).
+  const parts = src.replace(/^api\./i, "").split(".").filter(Boolean);
+  if (parts.length === 0) return "performed an action";
+  if (parts.length === 1) return `accessed ${splitPascal(parts[0]).join(" ").toLowerCase()}`;
+  const action = parts[parts.length - 1];
+  const area = parts[0];
+  return humanizeAction(action, area);
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/clients/dashboard/src/api/identity.ts
+++ b/clients/dashboard/src/api/identity.ts
@@ -111,6 +111,20 @@ export async function deleteUser(userId: string): Promise<void> {
   });
 }
 
+export async function confirmUserEmail(userId: string): Promise<void> {
+  await apiFetch<void>(
+    `/api/v1/identity/users/${encodeURIComponent(userId)}/confirm-email`,
+    { method: "POST" },
+  );
+}
+
+export async function resendUserConfirmationEmail(userId: string): Promise<void> {
+  await apiFetch<void>(
+    `/api/v1/identity/users/${encodeURIComponent(userId)}/resend-confirmation-email`,
+    { method: "POST" },
+  );
+}
+
 /**
  * Persist a durable avatar URL on the authenticated user. Typically the publicUrl returned
  * by the Files module after a presigned upload; pass null/empty to clear.
@@ -123,6 +137,15 @@ export async function setProfileImage(imageUrl: string | null): Promise<void> {
 }
 
 /** Fetch the authenticated user's full profile (name, email, phone, imageUrl, etc.). */
+/**
+ * The signed-in user's effective permissions. The JWT carries only role names;
+ * permissions are resolved server-side per role here. The auth context calls
+ * this after login and on subject changes so gated UI reflects the live grants.
+ */
+export async function getMyPermissions(): Promise<string[]> {
+  return (await apiFetch<string[] | null>(`/api/v1/identity/permissions`)) ?? [];
+}
+
 export async function getMyProfile(): Promise<UserDto> {
   return apiFetch<UserDto>("/api/v1/identity/profile");
 }

--- a/clients/dashboard/src/auth/auth-context.tsx
+++ b/clients/dashboard/src/auth/auth-context.tsx
@@ -1,10 +1,10 @@
-import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { tokenStore } from "@/auth/token-store";
 import { decodeJwt, isTokenExpired, type JwtClaims } from "@/auth/jwt";
 import { issueToken } from "@/auth/api";
 import { refreshAccessToken } from "@/lib/api-client";
-import { endImpersonation, startImpersonation } from "@/api/identity";
+import { endImpersonation, getMyPermissions, startImpersonation } from "@/api/identity";
 
 export type AuthUser = {
   id: string;
@@ -33,10 +33,18 @@ export type AuthContextValue = {
    * while this is true, so a stale token never flashes a doomed dashboard.
    */
   isInitializing: boolean;
+  /**
+   * True once permissions have been fetched at least once for the current
+   * subject (or no user is signed in). Lets gated UI avoid flashing while the
+   * permissions request is still in flight.
+   */
+  permissionsHydrated: boolean;
   /** Truthy iff the current access token carries act_sub (impersonation mode). */
   impersonation: ImpersonationInfo | null;
   login: (input: { email: string; password: string; tenant: string }) => Promise<void>;
   logout: () => void;
+  /** Re-fetch the permission set for the signed-in user (e.g. after a role change). */
+  refreshPermissions: () => Promise<void>;
   /** Begin impersonating another user. Resolves once the new token is installed. */
   beginImpersonation: (input: {
     targetUserId: string;
@@ -49,13 +57,11 @@ export type AuthContextValue = {
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-function claimsToUser(claims: JwtClaims | null): AuthUser | null {
+// Permissions are NOT in the JWT (it carries only role names). They're fetched
+// from /api/v1/identity/permissions and cached in the token store; this builds
+// the user from the token's identity claims + that separately-hydrated list.
+function claimsToUser(claims: JwtClaims | null, permissions: string[]): AuthUser | null {
   if (!claims?.sub) return null;
-  const permissions = Array.isArray(claims.permissions)
-    ? claims.permissions
-    : typeof claims.permissions === "string"
-      ? [claims.permissions]
-      : [];
   // `name` is the standard short claim; `unique_name` is what
   // JwtSecurityTokenHandler emits for ClaimTypes.Name. Treat empty
   // strings as missing so the topbar falls through to email/Unknown
@@ -100,8 +106,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const [user, setUser] = useState<AuthUser | null>(() => {
     const { claims, usable } = readStoredSession();
-    return usable ? claimsToUser(claims) : null;
+    return usable ? claimsToUser(claims, tokenStore.getPermissions()) : null;
   });
+  // Hydrated once permissions have been fetched for the current subject. Seed
+  // from any cached list so a warm reload doesn't flash ungated UI.
+  const [permissionsHydrated, setPermissionsHydrated] = useState<boolean>(() => {
+    if (!tokenStore.getAccessToken()) return true;
+    return tokenStore.getPermissions().length > 0;
+  });
+  const lastHydratedSubject = useRef<string | null>(null);
   const [impersonation, setImpersonation] = useState<ImpersonationInfo | null>(() => {
     const { claims, usable } = readStoredSession();
     return usable ? claimsToImpersonation(claims) : null;
@@ -135,10 +148,42 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Hydrate (or re-hydrate) the permission list from the server whenever the
+  // signed-in subject changes — covers cold-start, login, and impersonation
+  // swaps. Permissions live server-side per role, not in the JWT.
+  useEffect(() => {
+    if (!user) {
+      lastHydratedSubject.current = null;
+      setPermissionsHydrated(true);
+      return;
+    }
+    if (lastHydratedSubject.current === user.id && permissionsHydrated) {
+      return;
+    }
+    lastHydratedSubject.current = user.id;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const perms = await getMyPermissions();
+        if (cancelled) return;
+        // setPermissions emits → the subscribe listener rebuilds `user` with the list.
+        tokenStore.setPermissions(perms);
+        setPermissionsHydrated(true);
+      } catch {
+        // A fetch failure must not sign the user out — gated UI just stays
+        // hidden until the next successful hydration.
+        if (!cancelled) setPermissionsHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, permissionsHydrated]);
+
   useEffect(() => {
     const refresh = () => {
       const claims = decodeJwt(tokenStore.getAccessToken());
-      setUser(claimsToUser(claims));
+      setUser(claimsToUser(claims, tokenStore.getPermissions()));
       setImpersonation(claimsToImpersonation(claims));
     };
     const unsubscribe = tokenStore.subscribe(refresh);
@@ -167,6 +212,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback(
     async (input: { email: string; password: string; tenant: string }) => {
       tokenStore.setTenant(input.tenant);
+      // Stale permissions from a previous user must not leak into the new
+      // session — clear before issuing the token so the hydration effect
+      // re-fetches from scratch.
+      tokenStore.setPermissions([]);
+      setPermissionsHydrated(false);
       const tokens = await issueToken(input);
       // Defence-in-depth: even though the API rejects root-tenant logins
       // submitted with X-FSH-App=dashboard, double-check the issued token
@@ -243,18 +293,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [queryClient, logout]);
 
+  const refreshPermissions = useCallback(async () => {
+    try {
+      const perms = await getMyPermissions();
+      tokenStore.setPermissions(perms);
+    } catch {
+      /* swallow — see hydration effect */
+    }
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
       isAuthenticated: user !== null,
       isInitializing,
+      permissionsHydrated,
       impersonation,
       login,
       logout,
       beginImpersonation,
       stopImpersonation,
+      refreshPermissions,
     }),
-    [user, isInitializing, impersonation, login, logout, beginImpersonation, stopImpersonation],
+    [user, isInitializing, permissionsHydrated, impersonation, login, logout, beginImpersonation, stopImpersonation, refreshPermissions],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/clients/dashboard/src/auth/token-store.ts
+++ b/clients/dashboard/src/auth/token-store.ts
@@ -1,6 +1,7 @@
 const ACCESS_KEY = "fsh.dashboard.accessToken";
 const REFRESH_KEY = "fsh.dashboard.refreshToken";
 const TENANT_KEY = "fsh.dashboard.tenant";
+const PERMS_KEY = "fsh.dashboard.permissions";
 
 // Impersonation stash. While an operator is impersonating another user,
 // the live token store holds the impersonation tokens; the operator's
@@ -23,6 +24,28 @@ export const tokenStore = {
   getRefreshToken: () => localStorage.getItem(REFRESH_KEY),
   getTenant: () => localStorage.getItem(TENANT_KEY),
 
+  /**
+   * Permissions are fetched separately from the JWT (the token only carries
+   * role names — see GetCurrentUserPermissionsEndpoint server-side). Cached
+   * here so gated UI can read them synchronously; re-hydrated on each login
+   * and whenever the signed-in subject changes (incl. impersonation swaps).
+   */
+  getPermissions(): string[] {
+    try {
+      const raw = localStorage.getItem(PERMS_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw) as unknown;
+      return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === "string") : [];
+    } catch {
+      return [];
+    }
+  },
+
+  setPermissions(permissions: string[]) {
+    localStorage.setItem(PERMS_KEY, JSON.stringify(permissions));
+    emit();
+  },
+
   setTokens(accessToken: string, refreshToken: string) {
     localStorage.setItem(ACCESS_KEY, accessToken);
     localStorage.setItem(REFRESH_KEY, refreshToken);
@@ -37,6 +60,7 @@ export const tokenStore = {
   clear() {
     localStorage.removeItem(ACCESS_KEY);
     localStorage.removeItem(REFRESH_KEY);
+    localStorage.removeItem(PERMS_KEY);
     // Also clear any impersonation stash so a fresh login doesn't
     // inherit half of a previous operator's session.
     localStorage.removeItem(STASH_ACCESS_KEY);
@@ -62,6 +86,9 @@ export const tokenStore = {
 
     localStorage.setItem(ACCESS_KEY, impersonationAccessToken);
     localStorage.removeItem(REFRESH_KEY);
+    // Drop the operator's permissions — the impersonated subject has its own;
+    // the auth context re-hydrates on the subject change.
+    localStorage.removeItem(PERMS_KEY);
     if (impersonatedTenant) localStorage.setItem(TENANT_KEY, impersonatedTenant);
     emit();
   },
@@ -74,6 +101,7 @@ export const tokenStore = {
     const stashTenant = localStorage.getItem(STASH_TENANT_KEY);
     localStorage.setItem(ACCESS_KEY, accessToken);
     localStorage.setItem(REFRESH_KEY, refreshToken);
+    localStorage.removeItem(PERMS_KEY);
     if (stashTenant) localStorage.setItem(TENANT_KEY, stashTenant);
     localStorage.removeItem(STASH_ACCESS_KEY);
     localStorage.removeItem(STASH_REFRESH_KEY);
@@ -94,6 +122,7 @@ export const tokenStore = {
     if (!access) return false;
     localStorage.setItem(ACCESS_KEY, access);
     if (refresh) localStorage.setItem(REFRESH_KEY, refresh);
+    localStorage.removeItem(PERMS_KEY);
     if (tenant) localStorage.setItem(TENANT_KEY, tenant);
     localStorage.removeItem(STASH_ACCESS_KEY);
     localStorage.removeItem(STASH_REFRESH_KEY);

--- a/clients/dashboard/src/components/file/image-input.tsx
+++ b/clients/dashboard/src/components/file/image-input.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { Image as ImageIcon, Loader2, Upload, X, Link as LinkIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -97,6 +97,12 @@ export function ImageInput({
   const isWorking = isUploading || resolveUrl.isPending;
   const tileClass = shape === "circle" ? "rounded-full" : "rounded-xl";
 
+  // Show the placeholder (not a broken-image icon) when the current URL fails to
+  // load — e.g. a seeded default-avatar URL that 404s. Reset on every URL change.
+  const [imgFailed, setImgFailed] = useState(false);
+  useEffect(() => setImgFailed(false), [value]);
+  const showImage = hasImage && !imgFailed;
+
   return (
     <div className={cn("space-y-3", className)}>
       {/* Mode toggle */}
@@ -117,8 +123,13 @@ export function ImageInput({
             shape === "circle" ? "h-20 w-20 rounded-full" : "h-24 w-24 rounded-xl",
           )}
         >
-          {hasImage ? (
-            <img src={value} alt="" className={cn("h-full w-full object-cover", tileClass)} />
+          {showImage ? (
+            <img
+              src={value}
+              alt=""
+              onError={() => setImgFailed(true)}
+              className={cn("h-full w-full object-cover", tileClass)}
+            />
           ) : isWorking ? (
             <Loader2 className="h-5 w-5 animate-spin text-[var(--color-primary)]" />
           ) : (
@@ -133,9 +144,9 @@ export function ImageInput({
                 {isWorking
                   ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
                   : <Upload className="h-3.5 w-3.5" />}
-                {hasImage ? "Replace image" : "Choose image"}
+                {showImage ? "Replace image" : "Choose image"}
               </Button>
-              {hasImage && !isWorking && (
+              {showImage && !isWorking && (
                 <Button type="button" size="sm" variant="outline" onClick={() => onChange("")}>
                   <X className="h-3.5 w-3.5" />
                   Remove

--- a/clients/dashboard/src/components/layout/topbar.tsx
+++ b/clients/dashboard/src/components/layout/topbar.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
   Check,
   ChevronsUpDown,
@@ -35,6 +36,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar } from "@/components/ui/avatar";
+import { getMyProfile } from "@/api/identity";
 import { useAuth } from "@/auth/use-auth";
 import { useSseStatus } from "@/sse/sse-context";
 import { useTheme } from "@/components/theme/theme-provider";
@@ -57,6 +59,35 @@ function initialsOf(name?: string | null): string {
     .join("")
     .slice(0, 2)
     .toUpperCase();
+}
+
+/** Square rose-tinted user tile (dos pattern) — shows the profile photo when set,
+ *  falling back to initials when there's no image or it fails to load. */
+function SquareUserAvatar({ src, name }: { src?: string | null; name?: string | null }) {
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [src]);
+  const showImage = Boolean(src) && !failed;
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "grid size-8 shrink-0 place-items-center overflow-hidden rounded-lg",
+        "bg-[oklch(from_var(--color-primary)_l_c_h_/_0.15)] text-[var(--color-primary)]",
+        "font-display text-[11px] font-bold tracking-tight",
+      )}
+    >
+      {showImage ? (
+        <img
+          src={src ?? undefined}
+          alt=""
+          onError={() => setFailed(true)}
+          className="size-full object-cover"
+        />
+      ) : (
+        initialsOf(name)
+      )}
+    </span>
+  );
 }
 
 /** Theme-pick row inside the dropdown — icon + label + check on the
@@ -117,6 +148,14 @@ function SimpleMenuItem({
 
 export function Topbar() {
   const { user, logout } = useAuth();
+  // Shared with the Profile settings page (same query key), so changing the
+  // photo there invalidates this and the topbar avatar updates live.
+  const { data: profile } = useQuery({
+    queryKey: ["identity", "me"],
+    queryFn: getMyProfile,
+    staleTime: 5 * 60 * 1000,
+  });
+  const avatarUrl = profile?.imageUrl ?? null;
   const { status: sseStatus, eventCount } = useSseStatus();
   const { mode, setMode } = useTheme();
   const { setOpen: setPaletteOpen } = useCommandPalette();
@@ -230,17 +269,8 @@ export function Topbar() {
               "data-[state=open]:bg-[var(--color-accent)]",
             )}
           >
-            {/* Rose-tinted square initials tile (dos pattern) */}
-            <span
-              aria-hidden
-              className={cn(
-                "grid size-8 shrink-0 place-items-center rounded-lg",
-                "bg-[oklch(from_var(--color-primary)_l_c_h_/_0.15)] text-[var(--color-primary)]",
-                "font-display text-[11px] font-bold tracking-tight",
-              )}
-            >
-              {initialsOf(user?.name ?? user?.email)}
-            </span>
+            {/* Rose-tinted square avatar tile — photo if set, else initials. */}
+            <SquareUserAvatar src={avatarUrl} name={user?.name ?? user?.email} />
             {/* Name + role caption — desktop only */}
             <div className="hidden min-w-0 text-left md:block">
               <p className="truncate text-[12px] font-medium leading-none text-[var(--color-foreground)]">
@@ -343,7 +373,7 @@ export function Topbar() {
           </DialogHeader>
           <DialogBody>
             <div className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2.5">
-              <Avatar name={user?.name ?? user?.email ?? "?"} size="md" />
+              <Avatar name={user?.name ?? user?.email ?? "?"} src={avatarUrl} size="md" />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-medium tracking-tight">
                   {user?.name ?? user?.email ?? "Unknown"}

--- a/clients/dashboard/src/components/list/entity-detail.tsx
+++ b/clients/dashboard/src/components/list/entity-detail.tsx
@@ -144,6 +144,12 @@ export function EntityDetailAvatar({
         .toUpperCase() || "·"
     : "·";
 
+  // Fall back to the icon/initials when the image is missing OR fails to load
+  // (e.g. a seeded default-avatar URL that 404s) — never show a broken image.
+  const [imgFailed, setImgFailed] = React.useState(false);
+  React.useEffect(() => setImgFailed(false), [src]);
+  const showImage = Boolean(src) && !imgFailed;
+
   return (
     <div
       className={cn(
@@ -153,8 +159,13 @@ export function EntityDetailAvatar({
         className,
       )}
     >
-      {src ? (
-        <img src={src} alt="" className="size-full object-cover" />
+      {showImage ? (
+        <img
+          src={src ?? undefined}
+          alt=""
+          onError={() => setImgFailed(true)}
+          className="size-full object-cover"
+        />
       ) : Icon ? (
         <Icon className="size-5 text-[var(--color-primary)] sm:size-6" />
       ) : (

--- a/clients/dashboard/src/lib/list-helpers.ts
+++ b/clients/dashboard/src/lib/list-helpers.ts
@@ -17,6 +17,18 @@ export function formatDateMono(iso: string | null | undefined) {
   return dateLong.format(new Date(iso)).toUpperCase().replace(",", "");
 }
 
+// "3:42 PM" — local wall-clock time. Intl renders in the browser's timezone.
+const timeShort = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+// "APR 30 2026 · 3:42 PM" — date + local time for audit/detail panels.
+export function formatDateTimeMono(iso: string | null | undefined) {
+  if (!iso) return "—";
+  return `${formatDateMono(iso)} · ${timeShort.format(new Date(iso))}`;
+}
+
 // "3d ago", "2mo ago" — terse relative time for the secondary line.
 export function formatRelative(iso: string | null | undefined) {
   if (!iso) return "";

--- a/clients/dashboard/src/pages/audits.tsx
+++ b/clients/dashboard/src/pages/audits.tsx
@@ -24,6 +24,7 @@ import {
   AUDIT_EVENT_TYPE_LABELS,
   AUDIT_SEVERITY_LABELS,
   AUDIT_TAG_LABELS,
+  auditPredicate,
   severityRank,
   decodeTags,
   getAuditById,
@@ -38,6 +39,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import {
   EntityEmpty,
   EntityInitialsAvatar,
@@ -62,7 +64,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cn } from "@/lib/cn";
 
 const PAGE_SIZE = 25;
-const DESKTOP_COLS = "grid-cols-[1.6fr_140px_1.2fr_180px]";
+const DESKTOP_COLS = "grid-cols-[minmax(0,1fr)_minmax(0,2fr)_96px_160px]";
 
 // ────────────────────────────────────────────────────────────────────────
 // Time-range presets — keep the SQL window predictable from the UI.
@@ -159,6 +161,8 @@ type FilterState = {
   correlation: string;
   trace: string;
   search: string;
+  /** Hide the firehose of system-level Activity (HTTP) events. On by default. */
+  hideSystem: boolean;
   page: number;
 };
 
@@ -172,6 +176,7 @@ const INITIAL_FILTERS: FilterState = {
   correlation: "",
   trace: "",
   search: "",
+  hideSystem: true,
   page: 1,
 };
 
@@ -204,6 +209,12 @@ export function AuditsPage() {
           fromUtc: window_.from,
           toUtc: window_.to,
           eventType: (filters.eventType ?? undefined) as AuditEventType | undefined,
+          // Hide system Activity unless the user has explicitly filtered TO Activity
+          // (in which case they clearly want to see it).
+          excludeEventType:
+            filters.hideSystem && filters.eventType !== AuditEventType.Activity
+              ? AuditEventType.Activity
+              : undefined,
           severity: (filters.severity ?? undefined) as AuditSeverity | undefined,
           tags: filters.tagsMask || undefined,
           source: filters.source || undefined,
@@ -368,8 +379,8 @@ export function AuditsPage() {
           <EntityListCard className="hidden md:block">
             <EntityListHeader className={DESKTOP_COLS}>
               <span>Actor</span>
-              <span>Action</span>
-              <span>Entity</span>
+              <span>Event</span>
+              <span>Severity</span>
               <span>Timestamp</span>
             </EntityListHeader>
             {items.map((row, i) => (
@@ -445,8 +456,9 @@ function AuditMobileCard({
           <EntityInitialsAvatar name={actor} size={40} />
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
-              <p className="truncate text-[14px] font-medium text-[var(--color-foreground)]">
-                {actor}
+              <p className="truncate text-[14px] text-[var(--color-foreground)]">
+                <span className="font-semibold">{actor}</span>{" "}
+                {auditPredicate(row)}
               </p>
               <EntityStatusBadge
                 tone={tone === "danger" ? "danger" : tone === "warning" ? "warning" : tone === "info" ? "info" : "default"}
@@ -511,44 +523,43 @@ function AuditDesktopRow({
         </div>
       </div>
 
-      {/* Action (event type + severity) */}
-      <div className="flex min-w-0 items-center gap-1.5">
-        <Icon className="size-3.5 shrink-0" style={{ color: toneColor }} aria-hidden />
+      {/* Event — the plain-English summary is the hero; the raw source sits
+          beneath it, muted, for anyone who wants the exact endpoint. */}
+      <div className="flex min-w-0 items-start gap-2.5">
+        <Icon className="mt-[3px] size-4 shrink-0" style={{ color: toneColor }} aria-hidden />
         <div className="min-w-0">
-          <div className="truncate text-[12.5px] font-medium tracking-tight">
-            {AUDIT_EVENT_TYPE_LABELS[row.eventType]}
+          <div className="truncate text-[13px] font-medium leading-snug tracking-tight text-[var(--color-foreground)] first-letter:uppercase">
+            {auditPredicate(row)}
           </div>
-          <EntityStatusBadge
-            tone={tone === "danger" ? "danger" : tone === "warning" ? "warning" : tone === "info" ? "info" : "default"}
-          >
-            {AUDIT_SEVERITY_LABELS[row.severity]}
-          </EntityStatusBadge>
-        </div>
-      </div>
-
-      {/* Entity (source + tags) */}
-      <div className="min-w-0">
-        <code className="block truncate font-mono text-[12px] text-[var(--color-foreground)]">
-          {row.source ?? "—"}
-        </code>
-        {tags.length > 0 && (
-          <div className="mt-0.5 flex flex-wrap items-center gap-1">
+          <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
+            <code className="truncate font-mono text-[11px] text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.8)]">
+              {row.source ?? "—"}
+            </code>
             {tags.slice(0, 2).map((name) => (
               <span
                 key={name}
-                className="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-muted)] px-1.5 py-0 font-mono text-[10px]"
+                className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-[var(--color-muted)] px-1.5 py-0 font-mono text-[10px] text-[var(--color-muted-foreground)]"
               >
                 <Tag className="size-2.5" />
                 {name}
               </span>
             ))}
             {tags.length > 2 && (
-              <span className="font-mono text-[10px] text-[var(--color-muted-foreground)]">
+              <span className="shrink-0 font-mono text-[10px] text-[var(--color-muted-foreground)]">
                 +{tags.length - 2}
               </span>
             )}
           </div>
-        )}
+        </div>
+      </div>
+
+      {/* Severity */}
+      <div className="flex items-center">
+        <EntityStatusBadge
+          tone={tone === "danger" ? "danger" : tone === "warning" ? "warning" : tone === "info" ? "info" : "default"}
+        >
+          {AUDIT_SEVERITY_LABELS[row.severity]}
+        </EntityStatusBadge>
       </div>
 
       {/* Timestamp */}
@@ -767,6 +778,26 @@ function FilterBar({
               </Badge>
             )}
           </Button>
+
+          {/* Hide the system-level Activity firehose (HTTP request audits). On by
+              default so the trail reads as meaningful events, not infrastructure noise. */}
+          <div
+            className="flex shrink-0 items-center gap-2"
+            title="Hide the per-request system Activity events (api.*) so only meaningful audits show"
+          >
+            <Switch
+              aria-label="Hide system activity"
+              checked={filters.hideSystem}
+              onCheckedChange={(v) => onPatch({ hideSystem: v })}
+            />
+            <button
+              type="button"
+              onClick={() => onPatch({ hideSystem: !filters.hideSystem })}
+              className="select-none text-[12px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
+            >
+              Hide system activity
+            </button>
+          </div>
 
           {activeChipCount > 0 && (
             <button

--- a/clients/dashboard/src/pages/catalog/brands.tsx
+++ b/clients/dashboard/src/pages/catalog/brands.tsx
@@ -588,6 +588,7 @@ function DeleteBrandDialog({
     onSuccess: () => {
       toast.success("Brand deleted");
       queryClient.invalidateQueries({ queryKey: ["catalog", "brands"] });
+      queryClient.invalidateQueries({ queryKey: ["trash", "brands"] });
       onClose();
     },
     onError: (err) => toast.error("Delete failed", { description: describe(err) }),

--- a/clients/dashboard/src/pages/catalog/categories.tsx
+++ b/clients/dashboard/src/pages/catalog/categories.tsx
@@ -675,6 +675,7 @@ function DeleteCategoryDialog({
     onSuccess: () => {
       toast.success("Category deleted");
       queryClient.invalidateQueries({ queryKey: ["catalog", "categories"] });
+      queryClient.invalidateQueries({ queryKey: ["trash", "categories"] });
       onClose();
     },
     onError: (err) => toast.error("Delete failed", { description: describe(err) }),

--- a/clients/dashboard/src/pages/catalog/product-detail.tsx
+++ b/clients/dashboard/src/pages/catalog/product-detail.tsx
@@ -76,7 +76,7 @@ import { cn } from "@/lib/cn";
 import {
   describe,
   formatDate,
-  formatDateMono,
+  formatDateTimeMono,
   formatMoney,
   formatRelative,
 } from "@/lib/list-helpers";
@@ -520,13 +520,13 @@ function AuditPanel({ product }: { product: ProductDto }) {
     <dl className="grid grid-cols-1 gap-x-6 gap-y-3 text-[13px] sm:grid-cols-2">
       <MetaRow
         label="Created"
-        value={formatDateMono(product.createdAtUtc)}
+        value={formatDateTimeMono(product.createdAtUtc)}
         hint={formatRelative(product.createdAtUtc)}
       />
       {product.updatedAtUtc ? (
         <MetaRow
           label="Revised"
-          value={formatDateMono(product.updatedAtUtc)}
+          value={formatDateTimeMono(product.updatedAtUtc)}
           hint={formatRelative(product.updatedAtUtc)}
         />
       ) : (
@@ -858,6 +858,7 @@ function DeleteDialog({
     onSuccess: () => {
       toast.success("Product deleted");
       queryClient.invalidateQueries({ queryKey: ["catalog", "products"] });
+      queryClient.invalidateQueries({ queryKey: ["trash", "products"] });
       onClose();
       onDeleted();
     },

--- a/clients/dashboard/src/pages/catalog/products.tsx
+++ b/clients/dashboard/src/pages/catalog/products.tsx
@@ -347,7 +347,7 @@ export function ProductsPage() {
           {/* Desktop: table */}
           <div className="hidden overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] shadow-xs md:block">
             {/* Header */}
-            <div className="grid grid-cols-[1fr_120px_24px] gap-3 border-b border-[var(--color-border)] bg-[oklch(from_var(--color-muted)_l_c_h_/_0.4)] px-5 py-3 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)] lg:grid-cols-[1fr_140px_110px_120px_24px]">
+            <div className="grid grid-cols-[1fr_120px_24px] gap-3 border-b border-[var(--color-border)] bg-[oklch(from_var(--color-muted)_l_c_h_/_0.4)] px-5 py-3 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)] lg:grid-cols-[1fr_140px_110px_120px_90px]">
               <span>Product</span>
               <span>SKU</span>
               <span className="hidden lg:block">Brand</span>
@@ -521,7 +521,7 @@ function DesktopRow({
       className={cn(
         "group grid grid-cols-[1fr_120px_24px] items-center gap-3 px-5 py-3 transition-colors duration-100",
         "hover:bg-[oklch(from_var(--color-accent)_l_c_h_/_0.4)]",
-        "lg:grid-cols-[1fr_140px_110px_120px_24px]",
+        "lg:grid-cols-[1fr_140px_110px_120px_90px]",
         !isLast && "border-b border-[oklch(from_var(--color-border)_l_c_h_/_0.3)]",
         !product.isActive && "opacity-75",
       )}
@@ -1369,6 +1369,7 @@ function DeleteProductDialog({
     onSuccess: () => {
       toast.success("Product deleted");
       queryClient.invalidateQueries({ queryKey: ["catalog", "products"] });
+      queryClient.invalidateQueries({ queryKey: ["trash", "products"] });
       onClose();
     },
     onError: (err) => toast.error("Delete failed", { description: describe(err) }),

--- a/clients/dashboard/src/pages/identity/user-detail.tsx
+++ b/clients/dashboard/src/pages/identity/user-detail.tsx
@@ -28,10 +28,12 @@ import {
   adminRevokeAllUserSessions,
   adminRevokeUserSession,
   assignUserRoles,
+  confirmUserEmail,
   deleteUser,
   getUserById,
   getUserRoles,
   getUserSessionsAdmin,
+  resendUserConfirmationEmail,
   toggleUserStatus,
   type AdminUserSessionDto,
   type UserRoleDto,
@@ -91,6 +93,7 @@ export function UserDetailPage() {
   const canImpersonate = (actor?.permissions ?? []).includes("Permissions.Users.Impersonate");
   const canViewSessions = (actor?.permissions ?? []).includes("Permissions.Sessions.ViewAll");
   const canRevokeSessions = (actor?.permissions ?? []).includes("Permissions.Sessions.RevokeAll");
+  const canConfirmEmail = (actor?.permissions ?? []).includes("Permissions.Users.ConfirmEmail");
 
   const userQuery = useQuery({
     queryKey: ["identity", "users", userId],
@@ -177,6 +180,28 @@ export function UserDetailPage() {
       setDialog({ mode: "closed" });
     },
     onError: (err) => toast.error("Status change failed", { description: describe(err) }),
+  });
+
+  const confirmEmail = useMutation({
+    mutationFn: () => {
+      if (!user?.id) throw new Error("Missing user id");
+      return confirmUserEmail(user.id);
+    },
+    onSuccess: () => {
+      toast.success("Email confirmed");
+      void queryClient.invalidateQueries({ queryKey: ["identity", "users", userId] });
+      void queryClient.invalidateQueries({ queryKey: ["identity", "users"] });
+    },
+    onError: (err) => toast.error("Confirm email failed", { description: describe(err) }),
+  });
+
+  const resendConfirmation = useMutation({
+    mutationFn: () => {
+      if (!user?.id) throw new Error("Missing user id");
+      return resendUserConfirmationEmail(user.id);
+    },
+    onSuccess: () => toast.success("Confirmation email sent"),
+    onError: (err) => toast.error("Couldn't send confirmation email", { description: describe(err) }),
   });
 
   const removeUser = useMutation({
@@ -334,6 +359,30 @@ export function UserDetailPage() {
               >
                 <UserCog className="h-3.5 w-3.5" /> Impersonate
               </Button>
+            )}
+            {canConfirmEmail && !user.emailConfirmed && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => resendConfirmation.mutate()}
+                  disabled={resendConfirmation.isPending}
+                  className="gap-1.5"
+                >
+                  <Mail className="h-3.5 w-3.5" />
+                  {resendConfirmation.isPending ? "Sending…" : "Resend confirmation"}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => confirmEmail.mutate()}
+                  disabled={confirmEmail.isPending}
+                  className="gap-1.5"
+                >
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                  {confirmEmail.isPending ? "Confirming…" : "Confirm email"}
+                </Button>
+              </>
             )}
             <Button
               variant="outline"

--- a/clients/dashboard/src/pages/overview.tsx
+++ b/clients/dashboard/src/pages/overview.tsx
@@ -1174,8 +1174,11 @@ export function OverviewPage() {
               <span
                 aria-hidden
                 className={cn(
-                  "inline-block size-1.5 rounded-full",
-                  sseStatus === "connected" && "pulse-dot",
+                  "inline-block size-1.5 shrink-0 rounded-full",
+                  // Contained opacity pulse — the design-system .pulse-dot halo
+                  // (an overflowing ::before ring) gets clipped by this sublabel's
+                  // `truncate` (overflow-hidden), so it can't be used here.
+                  sseStatus === "connected" && "animate-pulse",
                 )}
                 style={{
                   backgroundColor:
@@ -1184,8 +1187,6 @@ export function OverviewPage() {
                       : sseStatus === "error"
                         ? "var(--color-destructive)"
                         : "var(--color-muted-foreground)",
-                  color:
-                    sseStatus === "connected" ? "var(--color-success)" : undefined,
                 }}
               />
               <span className="capitalize">{sseStatus}</span>

--- a/clients/dashboard/src/pages/settings/security.tsx
+++ b/clients/dashboard/src/pages/settings/security.tsx
@@ -3,8 +3,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   AlertCircle,
+  Check,
   ClipboardCheck,
   Copy,
+  Eye,
+  EyeOff,
   KeyRound,
   LogOut,
   MonitorSmartphone,
@@ -23,6 +26,7 @@ import {
 } from "@/components/ui/card";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -289,6 +293,95 @@ function PasswordCard() {
   );
 }
 
+// Labelled password field with an inline show/hide toggle. Reusable across the
+// security dialogs so every secret entry behaves identically.
+function PasswordField({
+  id,
+  label,
+  value,
+  onChange,
+  autoComplete,
+  autoFocus,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  autoComplete: string;
+  autoFocus?: boolean;
+}) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="relative">
+        <Input
+          id={id}
+          type={show ? "text" : "password"}
+          autoComplete={autoComplete}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          autoFocus={autoFocus}
+          required
+          className="pr-10"
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={show ? `Hide ${label.toLowerCase()}` : `Show ${label.toLowerCase()}`}
+          onClick={() => setShow((s) => !s)}
+          className="absolute right-1.5 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-md text-[var(--color-muted-foreground)] outline-none transition-colors hover:text-[var(--color-foreground)] focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// 0–4 heuristic: length tiers + mixed case + digit/symbol. Drives the meter only;
+// the server enforces the real policy.
+function passwordStrength(pw: string): { score: number; label: string } {
+  if (!pw) return { score: 0, label: "" };
+  let s = 0;
+  if (pw.length >= 8) s++;
+  if (pw.length >= 12) s++;
+  if (/[a-z]/.test(pw) && /[A-Z]/.test(pw)) s++;
+  if (/\d/.test(pw) && /[^A-Za-z0-9]/.test(pw)) s++;
+  s = Math.max(1, Math.min(4, s));
+  return { score: s, label: ["", "Weak", "Fair", "Good", "Strong"][s] };
+}
+
+function StrengthMeter({ password }: { password: string }) {
+  if (!password) return null;
+  const { score, label } = passwordStrength(password);
+  const tone =
+    score <= 1
+      ? "var(--color-destructive)"
+      : score < 4
+        ? "var(--color-warning)"
+        : "var(--color-success)";
+  return (
+    <div className="mt-2 flex items-center gap-2.5">
+      <div className="flex flex-1 gap-1" aria-hidden>
+        {[1, 2, 3, 4].map((i) => (
+          <span
+            key={i}
+            className="h-1 flex-1 rounded-full transition-colors duration-[var(--duration-fast)]"
+            style={{ backgroundColor: i <= score ? tone : "var(--color-muted)" }}
+          />
+        ))}
+      </div>
+      <span
+        className="shrink-0 text-[11px] font-semibold tabular-nums"
+        style={{ color: tone }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
 function ChangePasswordDialog({
   open,
   onOpenChange,
@@ -350,60 +443,70 @@ function ChangePasswordDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Change password</DialogTitle>
+          <div className="flex items-center gap-3">
+            <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-[oklch(from_var(--color-primary)_l_c_h_/_0.10)] ring-1 ring-inset ring-[oklch(from_var(--color-primary)_l_c_h_/_0.20)]">
+              <KeyRound className="size-4 text-[var(--color-primary)]" />
+            </span>
+            <DialogTitle>Change password</DialogTitle>
+          </div>
           <DialogDescription>
-            Sign-out events for other devices aren't fired automatically —
-            visit the Sessions list below to end them after rotating your password.
+            Pick a strong password you don&apos;t reuse elsewhere. Your other
+            signed-in sessions stay active — revoke them below if you want them out.
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={onSubmit} className="space-y-3" noValidate>
-          <div className="space-y-1.5">
-            <Label htmlFor="cp-current">Current password</Label>
-            <Input
+        <form onSubmit={onSubmit} className="contents" noValidate>
+          <DialogBody className="space-y-4">
+            <PasswordField
               id="cp-current"
-              type="password"
-              autoComplete="current-password"
+              label="Current password"
               value={current}
-              onChange={(e) => setCurrent(e.target.value)}
-              required
+              onChange={setCurrent}
+              autoComplete="current-password"
               autoFocus
             />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="cp-next">New password</Label>
-            <Input
-              id="cp-next"
-              type="password"
-              autoComplete="new-password"
-              value={next}
-              onChange={(e) => setNext(e.target.value)}
-              required
-              minLength={8}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="cp-confirm">Confirm new password</Label>
-            <Input
-              id="cp-confirm"
-              type="password"
-              autoComplete="new-password"
-              value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
-              required
-              minLength={8}
-            />
-          </div>
 
-          {localError && (
-            <div
-              role="alert"
-              className="flex items-start gap-2 rounded-md border border-[oklch(from_var(--color-destructive)_l_c_h_/_0.40)] bg-[oklch(from_var(--color-destructive)_l_c_h_/_0.08)] px-3 py-2 text-sm text-[var(--color-destructive)]"
-            >
-              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span className="leading-snug">{localError}</span>
+            <div>
+              <PasswordField
+                id="cp-next"
+                label="New password"
+                value={next}
+                onChange={setNext}
+                autoComplete="new-password"
+              />
+              <StrengthMeter password={next} />
             </div>
-          )}
+
+            <div>
+              <PasswordField
+                id="cp-confirm"
+                label="Confirm new password"
+                value={confirm}
+                onChange={setConfirm}
+                autoComplete="new-password"
+              />
+              {confirm.length > 0 &&
+                (confirm === next ? (
+                  <p className="mt-1.5 flex items-center gap-1 text-[11px] font-medium text-[var(--color-success)]">
+                    <Check className="size-3.5" /> Passwords match
+                  </p>
+                ) : (
+                  <p className="mt-1.5 text-[11px] text-[var(--color-muted-foreground)]">
+                    Passwords don&apos;t match yet
+                  </p>
+                ))}
+            </div>
+
+            {localError && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-lg border border-[oklch(from_var(--color-destructive)_l_c_h_/_0.40)] bg-[oklch(from_var(--color-destructive)_l_c_h_/_0.08)] px-3 py-2 text-sm text-[var(--color-destructive)]"
+              >
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span className="leading-snug">{localError}</span>
+              </div>
+            )}
+          </DialogBody>
 
           <DialogFooter>
             <Button
@@ -675,17 +778,13 @@ function TwoFactorDisable() {
         a new QR code.
       </p>
       <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
-        <div className="space-y-1.5">
-          <Label htmlFor="disable-pw">Current password</Label>
-          <Input
-            id="disable-pw"
-            type="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="font-mono"
-          />
-        </div>
+        <PasswordField
+          id="disable-pw"
+          label="Current password"
+          value={password}
+          onChange={setPassword}
+          autoComplete="current-password"
+        />
         <Button
           type="button"
           variant="destructive"

--- a/clients/dashboard/src/pages/system/trash.tsx
+++ b/clients/dashboard/src/pages/system/trash.tsx
@@ -34,6 +34,15 @@ import {
   type FileAssetDto,
 } from "@/api/files";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/cn";
 import {
   EntityEmpty,
@@ -376,9 +385,11 @@ function TrashShell<T>({
   mapRow: (item: T) => RowVm;
 }) {
   const navigate = useNavigate();
+  const [pendingId, setPendingId] = useState<string | null>(null);
   const items = query.data?.items ?? [];
   const total = query.data?.totalCount ?? 0;
   const rows = items.map(mapRow);
+  const pendingRow = rows.find((r) => r.id === pendingId) ?? null;
 
   if (query.isLoading && rows.length === 0) {
     return <EntityListLoading desktopColumns={DESKTOP_COLS} />;
@@ -426,7 +437,11 @@ function TrashShell<T>({
       {/* Mobile cards */}
       <div className="space-y-2 md:hidden">
         {rows.map((row) => (
-          <TrashMobileCard key={row.id} row={row} />
+          <TrashMobileCard
+            key={row.id}
+            row={row}
+            onRequestRestore={() => setPendingId(row.id)}
+          />
         ))}
       </div>
 
@@ -439,7 +454,12 @@ function TrashShell<T>({
           <span className="text-right">Actions</span>
         </EntityListHeader>
         {rows.map((row, i) => (
-          <TrashDesktopRow key={row.id} row={row} isLast={i === rows.length - 1} />
+          <TrashDesktopRow
+            key={row.id}
+            row={row}
+            isLast={i === rows.length - 1}
+            onRequestRestore={() => setPendingId(row.id)}
+          />
         ))}
       </EntityListCard>
 
@@ -451,7 +471,59 @@ function TrashShell<T>({
         onPrev={() => setPageNumber(Math.max(1, pageNumber - 1))}
         onNext={() => setPageNumber(pageNumber + 1)}
       />
+
+      <RestoreConfirmDialog
+        row={pendingRow}
+        label={label}
+        onClose={() => setPendingId(null)}
+        onConfirm={() => {
+          pendingRow?.onRestore();
+          setPendingId(null);
+        }}
+      />
     </div>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+//  Restore confirmation
+// ───────────────────────────────────────────────────────────────────────
+
+function RestoreConfirmDialog({
+  row,
+  label,
+  onClose,
+  onConfirm,
+}: {
+  row: RowVm | null;
+  label: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const singular = label.replace(/s$/, "").toLowerCase();
+  return (
+    <Dialog open={row !== null} onOpenChange={(o) => (!o ? onClose() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Restore {singular}?</DialogTitle>
+          <DialogDescription>
+            <span className="font-medium text-[var(--color-foreground)]">{row?.title}</span>{" "}
+            will be moved back to its {singular} list with the same ID and history intact.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="button" onClick={onConfirm} className="gap-1.5">
+            <RotateCcw className="size-3.5" />
+            Restore {singular}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -470,7 +542,13 @@ function tabPath(label: string): string {
 //  Mobile card
 // ───────────────────────────────────────────────────────────────────────
 
-function TrashMobileCard({ row }: { row: RowVm }) {
+function TrashMobileCard({
+  row,
+  onRequestRestore,
+}: {
+  row: RowVm;
+  onRequestRestore: () => void;
+}) {
   return (
     <div
       className={cn(
@@ -493,7 +571,7 @@ function TrashMobileCard({ row }: { row: RowVm }) {
         <Button
           variant="outline"
           size="sm"
-          onClick={row.onRestore}
+          onClick={onRequestRestore}
           disabled={row.isRestoring}
           className="shrink-0 gap-1.5"
         >
@@ -520,7 +598,15 @@ function TrashMobileCard({ row }: { row: RowVm }) {
 //  Desktop row
 // ───────────────────────────────────────────────────────────────────────
 
-function TrashDesktopRow({ row, isLast }: { row: RowVm; isLast: boolean }) {
+function TrashDesktopRow({
+  row,
+  isLast,
+  onRequestRestore,
+}: {
+  row: RowVm;
+  isLast: boolean;
+  onRequestRestore: () => void;
+}) {
   return (
     <EntityListRow className={DESKTOP_COLS} isLast={isLast}>
       {/* Entity */}
@@ -558,7 +644,7 @@ function TrashDesktopRow({ row, isLast }: { row: RowVm; isLast: boolean }) {
         <Button
           variant="outline"
           size="sm"
-          onClick={row.onRestore}
+          onClick={onRequestRestore}
           disabled={row.isRestoring}
           className="gap-1.5"
         >

--- a/clients/dashboard/vite.config.ts
+++ b/clients/dashboard/vite.config.ts
@@ -1,14 +1,45 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import fs from "node:fs";
 import path from "node:path";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const apiBase = env.VITE_API_BASE_URL ?? "https://localhost:7030";
 
+  // Dev only: serve the runtime config with apiBase pointed straight at the API. This makes
+  // REST + the long-lived SSE / SignalR streams hit localhost:7030 directly instead of being
+  // proxied through Vite. Otherwise those streams hold connections on localhost:5174 and, under
+  // HTTP/1.1's ~6-per-host cap, intermittently starve lazy route-chunk loads ("page won't load").
+  // The committed public/config.json keeps apiBase="" as the same-origin production default.
+  const devDirectApiConfig: Plugin = {
+    name: "fsh-dev-direct-api-config",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? "";
+        if (url !== "/config.json" && !url.startsWith("/config.json?")) {
+          next();
+          return;
+        }
+        let base: Record<string, unknown> = {};
+        try {
+          base = JSON.parse(
+            fs.readFileSync(path.resolve(__dirname, "public/config.json"), "utf8"),
+          ) as Record<string, unknown>;
+        } catch {
+          // Fall back to defaults if the file is missing/unreadable.
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Cache-Control", "no-store");
+        res.end(JSON.stringify({ ...base, apiBase }));
+      });
+    },
+  };
+
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [devDirectApiConfig, react(), tailwindcss()],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),

--- a/src/Host/FSH.Starter.Api/appsettings.Development.json
+++ b/src/Host/FSH.Starter.Api/appsettings.Development.json
@@ -31,9 +31,14 @@
     "Password": "Password123!"
   },
   "MailOptions": {
+    "UseSendGrid": false,
+    "From": "nicole.lueilwitz0@ethereal.email",
+    "DisplayName": "Mukesh Murugan",
     "SMTP": {
-      "UserName": "",
-      "Password": ""
+      "Host": "smtp.ethereal.email",
+      "Port": 587,
+      "UserName": "nicole.lueilwitz0@ethereal.email",
+      "Password": "x4VJz2r9x2NDss9KpC"
     }
   }
 }

--- a/src/Host/FSH.Starter.Api/appsettings.json
+++ b/src/Host/FSH.Starter.Api/appsettings.json
@@ -58,7 +58,7 @@
   },
   "DatabaseOptions": {
     "Provider": "POSTGRESQL",
-    "ConnectionString": "Server=localhost;Database=fsh;User Id=postgres;Password=password",
+    "ConnectionString": "Server=localhost;Database=fsh;User Id=postgres;Password=password;Minimum Pool Size=5",
     "MigrationsAssembly": "FSH.Starter.Migrations.PostgreSQL"
   },
   "OriginOptions": {

--- a/src/Host/FSH.Starter.AppHost/AppHost.cs
+++ b/src/Host/FSH.Starter.AppHost/AppHost.cs
@@ -20,6 +20,10 @@ var postgresServer = builder.AddPostgres("postgres")
 
 var postgres = postgresServer.AddDatabase("fsh-db");
 
+// Warm pooled-connection floor for the long-running API — Npgsql's default Minimum Pool Size of 0 lets the pool drain to cold, so /health/ready's ~10 concurrent DbContext checks cold-open a cohort at once and intermittently stall the probe; a floor keeps connections warm for reuse.
+var apiPgConnection = ReferenceExpression.Create(
+    $"{postgres.Resource.ConnectionStringExpression};Minimum Pool Size=5");
+
 // Valkey (BSD-3 Redis fork) as a plain container: Aspire 13.4.0 AddRedis() forces TLS-by-default in run mode and never materializes the container, so we drop to plain RESP over TCP. Name stays "redis" so config keys don't churn.
 var redis = builder.AddContainer("redis", "valkey/valkey", "9.1.0")
     .WithEndpoint(targetPort: 6379, scheme: "tcp", name: "tcp")
@@ -109,13 +113,21 @@ var api = builder.AddProject<Projects.FSH_Starter_Api>($"{appPrefix}-api")
     .WaitForCompletion(demoSeeder)
     .WithExternalHttpEndpoints()
     .WithEnvironment("DatabaseOptions__Provider", "POSTGRESQL")
-    .WithEnvironment("DatabaseOptions__ConnectionString", postgres.Resource.ConnectionStringExpression)
+    .WithEnvironment("DatabaseOptions__ConnectionString", apiPgConnection)
     .WithEnvironment("DatabaseOptions__MigrationsAssembly", "FSH.Starter.Migrations.PostgreSQL")
     .WithEnvironment("CachingOptions__Redis", redisConnectionString)
     .WithEnvironment("CachingOptions__EnableSsl", "false")
     // Hangfire dashboard (/jobs) creds — [Required], Password [MinLength(12)], ValidateOnStart; API won't boot without them. Dev-only, mirrors appsettings.Development.json.
     .WithEnvironment("HangfireOptions__UserName", "admin")
     .WithEnvironment("HangfireOptions__Password", "Password123!")
+    // SMTP via Ethereal (https://ethereal.email) — fake catch-all inbox for local dev (nothing delivered); mirrors appsettings.Development.json. Safe to commit: throwaway test creds.
+    .WithEnvironment("MailOptions__UseSendGrid", "false")
+    .WithEnvironment("MailOptions__From", "nicole.lueilwitz0@ethereal.email")
+    .WithEnvironment("MailOptions__DisplayName", "Mukesh Murugan")
+    .WithEnvironment("MailOptions__Smtp__Host", "smtp.ethereal.email")
+    .WithEnvironment("MailOptions__Smtp__Port", "587")
+    .WithEnvironment("MailOptions__Smtp__UserName", "nicole.lueilwitz0@ethereal.email")
+    .WithEnvironment("MailOptions__Smtp__Password", "x4VJz2r9x2NDss9KpC")
     .WithEnvironment("Storage__Provider", "s3")
     .WithEnvironment("Storage__S3__Bucket", MinioBucket)
     .WithEnvironment("Storage__S3__Region", "us-east-1")

--- a/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
+++ b/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
@@ -4,6 +4,9 @@ using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Shared.Constants;
 using FSH.Framework.Shared.Identity.Claims;
 using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Billing.Contracts;
+using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Domain;
 using FSH.Modules.Catalog.Data;
 using FSH.Modules.Catalog.Domain;
 using FSH.Modules.Chat.Data;
@@ -49,13 +52,15 @@ internal sealed class DemoSeeder
         Id: "acme",
         Name: "Acme Corp",
         AdminEmail: "admin@acme.com",
-        Issuer: "fsh.demo.acme");
+        Issuer: "fsh.demo.acme",
+        PlanKey: "pro-annual");
 
     public static readonly DemoTenant Globex = new(
         Id: "globex",
         Name: "Globex",
         AdminEmail: "admin@globex.com",
-        Issuer: "fsh.demo.globex");
+        Issuer: "fsh.demo.globex",
+        PlanKey: "free");
 
     public DemoSeeder(IServiceProvider services, IConfiguration config, ILogger<DemoSeeder> logger)
     {
@@ -76,6 +81,7 @@ internal sealed class DemoSeeder
 
         foreach (var demo in new[] { Acme, Globex })
         {
+            await SeedTenantSubscriptionAsync(demo, cancellationToken).ConfigureAwait(false);
             await SeedTenantUsersAsync(demo, cancellationToken).ConfigureAwait(false);
             await SeedTenantCatalogAsync(demo, cancellationToken).ConfigureAwait(false);
             await SeedTenantTicketsAsync(demo, cancellationToken).ConfigureAwait(false);
@@ -161,6 +167,105 @@ internal sealed class DemoSeeder
 
         tenantDb.Add(provisioning);
         await tenantDb.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    // ─── Subscription ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Attaches an active billing <see cref="Subscription"/> to the demo tenant so the dashboard's
+    /// PLAN / subscription cards are populated out of the box. The real tenant-create path drives this
+    /// via <c>TenantSubscribedIntegrationEvent</c>, but demo tenants are provisioned inline (see
+    /// <see cref="EnsureDemoTenantsExistAsync"/>) and never publish it — so we write the row directly.
+    ///
+    /// Paid plans also get an issued term invoice, matching the real flow. It's written directly
+    /// rather than via <c>IBillingService</c> so we don't publish <c>InvoiceIssuedIntegrationEvent</c>
+    /// — the one-shot migrator has no outbox dispatcher and demo seeding shouldn't fire
+    /// notifications/emails. The subscription's term is aligned to the tenant's <c>ValidUpto</c> so the
+    /// dashboard's term matches the enforced validity window.
+    ///
+    /// Idempotent: skips when the tenant already has an active subscription.
+    /// </summary>
+    private async Task SeedTenantSubscriptionAsync(DemoTenant demo, CancellationToken cancellationToken)
+    {
+        using var scope = _services.CreateScope();
+        var tenantStore = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<AppTenantInfo>>();
+        var tenant = await tenantStore.GetAsync(demo.Id).ConfigureAwait(false);
+        if (tenant is null) return;
+
+        // BillingDbContext is NOT tenant-filtered (TenantId is an explicit column), so no Finbuckle
+        // context juggling is required — we scope by TenantId directly.
+        var billingDb = scope.ServiceProvider.GetRequiredService<BillingDbContext>();
+
+        var plan = await billingDb.Plans
+            .FirstOrDefaultAsync(p => p.Key == demo.PlanKey && p.IsActive, cancellationToken)
+            .ConfigureAwait(false);
+        if (plan is null)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "[demo-seed] [{Tenant}] plan '{PlanKey}' not found — skipping subscription", demo.Id, demo.PlanKey);
+            }
+            return;
+        }
+
+        // Reuse the existing active subscription's term if there is one (so re-runs don't re-subscribe
+        // — but still backfill a missing invoice for it); otherwise start a fresh subscription aligned
+        // to the tenant's ValidUpto.
+        var existing = await billingDb.Subscriptions
+            .FirstOrDefaultAsync(s => s.TenantId == demo.Id && s.Status == SubscriptionStatus.Active, cancellationToken)
+            .ConfigureAwait(false);
+
+        var startUtc = existing?.StartUtc ?? DateTime.UtcNow;
+        var endUtc = existing?.EndUtc ?? DateTime.SpecifyKind(tenant.ValidUpto, DateTimeKind.Utc);
+
+        if (existing is null)
+        {
+            billingDb.Subscriptions.Add(Subscription.Create(demo.Id, plan.Id, startUtc, endUtc));
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "[demo-seed] [{Tenant}] subscribed to plan '{PlanKey}' (term ends {End:o})",
+                    demo.Id, plan.Key, endUtc);
+            }
+        }
+
+        // Paid plans get an issued term invoice, matching the real CreateTenant flow. Created directly
+        // (no IBillingService) so we don't publish InvoiceIssuedIntegrationEvent — the migrator has no
+        // outbox dispatcher and demo seeding shouldn't fire notifications/emails. Idempotent (keyed on
+        // the invoice number), so it also backfills an already-subscribed tenant. Free plans (term
+        // price 0) get none, exactly like production.
+        if (plan.TermPrice > 0m)
+        {
+            var invoiceNumber = string.Create(
+                CultureInfo.InvariantCulture, $"SUB-{startUtc:yyyyMM}-{demo.Id.ToUpperInvariant()}");
+            var invoiceExists = await billingDb.Invoices
+                .AnyAsync(i => i.TenantId == demo.Id && i.InvoiceNumber == invoiceNumber, cancellationToken)
+                .ConfigureAwait(false);
+            if (!invoiceExists)
+            {
+                var invoice = Invoice.CreateDraft(
+                    demo.Id, invoiceNumber, startUtc.Year, startUtc.Month, plan.Currency,
+                    InvoicePurpose.Subscription, startUtc, endUtc);
+                invoice.AddLineItem(
+                    InvoiceLineItemKind.BaseFee,
+                    string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"{plan.Name} — {plan.Interval} subscription ({startUtc:yyyy-MM-dd} to {endUtc:yyyy-MM-dd})"),
+                    1m,
+                    plan.TermPrice);
+                invoice.Issue();
+                billingDb.Invoices.Add(invoice);
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation(
+                        "[demo-seed] [{Tenant}] issued term invoice {InvoiceNumber} ({Amount} {Currency})",
+                        demo.Id, invoiceNumber, plan.TermPrice, plan.Currency);
+                }
+            }
+        }
+
+        await billingDb.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     // ─── Users + roles ─────────────────────────────────────────────────
@@ -594,7 +699,7 @@ internal sealed class DemoSeeder
 
     // ─── Demo content shapes ───────────────────────────────────────────
 
-    internal sealed record DemoTenant(string Id, string Name, string AdminEmail, string Issuer);
+    internal sealed record DemoTenant(string Id, string Name, string AdminEmail, string Issuer, string PlanKey);
     internal sealed record DemoUser(
         string UserName,
         string Email,

--- a/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetAudits/GetAuditsQuery.cs
+++ b/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetAudits/GetAuditsQuery.cs
@@ -23,6 +23,10 @@ public sealed class GetAuditsQuery : IPagedQuery, IQuery<PagedResponse<AuditSumm
 
     public AuditEventType? EventType { get; set; }
 
+    /// <summary>Hide a single event type (e.g. <c>Activity</c> to drop system-level HTTP noise).
+    /// Applied as a not-equals filter so paging + totals stay correct.</summary>
+    public AuditEventType? ExcludeEventType { get; set; }
+
     public AuditSeverity? Severity { get; set; }
 
     public AuditTag? Tags { get; set; }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
@@ -66,6 +66,11 @@ public sealed class GetAuditsQueryHandler : IQueryHandler<GetAuditsQuery, PagedR
             audits = audits.Where(a => a.EventType == (int)query.EventType.Value);
         }
 
+        if (query.ExcludeEventType.HasValue)
+        {
+            audits = audits.Where(a => a.EventType != (int)query.ExcludeEventType.Value);
+        }
+
         if (query.Severity.HasValue)
         {
             audits = audits.Where(a => a.Severity == (byte)query.Severity.Value);

--- a/src/Modules/Auditing/Modules.Auditing/Infrastructure/Http/AuditHttpMiddleware.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Infrastructure/Http/AuditHttpMiddleware.cs
@@ -19,7 +19,7 @@ public sealed class AuditHttpMiddleware
     {
         ArgumentNullException.ThrowIfNull(ctx);
 
-        if (ShouldSkip(ctx))
+        if (ShouldSkip(ctx) || IsStreamingResponse(ctx))
         {
             await _next(ctx).ConfigureAwait(false);
             return;
@@ -200,6 +200,16 @@ public sealed class AuditHttpMiddleware
         return _opts.ExcludePathStartsWith.Any(prefix =>
             path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
     }
+
+    // Streaming responses (Server-Sent Events, and the SignalR SSE transport) must never be buffered.
+    // The audit path swaps Response.Body for a MemoryStream and only copies it to the real socket once
+    // the handler returns — but a long-lived stream's handler never returns until the client
+    // disconnects, so the browser would receive nothing (no headers, no events) and sit forever on
+    // "connecting". Detect the SSE handshake by its Accept header and pass the request straight
+    // through, untouched. The stream's token/auth requests are short-lived and still audited normally.
+    private static bool IsStreamingResponse(HttpContext ctx) =>
+        ctx.Request.Headers.Accept.Any(static v =>
+            v is not null && v.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));
 
     private readonly record struct RequestCaptureContext(object? Preview, int Size, int MaskedFields);
 }

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
@@ -13,7 +13,14 @@ public sealed class DeleteProductCommandHandler(CatalogDbContext dbContext)
     {
         ArgumentNullException.ThrowIfNull(command);
 
+        // IgnoreAutoIncludes is load-bearing: Product.Images is AutoInclude'd and cascade-deleted.
+        // If we let the images load here, Remove() cascades EntityState.Deleted onto them, and the
+        // soft-delete interceptor only rescues owned references (Price/Money) — not this non-owned
+        // child collection — so EF would HARD-delete the image rows while the product is merely
+        // soft-deleted. Restoring the product would then come back with no images. Leaving the images
+        // untracked means the soft delete is a pure UPDATE and the image rows survive for restore.
         var product = await dbContext.Products
+            .IgnoreAutoIncludes()
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new NotFoundException($"Product {command.ProductId} not found.");

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChatAttachmentUrls.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChatAttachmentUrls.cs
@@ -1,0 +1,66 @@
+using FSH.Modules.Chat.Contracts.v1.DTOs;
+using FSH.Modules.Files.Contracts.v1.Queries;
+using Mediator;
+
+namespace FSH.Modules.Chat.Features.v1.Internal;
+
+/// <summary>
+/// Resolves message attachment URLs at <b>read</b> time. Chat files are uploaded Private, so the URL
+/// persisted on a <see cref="MessageAttachmentDto"/> is a short-lived presigned URL captured at send
+/// time — it expires, breaking historical images. For every attachment that carries a
+/// <c>FileAssetId</c> we mint a fresh presigned URL via <see cref="GetFileDownloadUrlQuery"/> (which
+/// also enforces the file's access policy), so the link is always valid when the page is fetched.
+/// If a file can't be resolved (deleted / access denied) the stored URL is kept as a best-effort
+/// fallback rather than failing the whole page.
+/// </summary>
+internal static class ChatAttachmentUrls
+{
+    public static async Task<List<MessageDto>> ResolveAsync(
+        IReadOnlyList<MessageDto> messages,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(mediator);
+
+        var ids = messages
+            .SelectMany(m => m.Attachments)
+            .Where(a => a.FileAssetId is { } id && id != Guid.Empty)
+            .Select(a => a.FileAssetId!.Value)
+            .Distinct()
+            .ToList();
+
+        if (ids.Count == 0)
+        {
+            return [.. messages];
+        }
+
+        // Sequential by design: each Send resolves through the Files module's scoped DbContext, so
+        // firing them concurrently would race that single context. The set is small (images per page).
+        var resolved = new Dictionary<Guid, string>(ids.Count);
+        foreach (var id in ids)
+        {
+            try
+            {
+                var presigned = await mediator
+                    .Send(new GetFileDownloadUrlQuery(id, Inline: true), cancellationToken)
+                    .ConfigureAwait(false);
+                resolved[id] = presigned.Url.ToString();
+            }
+#pragma warning disable CA1031 // a missing/forbidden file must not break the whole message page
+            catch (Exception ex) when (ex is not OperationCanceledException)
+#pragma warning restore CA1031
+            {
+                // Keep the stored URL as a best-effort fallback.
+            }
+        }
+
+        return [.. messages.Select(m => m with
+        {
+            Attachments = [.. m.Attachments.Select(a =>
+                a.FileAssetId is { } fid && resolved.TryGetValue(fid, out var url)
+                    ? a with { Url = url }
+                    : a)],
+        })];
+    }
+}

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/GetPinnedMessages/GetPinnedMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/GetPinnedMessages/GetPinnedMessagesQueryHandler.cs
@@ -12,7 +12,8 @@ namespace FSH.Modules.Chat.Features.v1.Messages.GetPinnedMessages;
 
 public sealed class GetPinnedMessagesQueryHandler(
     ChatDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    IMediator mediator)
     : IQueryHandler<GetPinnedMessagesQuery, ReadOnlyCollection<MessageDto>>
 {
     public async ValueTask<ReadOnlyCollection<MessageDto>> Handle(
@@ -38,6 +39,8 @@ public sealed class GetPinnedMessagesQueryHandler(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return rows.Select(m => m.ToDto()).ToList().AsReadOnly();
+        var dtos = rows.Select(m => m.ToDto()).ToList();
+        var resolved = await ChatAttachmentUrls.ResolveAsync(dtos, mediator, cancellationToken).ConfigureAwait(false);
+        return resolved.AsReadOnly();
     }
 }

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListChannelMessages/ListChannelMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListChannelMessages/ListChannelMessagesQueryHandler.cs
@@ -12,7 +12,8 @@ namespace FSH.Modules.Chat.Features.v1.Messages.ListChannelMessages;
 
 public sealed class ListChannelMessagesQueryHandler(
     ChatDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    IMediator mediator)
     : IQueryHandler<ListChannelMessagesQuery, ReadOnlyCollection<MessageDto>>
 {
     public async ValueTask<ReadOnlyCollection<MessageDto>> Handle(
@@ -46,6 +47,8 @@ public sealed class ListChannelMessagesQueryHandler(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return rows.Select(m => m.ToDto()).ToList().AsReadOnly();
+        var dtos = rows.Select(m => m.ToDto()).ToList();
+        var resolved = await ChatAttachmentUrls.ResolveAsync(dtos, mediator, cancellationToken).ConfigureAwait(false);
+        return resolved.AsReadOnly();
     }
 }

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListMessageReplies/ListMessageRepliesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListMessageReplies/ListMessageRepliesQueryHandler.cs
@@ -12,7 +12,8 @@ namespace FSH.Modules.Chat.Features.v1.Messages.ListMessageReplies;
 
 public sealed class ListMessageRepliesQueryHandler(
     ChatDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    IMediator mediator)
     : IQueryHandler<ListMessageRepliesQuery, ReadOnlyCollection<MessageDto>>
 {
     public async ValueTask<ReadOnlyCollection<MessageDto>> Handle(
@@ -54,6 +55,8 @@ public sealed class ListMessageRepliesQueryHandler(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return rows.Select(m => m.ToDto()).ToList().AsReadOnly();
+        var dtos = rows.Select(m => m.ToDto()).ToList();
+        var resolved = await ChatAttachmentUrls.ResolveAsync(dtos, mediator, cancellationToken).ConfigureAwait(false);
+        return resolved.AsReadOnly();
     }
 }

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
@@ -13,7 +13,8 @@ namespace FSH.Modules.Chat.Features.v1.Search;
 
 public sealed class SearchMessagesQueryHandler(
     ChatDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    IMediator mediator)
     : IQueryHandler<SearchMessagesQuery, ReadOnlyCollection<MessageDto>>
 {
     public async ValueTask<ReadOnlyCollection<MessageDto>> Handle(
@@ -70,6 +71,8 @@ LIMIT {pageSize} OFFSET {offset}
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return rows.Select(m => m.ToDto()).ToList().AsReadOnly();
+        var dtos = rows.Select(m => m.ToDto()).ToList();
+        var resolved = await ChatAttachmentUrls.ResolveAsync(dtos, mediator, cancellationToken).ConfigureAwait(false);
+        return resolved.AsReadOnly();
     }
 }

--- a/src/Modules/Identity/Modules.Identity.Contracts/Authorization/IdentityPermissions.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Authorization/IdentityPermissions.cs
@@ -20,6 +20,7 @@ public static class IdentityPermissions
         public const string Export        = $"Permissions.{Resource}.Export";
         public const string ManageRoles   = $"Permissions.{Resource}.ManageRoles";
         public const string Impersonate   = $"Permissions.{Resource}.Impersonate";
+        public const string ConfirmEmail  = $"Permissions.{Resource}.ConfirmEmail";
     }
 
     public static class UserRoles
@@ -83,6 +84,7 @@ public static class IdentityPermissions
         new("Export Users",        ActionConstants.Export, Users.Resource),
         new("Manage User Roles",   "ManageRoles",          Users.Resource),
         new("Impersonate User",    "Impersonate",          Users.Resource),
+        new("Confirm User Email",  "ConfirmEmail",         Users.Resource),
 
         new("View User Roles",     ActionConstants.View,   UserRoles.Resource, IsBasic: true),
         new("Update User Roles",   ActionConstants.Update, UserRoles.Resource),

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserRegistrationService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserRegistrationService.cs
@@ -32,6 +32,19 @@ public interface IUserRegistrationService
     Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Administratively marks a user's email as confirmed without a confirmation token. Gated by the
+    /// <c>Permissions.Users.ConfirmEmail</c> permission at the endpoint. Idempotent.
+    /// </summary>
+    Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-sends the email-confirmation link to a user who has not yet confirmed their address.
+    /// <paramref name="origin"/> is the request base URL used to build the confirmation link.
+    /// Throws if the user's email is already confirmed.
+    /// </summary>
+    Task ResendConfirmationEmailAsync(string userId, string origin, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Confirms a user's phone number.
     /// </summary>
     Task<string> ConfirmPhoneNumberAsync(string userId, string code, CancellationToken cancellationToken = default);

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
@@ -18,6 +18,8 @@ public interface IUserService
     Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default);
     Task DeleteAsync(string userId, CancellationToken cancellationToken = default);
     Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken);
+    Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default);
+    Task ResendConfirmationEmailAsync(string userId, string origin, CancellationToken cancellationToken = default);
     Task<string> ConfirmPhoneNumberAsync(string userId, string code, CancellationToken cancellationToken = default);
 
     // permisions

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommand.cs
@@ -1,0 +1,9 @@
+using Mediator;
+
+namespace FSH.Modules.Identity.Contracts.v1.Users.AdminConfirmEmail;
+
+/// <summary>
+/// Administratively confirms a user's email (no confirmation token). Gated by
+/// <c>Permissions.Users.ConfirmEmail</c> at the endpoint.
+/// </summary>
+public sealed record AdminConfirmEmailCommand(string UserId) : ICommand<Unit>;

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommand.cs
@@ -1,0 +1,10 @@
+using Mediator;
+
+namespace FSH.Modules.Identity.Contracts.v1.Users.ResendConfirmationEmail;
+
+/// <summary>
+/// Re-sends the email-confirmation link to an unconfirmed user. Gated by
+/// <c>Permissions.Users.ConfirmEmail</c> at the endpoint. <see cref="Origin"/> is the request base
+/// URL used to build the confirmation link (set by the endpoint).
+/// </summary>
+public sealed record ResendConfirmationEmailCommand(string UserId, string Origin) : ICommand<Unit>;

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandHandler.cs
@@ -1,0 +1,24 @@
+using FSH.Modules.Identity.Contracts.Services;
+using FSH.Modules.Identity.Contracts.v1.Users.AdminConfirmEmail;
+using Mediator;
+
+namespace FSH.Modules.Identity.Features.v1.Users.AdminConfirmEmail;
+
+public sealed class AdminConfirmEmailCommandHandler : ICommandHandler<AdminConfirmEmailCommand, Unit>
+{
+    private readonly IUserService _userService;
+
+    public AdminConfirmEmailCommandHandler(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    public async ValueTask<Unit> Handle(AdminConfirmEmailCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _userService.AdminConfirmEmailAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.AdminConfirmEmail;
+
+namespace FSH.Modules.Identity.Features.v1.Users.AdminConfirmEmail;
+
+public sealed class AdminConfirmEmailCommandValidator : AbstractValidator<AdminConfirmEmailCommand>
+{
+    public AdminConfirmEmailCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailEndpoint.cs
@@ -1,0 +1,35 @@
+using FSH.Framework.Shared.Identity.Authorization;
+using FSH.Modules.Identity.Contracts.Authorization;
+using FSH.Modules.Identity.Contracts.v1.Users.AdminConfirmEmail;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace FSH.Modules.Identity.Features.v1.Users.AdminConfirmEmail;
+
+public static class AdminConfirmEmailEndpoint
+{
+    internal static RouteHandlerBuilder MapAdminConfirmEmailEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapPost("/users/{id:guid}/confirm-email", Handler)
+        .WithName("AdminConfirmEmail")
+        .WithSummary("Confirm a user's email (admin)")
+        .RequirePermission(IdentityPermissions.Users.ConfirmEmail)
+        .WithDescription("Marks another user's email address as confirmed without a confirmation token.")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<NoContent> Handler(
+        Guid id,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(new AdminConfirmEmailCommand(id.ToString()), cancellationToken);
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandHandler.cs
@@ -1,0 +1,24 @@
+using FSH.Modules.Identity.Contracts.Services;
+using FSH.Modules.Identity.Contracts.v1.Users.ResendConfirmationEmail;
+using Mediator;
+
+namespace FSH.Modules.Identity.Features.v1.Users.ResendConfirmationEmail;
+
+public sealed class ResendConfirmationEmailCommandHandler : ICommandHandler<ResendConfirmationEmailCommand, Unit>
+{
+    private readonly IUserService _userService;
+
+    public ResendConfirmationEmailCommandHandler(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    public async ValueTask<Unit> Handle(ResendConfirmationEmailCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _userService.ResendConfirmationEmailAsync(command.UserId, command.Origin, cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using FSH.Modules.Identity.Contracts.v1.Users.ResendConfirmationEmail;
+
+namespace FSH.Modules.Identity.Features.v1.Users.ResendConfirmationEmail;
+
+public sealed class ResendConfirmationEmailCommandValidator : AbstractValidator<ResendConfirmationEmailCommand>
+{
+    public ResendConfirmationEmailCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailEndpoint.cs
@@ -1,0 +1,38 @@
+using FSH.Framework.Shared.Identity.Authorization;
+using FSH.Modules.Identity.Contracts.Authorization;
+using FSH.Modules.Identity.Contracts.v1.Users.ResendConfirmationEmail;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace FSH.Modules.Identity.Features.v1.Users.ResendConfirmationEmail;
+
+public static class ResendConfirmationEmailEndpoint
+{
+    internal static RouteHandlerBuilder MapResendConfirmationEmailEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapPost("/users/{id:guid}/resend-confirmation-email", Handler)
+        .WithName("ResendConfirmationEmail")
+        .WithSummary("Resend a user's email confirmation (admin)")
+        .RequirePermission(IdentityPermissions.Users.ConfirmEmail)
+        .WithDescription("Re-sends the email-confirmation link to a user who has not confirmed their address yet.")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<NoContent> Handler(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        // Build the confirmation-link base URL from the request, same as the registration endpoint.
+        var origin = $"{context.Request.Scheme}://{context.Request.Host.Value}{context.Request.PathBase.Value}";
+        await mediator.Send(new ResendConfirmationEmailCommand(id.ToString(), origin), cancellationToken);
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Modules/Identity/Modules.Identity/IdentityModule.cs
+++ b/src/Modules/Identity/Modules.Identity/IdentityModule.cs
@@ -46,7 +46,9 @@ using FSH.Modules.Identity.Features.v1.TwoFactor.Enroll;
 using FSH.Modules.Identity.Features.v1.TwoFactor.VerifyEnroll;
 using FSH.Modules.Identity.Features.v1.Users.AssignUserRoles;
 using FSH.Modules.Identity.Features.v1.Users.ChangePassword;
+using FSH.Modules.Identity.Features.v1.Users.AdminConfirmEmail;
 using FSH.Modules.Identity.Features.v1.Users.ConfirmEmail;
+using FSH.Modules.Identity.Features.v1.Users.ResendConfirmationEmail;
 using FSH.Modules.Identity.Features.v1.Users.DeleteUser;
 using FSH.Modules.Identity.Features.v1.Users.ForgotPassword;
 using FSH.Modules.Identity.Features.v1.Users.GetUserById;
@@ -206,6 +208,8 @@ public class IdentityModule : IModule
         // users
         group.MapAssignUserRolesEndpoint();
         group.MapChangePasswordEndpoint();
+        group.MapAdminConfirmEmailEndpoint();
+        group.MapResendConfirmationEmailEndpoint().RequireRateLimiting("auth");
         group.MapConfirmEmailEndpoint().RequireRateLimiting("auth");
         group.MapDeleteUserEndpoint();
         group.MapGetUserByIdEndpoint();

--- a/src/Modules/Identity/Modules.Identity/Services/UserRegistrationService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserRegistrationService.cs
@@ -88,6 +88,53 @@ internal sealed class UserRegistrationService(
             : throw new CustomException(string.Format(CultureInfo.InvariantCulture, "An error occurred while confirming {0}", user.Email));
     }
 
+    public async Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        EnsureValidTenant();
+
+        var user = await userManager.Users
+            .Where(u => u.Id == userId)
+            .FirstOrDefaultAsync(cancellationToken)
+            ?? throw new NotFoundException($"User {userId} was not found.");
+
+        // Idempotent: a second confirm is a no-op rather than an error.
+        if (user.EmailConfirmed)
+        {
+            return;
+        }
+
+        user.EmailConfirmed = true;
+        var result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+        {
+            throw new CustomException(string.Format(
+                CultureInfo.InvariantCulture,
+                "An error occurred while confirming the email for {0}: {1}",
+                user.Email,
+                string.Join("; ", result.Errors.Select(e => e.Description))));
+        }
+    }
+
+    public async Task ResendConfirmationEmailAsync(string userId, string origin, CancellationToken cancellationToken = default)
+    {
+        EnsureValidTenant();
+
+        var user = await userManager.Users
+            .Where(u => u.Id == userId)
+            .FirstOrDefaultAsync(cancellationToken)
+            ?? throw new NotFoundException($"User {userId} was not found.");
+
+        if (user.EmailConfirmed)
+        {
+            throw new CustomException(string.Format(
+                CultureInfo.InvariantCulture,
+                "The email for {0} is already confirmed.",
+                user.Email));
+        }
+
+        await SendConfirmationEmailAsync(user, origin, cancellationToken);
+    }
+
     public async Task<string> ConfirmPhoneNumberAsync(string userId, string code, CancellationToken cancellationToken = default)
     {
         EnsureValidTenant();

--- a/src/Modules/Identity/Modules.Identity/Services/UserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserService.cs
@@ -36,6 +36,12 @@ internal sealed class UserService(
     public Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken)
         => registrationService.ConfirmEmailAsync(userId, code, tenant, cancellationToken);
 
+    public Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default)
+        => registrationService.AdminConfirmEmailAsync(userId, cancellationToken);
+
+    public Task ResendConfirmationEmailAsync(string userId, string origin, CancellationToken cancellationToken = default)
+        => registrationService.ResendConfirmationEmailAsync(userId, origin, cancellationToken);
+
     public Task<string> ConfirmPhoneNumberAsync(string userId, string code, CancellationToken cancellationToken = default)
         => registrationService.ConfirmPhoneNumberAsync(userId, code, cancellationToken);
 

--- a/src/Tests/Auditing.Tests/Http/AuditHttpMiddlewareStreamingTests.cs
+++ b/src/Tests/Auditing.Tests/Http/AuditHttpMiddlewareStreamingTests.cs
@@ -1,0 +1,48 @@
+using FSH.Modules.Auditing;
+using FSH.Modules.Auditing.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace Auditing.Tests.Http;
+
+/// <summary>
+/// Regression guard: <see cref="AuditHttpMiddleware"/> buffers the response body into a MemoryStream
+/// and only copies it to the socket after the handler returns. A long-lived streaming handler (SSE)
+/// never returns, so buffering it left the client hanging forever on "connecting" with zero bytes.
+/// Streaming requests (identified by the <c>text/event-stream</c> Accept header) must pass straight
+/// through with the original response body intact.
+/// </summary>
+public sealed class AuditHttpMiddlewareStreamingTests
+{
+    private sealed class StubAuditPublisher : IAuditPublisher
+    {
+        public IAuditScope CurrentScope => throw new NotSupportedException("not used on the streaming path");
+        public ValueTask PublishAsync(IAuditEvent auditEvent, CancellationToken ct = default) => ValueTask.CompletedTask;
+    }
+
+    [Theory]
+    [InlineData("text/event-stream")]
+    [InlineData("text/event-stream, */*")]
+    [InlineData("application/json, text/event-stream")]
+    public async Task InvokeAsync_Should_NotBufferResponseBody_For_EventStreamRequests(string accept)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Accept = accept;
+        using var originalBody = new MemoryStream();
+        ctx.Response.Body = originalBody;
+
+        Stream? bodySeenByHandler = null;
+        Task Next(HttpContext c)
+        {
+            bodySeenByHandler = c.Response.Body;
+            return Task.CompletedTask;
+        }
+
+        var middleware = new AuditHttpMiddleware(Next, new AuditHttpOptions(), new StubAuditPublisher());
+
+        await middleware.InvokeAsync(ctx);
+
+        // The handler must see the real response body, not a swapped-in audit buffer.
+        bodySeenByHandler.ShouldBeSameAs(originalBody);
+        ctx.Response.Body.ShouldBeSameAs(originalBody);
+    }
+}


### PR DESCRIPTION
A batch of dashboard UX polish and platform bug fixes from one working session.

## Auditing
- **SSE fix (root cause):** `AuditHttpMiddleware` buffered every response into a `MemoryStream` and only flushed after the handler returned - which never happens for the long-lived SSE stream, so the dashboard "System status / Live events" sat on *Connecting* forever. Streaming responses (`Accept: text/event-stream`) now bypass buffering. Regression test added.
- **Readable audit trail:** rows render plain-English summaries (`auditPredicate`, e.g. `api.identity.IssueJwtToken` -> "signed in") and a rebalanced **Event** column (sentence is the hero, raw source muted beneath).
- **Hide system activity:** a toggle (on by default) drops the per-request Activity firehose, backed by a new optional `ExcludeEventType` query filter so paging + totals stay correct.

## Identity / permissions
- **Permissions were never wired in the dashboard:** it read a JWT `permissions` claim the API never emitted, so `actor.permissions` was always empty and *all* permission-gated UI was dead. The dashboard now hydrates permissions from `/api/v1/identity/permissions` (live, like the admin app).
- **New admin actions** on the user-detail page: **Confirm email** and **Resend confirmation** (gated by `Permissions.Users.ConfirmEmail`) - backend slices + UI.

## Chat
- Message attachment URLs are resolved **fresh at read time** from the `FileAssetId` (private chat files), so historical images stop expiring.

## Catalog / billing
- Soft-deleting a product no longer **hard-deletes its images** (`IgnoreAutoIncludes` so the cascade can't reach them).
- Demo seeder attaches a subscription and, for paid plans, an **issued term invoice** (created directly, no notification event).

## Dashboard UX
- Profile photo now shows in the topbar; detail/profile/avatars fall back to **initials** on missing/broken images.
- Trash **restore confirmation** dialog; products-list **action-column overlap** fixed; overview **live-events pulse dot** clipping fixed.
- **Change-password dialog** redesign (show/hide toggles, strength meter, live match) + 2FA password field show/hide.
- Audit timestamps show **local time**; browser titles lowercased.

## Dev / infra
- Dev serves `config.json` with `apiBase` pointed **straight at the API** to avoid Vite HTTP/1.1 connection starvation intermittently stalling lazy route chunks. Committed `config.json` keeps `apiBase: ""` (same-origin prod default).
- Ethereal SMTP config for local mail; `AppHost.cs` comments collapsed to one-liners.

## Notes for reviewers / after merge
- **API restart** needed for backend changes (auditing, identity, chat, billing).
- **Re-run `seed-demo`** to backfill the demo subscription + invoice.
- Dev `apiBase` direct requires the ASP.NET dev cert to be trusted (`dotnet dev-certs https --trust`).

## Test plan
- `dotnet build src/FSH.Starter.slnx` (backend) and `npx tsc -b` + `npx eslint` (dashboard) pass.
- New `Auditing.Tests/Http/AuditHttpMiddlewareStreamingTests` is green.
- Manual: SSE goes live; permission-gated buttons appear after re-login; chat images survive; product image survives delete+restore; audit trail reads as sentences with the system toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)