### PR TITLE
fix(ci): green main — Resend endpoint verb + password toggle a11y label

### DIFF
--- a/clients/dashboard/src/pages/settings/security.tsx
+++ b/clients/dashboard/src/pages/settings/security.tsx
@@ -328,7 +328,7 @@ function PasswordField({
         <button
           type="button"
           tabIndex={-1}
-          aria-label={show ? `Hide ${label.toLowerCase()}` : `Show ${label.toLowerCase()}`}
+          aria-label={show ? "Hide password" : "Show password"}
           onClick={() => setShow((s) => !s)}
           className="absolute right-1.5 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-md text-[var(--color-muted-foreground)] outline-none transition-colors hover:text-[var(--color-foreground)] focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
         >

--- a/clients/dashboard/tests/settings/security.spec.ts
+++ b/clients/dashboard/tests/settings/security.spec.ts
@@ -56,7 +56,9 @@ test.describe("settings/security — change password (Dialog)", () => {
     await dialog.getByLabel("New password", { exact: true }).fill("longenough123");
     await dialog.getByLabel("Confirm new password").fill("differentpw123");
     await dialog.getByRole("button", { name: /update password/i }).click();
-    await expect(dialog.getByText(/passwords don't match/i)).toBeVisible();
+    // Scope to the submit-error alert — the live "…don't match yet" hint under
+    // the confirm field also contains this phrase.
+    await expect(dialog.getByRole("alert")).toContainText(/passwords don't match/i);
 
     // Current === new is blocked — keeps users from "rotating" to the
     // same value just to reset a forgotten password.

--- a/src/Tests/Architecture.Tests/EndpointConventionTests.cs
+++ b/src/Tests/Architecture.Tests/EndpointConventionTests.cs
@@ -235,6 +235,7 @@ public class EndpointConventionTests
                                name.StartsWith("Register", StringComparison.Ordinal) ||
                                name.StartsWith("Generate", StringComparison.Ordinal) ||
                                name.StartsWith("Refresh", StringComparison.Ordinal) ||
+                               name.StartsWith("Resend", StringComparison.Ordinal) ||
                                name.StartsWith("Confirm", StringComparison.Ordinal) ||
                                name.StartsWith("Reset", StringComparison.Ordinal) ||
                                name.StartsWith("Forgot", StringComparison.Ordinal) ||


### PR DESCRIPTION
@
## Why
`main` (`2df3c264`, merge of #1279) went red across **three** workflows: Backend CI (Unit Tests), Frontend CI (E2E dashboard), and Template Smoke Test. All trace to two source issues introduced by that merge.

## Fixes
1. **Architecture test** — the new `ResendConfirmationEmailEndpoint` failed `EndpointConventionTests.Endpoint_Names_Should_Follow_Convention` because `Resend` was not in the allowed action-verb list. Added it. *(fixes Backend CI Unit Tests + Template Smoke, which runs the same arch test on scaffolded output.)*
2. **Dashboard a11y label** — the new `settings/security` `PasswordField` toggle used a field-specific `aria-label` (`"Show current password"`) that collided with the password inputs under Playwright `getByLabel` strict mode. Aligned to the repo-wide generic `"Show password"`/`"Hide password"` already used in `login.tsx` and `reset-password.tsx`. *(fixes Frontend CI E2E dashboard — 6 strict-mode violations.)*
3. **Test selector** — fixing #2 unmasked a second strict-mode collision: `getByText(/passwords don't match/i)` matched both the live "…don't match yet" hint and the submit error. Scoped the assertion to the `role="alert"` region.

## Verification
- `Architecture.Tests` `Endpoint_Names_Should_Follow_Convention` → **Passed**
- `clients/dashboard` `tests/settings/security.spec.ts` → **10/10 passed**
- Confirmed these were the *only* failing tests in each job (no other FAILs in the CI logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@