### PR TITLE
feat(clients): inactivity auto-logout + admin UX polish + dashboard tenant-deactivated/impersonation fixes

### DIFF
--- a/clients/admin/public/config.json
+++ b/clients/admin/public/config.json
@@ -1,5 +1,7 @@
 {
   "apiBase": "",
   "defaultTenant": "root",
-  "dashboardUrl": "http://localhost:5174"
+  "dashboardUrl": "http://localhost:5174",
+  "inactivityIdleMs": 600000,
+  "inactivityWarningMs": 60000
 }

--- a/clients/admin/src/auth/auth-context.tsx
+++ b/clients/admin/src/auth/auth-context.tsx
@@ -141,6 +141,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  // Cross-tab auth sync. tokenStore.subscribe only fires for in-app mutations;
+  // a `storage` event fires when ANOTHER tab logs in/out (e.g. inactivity
+  // sign-out). Rebuild from the (now changed) tokens so a logout in one tab
+  // drops every tab to /login. Scoped to the token keys so the inactivity
+  // heartbeat ("fsh.lastActivity") doesn't trigger a rebuild every second.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (
+        e.key !== null &&
+        e.key !== "fsh.admin.accessToken" &&
+        e.key !== "fsh.admin.refreshToken"
+      ) {
+        return;
+      }
+      setUser(claimsToUser(decodeJwt(tokenStore.getAccessToken()), tokenStore.getPermissions()));
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
   const login = useCallback(
     async (input: { email: string; password: string; tenant: string }) => {
       tokenStore.setTenant(input.tenant);

--- a/clients/admin/src/auth/inactivity.ts
+++ b/clients/admin/src/auth/inactivity.ts
@@ -1,0 +1,75 @@
+// Inactivity auto-logout — shared, app-agnostic primitives.
+//
+// localStorage/sessionStorage is per-origin, so the admin and dashboard apps
+// never share these keys (different hosts). That lets us use short, un-prefixed
+// key names without colliding — and, importantly, the activity heartbeat key
+// does NOT start with "fsh.{app}." so it won't trip each app's auth storage
+// listeners on every cross-tab tick.
+
+/** Shared "last user activity" timestamp — one value across every tab of this origin. */
+const LAST_ACTIVITY_KEY = "fsh.lastActivity";
+/** Ephemeral, per-tab reason stash read once by the login page after a sign-out. */
+const SIGNED_OUT_REASON_KEY = "fsh.signedOutReason";
+
+export type InactivityPhase = "active" | "warning" | "expired";
+
+/**
+ * Pure phase evaluation — given the current time and the last activity stamp,
+ * decide whether the session is active, in its warning window, or expired.
+ * `secondsLeft` is the whole seconds remaining until expiry during `warning`.
+ */
+export function evaluateInactivity(
+  now: number,
+  lastActivity: number,
+  idleMs: number,
+  warningMs: number,
+): { phase: InactivityPhase; secondsLeft: number } {
+  const idle = now - lastActivity;
+  if (idle >= idleMs + warningMs) return { phase: "expired", secondsLeft: 0 };
+  if (idle >= idleMs) {
+    const remainingMs = idleMs + warningMs - idle;
+    return { phase: "warning", secondsLeft: Math.max(0, Math.ceil(remainingMs / 1000)) };
+  }
+  return { phase: "active", secondsLeft: 0 };
+}
+
+/** Cross-tab shared activity timestamp. Writes are best-effort (private mode). */
+export const activityStore = {
+  key: LAST_ACTIVITY_KEY,
+  get(): number {
+    try {
+      const raw = localStorage.getItem(LAST_ACTIVITY_KEY);
+      const parsed = raw ? Number(raw) : Number.NaN;
+      return Number.isFinite(parsed) ? parsed : 0;
+    } catch {
+      return 0;
+    }
+  },
+  set(ts: number): void {
+    try {
+      localStorage.setItem(LAST_ACTIVITY_KEY, String(ts));
+    } catch {
+      /* storage unavailable (private mode / quota) — degrade to single-tab timing */
+    }
+  },
+};
+
+/** Stash why the session ended so the login page can explain it. */
+export function markSignedOut(reason: string): void {
+  try {
+    sessionStorage.setItem(SIGNED_OUT_REASON_KEY, reason);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Read-and-clear the sign-out reason (one-shot). */
+export function consumeSignedOutReason(): string | null {
+  try {
+    const value = sessionStorage.getItem(SIGNED_OUT_REASON_KEY);
+    if (value) sessionStorage.removeItem(SIGNED_OUT_REASON_KEY);
+    return value;
+  } catch {
+    return null;
+  }
+}

--- a/clients/admin/src/auth/use-inactivity-timeout.ts
+++ b/clients/admin/src/auth/use-inactivity-timeout.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { activityStore, evaluateInactivity, type InactivityPhase } from "@/auth/inactivity";
+
+// Genuine user-intent signals. Throttled before they touch storage so a
+// mousemove storm can't hammer localStorage.
+const ACTIVITY_EVENTS = [
+  "pointerdown",
+  "keydown",
+  "wheel",
+  "touchstart",
+  "scroll",
+  "mousemove",
+] as const;
+
+const WRITE_THROTTLE_MS = 1_000;
+const TICK_MS = 1_000;
+
+type Options = {
+  /** Watch only while signed in. When false the hook is fully inert. */
+  enabled: boolean;
+  idleMs: number;
+  warningMs: number;
+  /** Fired once when the session crosses the expiry threshold. */
+  onExpire: () => void;
+};
+
+/**
+ * Drives the inactivity state machine. Tracks a cross-tab "last activity"
+ * timestamp, ticks once a second, and surfaces the current phase + seconds
+ * left so a warning modal can render. Activity in any tab keeps every tab
+ * alive; while THIS tab shows the warning it stops recording passive activity
+ * so the prompt stays meaningful (only an explicit reset, or real activity in
+ * another tab, dismisses it).
+ */
+export function useInactivityTimeout({ enabled, idleMs, warningMs, onExpire }: Options) {
+  const [phase, setPhase] = useState<InactivityPhase>("active");
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  // Mutable mirrors so the event/interval wiring can stay mount-scoped.
+  const phaseRef = useRef<InactivityPhase>("active");
+  const lastWriteRef = useRef(0);
+  const expiredRef = useRef(false);
+  const idleRef = useRef(idleMs);
+  const warnRef = useRef(warningMs);
+  const onExpireRef = useRef(onExpire);
+  idleRef.current = idleMs;
+  warnRef.current = warningMs;
+  onExpireRef.current = onExpire;
+
+  const evaluateNow = useCallback(() => {
+    const { phase: next, secondsLeft: left } = evaluateInactivity(
+      Date.now(),
+      activityStore.get(),
+      idleRef.current,
+      warnRef.current,
+    );
+    phaseRef.current = next;
+    setPhase(next);
+    setSecondsLeft(left);
+    if (next === "expired" && !expiredRef.current) {
+      expiredRef.current = true;
+      onExpireRef.current();
+    }
+  }, []);
+
+  const recordActivity = useCallback(() => {
+    // Freeze passive activity once we're warning/expired in this tab.
+    if (phaseRef.current !== "active") return;
+    const now = Date.now();
+    if (now - lastWriteRef.current < WRITE_THROTTLE_MS) return;
+    lastWriteRef.current = now;
+    activityStore.set(now);
+  }, []);
+
+  /** Explicit "I'm here" — refresh the shared stamp and drop back to active. */
+  const reset = useCallback(() => {
+    const now = Date.now();
+    lastWriteRef.current = now;
+    activityStore.set(now);
+    expiredRef.current = false;
+    phaseRef.current = "active";
+    setPhase("active");
+    setSecondsLeft(0);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      phaseRef.current = "active";
+      expiredRef.current = false;
+      setPhase("active");
+      setSecondsLeft(0);
+      return;
+    }
+
+    // Seed the shared stamp on first enable so a fresh login isn't instantly idle.
+    if (activityStore.get() <= 0) activityStore.set(Date.now());
+    expiredRef.current = false;
+
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, recordActivity, { passive: true, capture: true });
+    }
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === activityStore.key) evaluateNow();
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") evaluateNow();
+    };
+    window.addEventListener("storage", onStorage);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    evaluateNow();
+    const intervalId = window.setInterval(evaluateNow, TICK_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+      for (const evt of ACTIVITY_EVENTS) {
+        window.removeEventListener(evt, recordActivity, {
+          capture: true,
+        } as EventListenerOptions);
+      }
+      window.removeEventListener("storage", onStorage);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [enabled, recordActivity, evaluateNow]);
+
+  return { phase, secondsLeft, dismiss: reset };
+}

--- a/clients/admin/src/components/auth/inactivity-dialog.tsx
+++ b/clients/admin/src/components/auth/inactivity-dialog.tsx
@@ -1,0 +1,131 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+/**
+ * InactivityDialog — the inactivity warning. A forced-choice modal (no Esc,
+ * no overlay-dismiss, no close X) built on the raw Radix primitives so it can
+ * opt out of the shared DialogContent's close affordance. The centerpiece is
+ * an SVG countdown ring that drains as the seconds tick and shifts tone
+ * primary → amber → red, pulsing in the final stretch. Respects
+ * prefers-reduced-motion (the ring steps per second instead of animating).
+ */
+
+const RING_RADIUS = 52;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function ringTone(fraction: number): string {
+  if (fraction > 0.5) return "var(--color-primary)";
+  if (fraction > 0.2) return "var(--color-warning)";
+  return "var(--color-destructive)";
+}
+
+export function InactivityDialog({
+  open,
+  secondsLeft,
+  totalSeconds,
+  onStay,
+  onSignOut,
+}: {
+  open: boolean;
+  secondsLeft: number;
+  totalSeconds: number;
+  onStay: () => void;
+  onSignOut: () => void;
+}) {
+  const fraction =
+    totalSeconds > 0 ? Math.max(0, Math.min(1, secondsLeft / totalSeconds)) : 0;
+  const dashOffset = RING_CIRCUMFERENCE * (1 - fraction);
+  const tone = ringTone(fraction);
+  const urgent = secondsLeft <= 10;
+
+  return (
+    <DialogPrimitive.Root open={open}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-[oklch(0_0_0_/_0.45)] backdrop-blur-[6px]",
+            "data-[state=open]:animate-fsh-overlay-in data-[state=closed]:animate-fsh-overlay-out",
+          )}
+        />
+        <DialogPrimitive.Content
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          aria-describedby="inactivity-desc"
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-[400px] -translate-x-1/2 -translate-y-1/2",
+            "rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-7 text-center shadow-xl outline-none",
+            "data-[state=open]:animate-fsh-dialog-in data-[state=closed]:animate-fsh-dialog-out",
+          )}
+        >
+          {/* Countdown ring */}
+          <div className="relative mx-auto mb-5 size-[132px]">
+            <svg viewBox="0 0 120 120" className="size-full -rotate-90" aria-hidden>
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                strokeWidth="7"
+                className="stroke-[var(--color-muted)]"
+              />
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                strokeWidth="7"
+                strokeLinecap="round"
+                stroke={tone}
+                strokeDasharray={RING_CIRCUMFERENCE}
+                strokeDashoffset={dashOffset}
+                className={cn(
+                  "motion-safe:transition-[stroke-dashoffset,stroke] motion-safe:duration-1000 motion-safe:ease-linear",
+                  urgent && "motion-safe:animate-pulse",
+                )}
+              />
+            </svg>
+            <div className="absolute inset-0 grid place-items-center">
+              <div className="flex flex-col items-center">
+                <span
+                  className="font-display text-[34px] font-bold leading-none tabular-nums tracking-tight"
+                  style={{ color: tone }}
+                >
+                  {Math.max(0, secondsLeft)}
+                </span>
+                <span className="mt-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--color-muted-foreground)]">
+                  seconds
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="mb-1.5 flex items-center justify-center gap-2">
+            <ShieldAlert className="size-4 text-[var(--color-primary)]" aria-hidden />
+            <DialogPrimitive.Title className="font-display text-[18px] font-semibold tracking-tight text-[var(--color-foreground)]">
+              Still there?
+            </DialogPrimitive.Title>
+          </div>
+          <DialogPrimitive.Description
+            id="inactivity-desc"
+            className="mx-auto max-w-[300px] text-[13px] leading-relaxed text-[var(--color-muted-foreground)]"
+          >
+            You&apos;ve been inactive for a while. We&apos;ll sign you out shortly to keep your
+            account secure.
+          </DialogPrimitive.Description>
+
+          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-center">
+            <Button variant="outline" onClick={onSignOut} className="sm:min-w-[120px]">
+              Sign out now
+            </Button>
+            <Button onClick={onStay} className="sm:min-w-[120px]" autoFocus>
+              I&apos;m here
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/clients/admin/src/components/auth/inactivity-guard.tsx
+++ b/clients/admin/src/components/auth/inactivity-guard.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useAuth } from "@/auth/use-auth";
+import { env } from "@/env";
+import { markSignedOut } from "@/auth/inactivity";
+import { useInactivityTimeout } from "@/auth/use-inactivity-timeout";
+import { InactivityDialog } from "@/components/auth/inactivity-dialog";
+
+/**
+ * InactivityGuard — mounted once inside the authenticated shell. Watches for
+ * inactivity while signed in, shows the warning modal in the final window, and
+ * signs the user out (with an "inactivity" reason for the login page) when the
+ * countdown elapses. Durations come from runtime config so operators can tune
+ * them per deployment without a rebuild.
+ */
+export function InactivityGuard() {
+  const { isAuthenticated, logout } = useAuth();
+  const idleMs = env.inactivityIdleMs;
+  const warningMs = env.inactivityWarningMs;
+
+  const signOut = useCallback(() => {
+    markSignedOut("inactivity");
+    logout();
+  }, [logout]);
+
+  const { phase, secondsLeft, dismiss } = useInactivityTimeout({
+    enabled: isAuthenticated,
+    idleMs,
+    warningMs,
+    onExpire: signOut,
+  });
+
+  return (
+    <InactivityDialog
+      open={isAuthenticated && phase === "warning"}
+      secondsLeft={secondsLeft}
+      totalSeconds={Math.round(warningMs / 1000)}
+      onStay={dismiss}
+      onSignOut={signOut}
+    />
+  );
+}

--- a/clients/admin/src/components/brand-mark.tsx
+++ b/clients/admin/src/components/brand-mark.tsx
@@ -46,7 +46,7 @@ export function BrandMarkXL({ className }: { className?: string }) {
       <div className="flex items-center gap-2.5">
         <img
           src="/logo-fullstackhero.png"
-          alt="FullStackHero"
+          alt="fullstackhero"
           className="size-7 object-contain"
         />
         <span className="font-display text-[18px] font-semibold tracking-tight text-[var(--color-foreground)]">

--- a/clients/admin/src/components/layout/app-shell.tsx
+++ b/clients/admin/src/components/layout/app-shell.tsx
@@ -6,6 +6,7 @@ import {
   MobileNavProvider,
   MobileNavRoot,
 } from "@/components/layout/mobile-nav";
+import { InactivityGuard } from "@/components/auth/inactivity-guard";
 
 /**
  * AppShell — three-area layout: sidebar / topbar / main content.
@@ -62,6 +63,9 @@ export function AppShell() {
 
       {/* Mobile drawer — mounted at root so it portals above the shell. */}
       <MobileNavRoot />
+
+      {/* Inactivity auto-logout — warning modal + countdown, signed-in only. */}
+      <InactivityGuard />
     </MobileNavProvider>
   );
 }

--- a/clients/admin/src/components/layout/topbar.tsx
+++ b/clients/admin/src/components/layout/topbar.tsx
@@ -308,7 +308,7 @@ export function Topbar() {
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Sign out of FullStackHero?</DialogTitle>
+            <DialogTitle>Sign out of fullstackhero?</DialogTitle>
             <DialogDescription>
               You'll need to sign in again to access this admin. Any unsaved
               work in this session will be lost.

--- a/clients/admin/src/components/layout/topbar.tsx
+++ b/clients/admin/src/components/layout/topbar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
   Check,
   ChevronsUpDown,
@@ -31,6 +32,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar } from "@/components/ui/avatar";
 import { useAuth } from "@/auth/use-auth";
+import { getMyProfile } from "@/api/users";
 import { useTheme } from "@/components/theme/theme-provider";
 import { cn } from "@/lib/cn";
 
@@ -50,6 +52,43 @@ function initialsOf(name?: string | null): string {
     .join("")
     .slice(0, 2)
     .toUpperCase();
+}
+
+/**
+ * ProfileTile — the square topbar avatar. Renders the uploaded profile
+ * image when present (object-cover to fill the rounded tile) and falls
+ * back to the brand-tinted initials tile when missing or on load error.
+ * Keyed by `src` at the call site so a freshly-uploaded image resets the
+ * failure state and shows immediately.
+ */
+function ProfileTile({ src, initials }: { src: string | null; initials: string }) {
+  const [failed, setFailed] = useState(false);
+  const showImage = Boolean(src) && !failed;
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "grid size-8 shrink-0 place-items-center overflow-hidden rounded-lg",
+        "bg-[oklch(from_var(--color-primary)_l_c_h_/_0.15)] text-[var(--color-primary)]",
+        "font-display text-[11px] font-bold tracking-tight",
+      )}
+    >
+      {showImage ? (
+        <img
+          src={src ?? undefined}
+          alt=""
+          width={32}
+          height={32}
+          loading="lazy"
+          decoding="async"
+          onError={() => setFailed(true)}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        initials
+      )}
+    </span>
+  );
 }
 
 function ThemeMenuItem({
@@ -111,6 +150,17 @@ export function Topbar() {
   const navigate = useNavigate();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
+  // Avatar lives on the profile, not the JWT — read it from the shared
+  // ["identity","profile"] query so it updates the instant a new image is
+  // uploaded (the profile page invalidates that key on success).
+  const profile = useQuery({
+    queryKey: ["identity", "profile"],
+    queryFn: getMyProfile,
+    staleTime: 60_000,
+  });
+  const avatarUrl = profile.data?.imageUrl ?? null;
+  const displayName = user?.name ?? user?.email ?? "Unknown";
+
   const onConfirmSignOut = () => {
     setConfirmOpen(false);
     logout();
@@ -148,21 +198,16 @@ export function Topbar() {
               "data-[state=open]:bg-[var(--color-accent)]",
             )}
           >
-          {/* Square initials tile */}
-          <span
-            aria-hidden
-            className={cn(
-              "grid size-8 shrink-0 place-items-center rounded-lg",
-              "bg-[oklch(from_var(--color-primary)_l_c_h_/_0.15)] text-[var(--color-primary)]",
-              "font-display text-[11px] font-bold tracking-tight",
-            )}
-          >
-            {initialsOf(user?.name ?? user?.email)}
-          </span>
+          {/* Square avatar tile — uploaded image with initials fallback */}
+          <ProfileTile
+            key={avatarUrl ?? "none"}
+            src={avatarUrl}
+            initials={initialsOf(user?.name ?? user?.email)}
+          />
           {/* Name + tenant — desktop only */}
           <div className="hidden min-w-0 text-left md:block">
             <p className="truncate text-[12px] font-medium leading-none text-[var(--color-foreground)]">
-              {user?.name ?? user?.email ?? "Unknown"}
+              {displayName}
             </p>
             <p className="mt-1 truncate text-[10px] leading-none text-[var(--color-muted-foreground)]">
               {user?.tenant ?? "—"}
@@ -183,7 +228,7 @@ export function Topbar() {
           {/* User info header */}
           <div className="px-3 py-2.5">
             <p className="truncate text-[12px] font-semibold text-[var(--color-foreground)]">
-              {user?.name ?? user?.email ?? "Unknown"}
+              {displayName}
             </p>
             {user?.email && user.name && (
               <p className="mt-0.5 truncate text-[10.5px] text-[var(--color-muted-foreground)]">
@@ -271,10 +316,10 @@ export function Topbar() {
           </DialogHeader>
           <DialogBody>
             <div className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2.5">
-              <Avatar name={user?.name ?? user?.email ?? "?"} size="md" />
+              <Avatar name={displayName} src={avatarUrl} size="md" />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-medium tracking-tight">
-                  {user?.name ?? user?.email ?? "Unknown"}
+                  {displayName}
                 </div>
                 {user?.email && user.name && (
                   <div className="truncate text-xs text-[var(--color-muted-foreground)]">

--- a/clients/admin/src/components/tenants/create-tenant-dialog.tsx
+++ b/clients/admin/src/components/tenants/create-tenant-dialog.tsx
@@ -1,35 +1,38 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
-  Building2,
-  CreditCard,
-  Database,
-  KeyRound,
-  UserRound,
+  ChevronDown,
+  CircleCheck,
+  Eye,
+  EyeOff,
+  Loader2,
+  Lock,
+  Pencil,
   Sparkles,
+  Wand2,
 } from "lucide-react";
 import { toast } from "sonner";
 import { createTenant } from "@/api/tenants";
 import { getPlans, planTermPrice } from "@/api/billing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Monogram } from "@/components/monogram";
 import { Field, Select, type SelectOption } from "@/components/list";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
-  DialogBody,
   DialogFooter,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { ApiRequestError } from "@/lib/api-client";
+import { cn } from "@/lib/cn";
 
-// ─── Schema (identical to the old page) ─────────────────────────────────────
+// ─── Schema (unchanged contract) ────────────────────────────────────────────
 
 const TENANT_ID_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
 
@@ -49,10 +52,12 @@ const schema = z.object({
     .max(128, "Maximum 128 characters."),
   issuer: z.string().trim().min(2, "Required.").max(256),
   connectionString: z.string().trim().max(2048).optional(),
-  // Optional: preselected to the default plan when plans load; if left empty (e.g. plans
-  // unavailable) the server falls back to the configured trial plan.
+  // Optional: preselected to the default plan when plans load; if left empty the
+  // server falls back to the configured trial plan.
   planKey: z.string().trim().optional(),
 });
+
+type FormValues = z.infer<typeof schema>;
 
 function formatMoney(amount: number, currency: string): string {
   try {
@@ -62,34 +67,131 @@ function formatMoney(amount: number, currency: string): string {
   }
 }
 
-type FormValues = z.infer<typeof schema>;
+/** Derive a URL-safe slug from free text. Trailing/leading hyphens trimmed; capped to 64. */
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
 
-// ─── Section header (inline, no card — we're inside the dialog already) ─────
+/** Strong random password from a copy-friendly charset (no ambiguous 0/O/1/l/I). */
+function generatePassword(length = 16): string {
+  const charset = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789!@#$%^&*?";
+  const bytes = new Uint32Array(length);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < length; i++) out += charset[bytes[i] % charset.length];
+  return out;
+}
 
-function SectionLabel({
-  icon: Icon,
-  title,
-  description,
+// ─── Small inline adornment button (eye / generate) ─────────────────────────
+
+function AdornButton({
+  label,
+  onClick,
+  children,
 }: {
-  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" }>;
-  title: string;
-  description: string;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start gap-2.5 pb-1">
-      <span
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "grid size-7 shrink-0 place-items-center rounded-md outline-none transition-colors cursor-pointer",
+        "text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]",
+        "focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]",
+        "[&_svg]:size-3.5",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ─── Live preview rail ───────────────────────────────────────────────────────
+
+function PreviewRail({
+  name,
+  slug,
+  planLabel,
+  email,
+}: {
+  name: string;
+  slug: string;
+  planLabel: string | null;
+  email: string;
+}) {
+  const displayName = name.trim() || "New tenant";
+  const displaySlug = slug || "tenant-id";
+
+  return (
+    <aside
+      className={cn(
+        "relative flex items-center gap-4 overflow-hidden p-5 sm:flex-col sm:items-start sm:gap-0 sm:p-6",
+        "border-b border-[var(--color-border)] sm:border-b-0 sm:border-r",
+        "bg-gradient-to-b from-[oklch(from_var(--color-primary)_l_c_h_/_0.06)] to-[var(--color-muted)]/40",
+      )}
+    >
+      {/* Soft radial glow behind the monogram for depth */}
+      <div
         aria-hidden
-        className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md bg-[var(--color-accent)] text-[var(--color-muted-foreground)]"
-      >
-        <Icon className="h-3.5 w-3.5" aria-hidden />
-      </span>
-      <div className="min-w-0">
-        <p className="text-[12.5px] font-semibold text-[var(--color-foreground)]">{title}</p>
-        <p className="text-[11.5px] leading-relaxed text-[var(--color-muted-foreground)]">
-          {description}
-        </p>
+        className="pointer-events-none absolute -left-8 -top-10 h-40 w-40 rounded-full opacity-60 blur-2xl
+          bg-[radial-gradient(circle,oklch(from_var(--color-primary)_l_c_h_/_0.18),transparent_70%)]"
+      />
+
+      <div className="relative shrink-0">
+        <Monogram seed={slug || name || "new"} fallback={displayName} size="lg" />
       </div>
-    </div>
+
+      <div className="relative min-w-0 sm:mt-4">
+        <p className="truncate font-display text-[15px] font-semibold leading-tight text-[var(--color-foreground)]">
+          {displayName}
+        </p>
+        <p className="mt-1 truncate font-mono text-[12px] text-[var(--color-muted-foreground)]">
+          {displaySlug}
+        </p>
+
+        {email.trim() && (
+          <p className="mt-0.5 hidden truncate font-mono text-[11px] text-[var(--color-muted-foreground)]/80 sm:block">
+            {email.trim()}
+          </p>
+        )}
+
+        {/* Live facts — hidden on mobile to keep the banner compact */}
+        <dl className="mt-4 hidden space-y-2 sm:block">
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className="size-1.5 rounded-full bg-[var(--color-primary)] ring-2 ring-[oklch(from_var(--color-primary)_l_c_h_/_0.18)]"
+            />
+            <span className="text-[12px] text-[var(--color-muted-foreground)]">
+              {planLabel ?? "Default plan"}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className="size-1.5 rounded-full bg-[var(--color-success)] ring-2 ring-[oklch(from_var(--color-success)_l_c_h_/_0.18)]"
+            />
+            <span className="text-[12px] text-[var(--color-muted-foreground)]">
+              Active on creation
+            </span>
+          </div>
+        </dl>
+      </div>
+
+      <p className="relative mt-auto hidden pt-6 text-[11px] leading-relaxed text-[var(--color-muted-foreground)]/75 sm:block">
+        Provisioning runs in the background. You can track progress on the tenant&apos;s detail page.
+      </p>
+    </aside>
   );
 }
 
@@ -104,6 +206,12 @@ export function CreateTenantDialog({
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  // UI-only state, reset on close.
+  const [idMode, setIdMode] = useState<"auto" | "manual">("auto");
+  const [issuerDirty, setIssuerDirty] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const plansQuery = useQuery({
     queryKey: ["billing", "plans", "active"],
@@ -127,6 +235,7 @@ export function CreateTenantDialog({
     reset,
     setValue,
     getValues,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -141,12 +250,39 @@ export function CreateTenantDialog({
     },
   });
 
-  // Preselect the default/trial plan once plans load (without clobbering an explicit choice).
+  // Live values for the preview rail + smart-field wiring.
+  const name = watch("name");
+  const idValue = watch("id");
+  const adminEmail = watch("adminEmail");
+  const planKey = watch("planKey");
+
+  const idValid = TENANT_ID_RE.test((idValue ?? "").trim());
+  const idTouched = (idValue ?? "").trim().length > 0;
+
+  const selectedPlan = plansQuery.data?.find((p) => p.key === planKey);
+  const planLabel = selectedPlan
+    ? `${selectedPlan.name} · ${formatMoney(planTermPrice(selectedPlan), selectedPlan.currency)}`
+    : null;
+
+  // Preselect the default/trial plan once plans load (without clobbering a choice).
   useEffect(() => {
     if (defaultPlanKey && !getValues("planKey")) {
       setValue("planKey", defaultPlanKey);
     }
   }, [defaultPlanKey, getValues, setValue]);
+
+  // Auto-derive the identifier slug from the display name until the operator
+  // unlocks the field for manual editing.
+  useEffect(() => {
+    if (idMode !== "auto") return;
+    setValue("id", slugify(name ?? ""), { shouldValidate: false });
+  }, [name, idMode, setValue]);
+
+  // JWT issuer mirrors the identifier until the operator edits it by hand.
+  useEffect(() => {
+    if (issuerDirty) return;
+    setValue("issuer", (idValue ?? "").trim(), { shouldValidate: false });
+  }, [idValue, issuerDirty, setValue]);
 
   const mutation = useMutation({
     // Pass values via mutate(arg) — no closed-over state captured at submit time.
@@ -165,7 +301,8 @@ export function CreateTenantDialog({
         description:
           "Provisioning runs in the background. Track progress on the detail page.",
       });
-      queryClient.invalidateQueries({ queryKey: ["tenants"] });
+      // Fire-and-forget refresh — don't block navigation on the list refetch.
+      void queryClient.invalidateQueries({ queryKey: ["tenants"] });
       handleClose();
       navigate(`/tenants/${result.id}`);
     },
@@ -180,11 +317,32 @@ export function CreateTenantDialog({
 
   function handleClose() {
     reset();
+    setIdMode("auto");
+    setIssuerDirty(false);
+    setShowPassword(false);
+    setAdvancedOpen(false);
     onOpenChange(false);
+  }
+
+  function unlockIdentifier() {
+    setIdMode("manual");
+    requestAnimationFrame(() => document.getElementById("ct-id")?.focus());
+  }
+
+  function relockIdentifier() {
+    setIdMode("auto");
+    setValue("id", slugify(getValues("name") ?? ""), { shouldValidate: false });
+  }
+
+  function fillGeneratedPassword() {
+    setValue("adminPassword", generatePassword(), { shouldValidate: true });
+    setShowPassword(true);
   }
 
   const onSubmit = handleSubmit((values) => mutation.mutate(values));
   const submitting = isSubmitting || mutation.isPending;
+
+  const issuerField = register("issuer");
 
   return (
     <Dialog
@@ -194,124 +352,153 @@ export function CreateTenantDialog({
         else onOpenChange(true);
       }}
     >
-      <DialogContent size="lg">
-        {/* ── Header ── */}
-        <DialogHeader>
-          <div className="flex items-center gap-3">
-            {/* Icon badge — geometric accent tile */}
-            <span
-              aria-hidden
-              className="relative grid h-9 w-9 shrink-0 place-items-center overflow-hidden rounded-xl
-                bg-[oklch(from_var(--color-primary)_l_c_h_/_0.12)]
-                text-[var(--color-primary)]
-                ring-1 ring-inset ring-[oklch(from_var(--color-primary)_l_c_h_/_0.18)]"
-            >
-              <Building2 className="h-[18px] w-[18px]" />
-              {/* Subtle sparkle accent — top-right corner */}
-              <Sparkles
-                className="absolute right-0.5 top-0.5 h-2.5 w-2.5 opacity-40"
-              />
-            </span>
-            <div className="min-w-0">
-              <DialogTitle className="text-[16px]">New tenant</DialogTitle>
-            </div>
-          </div>
-          <DialogDescription className="mt-1">
-            Provision a new tenant and its seed admin user. The identifier is the
-            URL-safe slug used in subdomain-like routing and JWT claims.
-          </DialogDescription>
-        </DialogHeader>
+      <DialogContent size="lg" className="overflow-hidden p-0 sm:max-w-3xl">
+        <form onSubmit={onSubmit} className="grid sm:grid-cols-[13.5rem_1fr]">
+          {/* ── Live preview rail ── */}
+          <PreviewRail
+            name={name ?? ""}
+            slug={idValue ?? ""}
+            planLabel={planLabel}
+            email={adminEmail ?? ""}
+          />
 
-        {/* ── Form ── */}
-        <form onSubmit={onSubmit}>
-          <DialogBody className="space-y-6">
-            {/* ── Identity section ── */}
-            <div className="space-y-3">
-              <SectionLabel
-                icon={UserRound}
-                title="Identity"
-                description="How the tenant is named on the platform. The identifier is immutable."
-              />
-              {/* Ruled separator */}
-              <div className="h-px bg-[var(--color-border)] opacity-60" />
-              <div className="grid gap-4 sm:grid-cols-2">
-                <Field
-                  id="ct-id"
-                  label="Identifier"
-                  required
-                  hint="Lowercase letters, digits, and hyphens. 3–64 characters."
-                  error={errors.id?.message}
-                >
+          {/* ── Form pane ── */}
+          <div className="min-w-0">
+            {/* Header (leave room for the close affordance, top-right) */}
+            <div className="flex flex-col gap-1 px-6 pb-2 pt-6 pr-12">
+              <div className="flex items-center gap-2">
+                <DialogTitle className="text-[16px]">New tenant</DialogTitle>
+                <Sparkles className="size-3.5 text-[var(--color-primary)] opacity-70" aria-hidden />
+              </div>
+              <DialogDescription>
+                Provision a tenant and its seed admin. The identifier is the URL-safe slug used in
+                routing and JWT claims.
+              </DialogDescription>
+            </div>
+
+            {/* Fields */}
+            <div className="space-y-4 px-6 py-4">
+              <Field id="ct-name" label="Display name" required error={errors.name?.message}>
+                <Input
+                  id="ct-name"
+                  autoComplete="off"
+                  placeholder="Acme Corp"
+                  {...register("name")}
+                />
+              </Field>
+
+              {/* Identifier — auto-derived, unlock to edit */}
+              <Field
+                id="ct-id"
+                label="Identifier"
+                required
+                hint={
+                  idTouched && idValid ? (
+                    <span className="inline-flex items-center gap-1 text-[var(--color-success)]">
+                      <CircleCheck className="size-3.5" aria-hidden />
+                      Valid format — availability is confirmed when you create.
+                    </span>
+                  ) : (
+                    "Lowercase letters, digits, and hyphens. 3–64 characters."
+                  )
+                }
+                error={errors.id?.message}
+              >
+                <div className="relative">
                   <Input
                     id="ct-id"
                     autoComplete="off"
                     placeholder="acme-corp"
-                    className="font-mono"
+                    readOnly={idMode === "auto"}
+                    className={cn(
+                      "pr-[4.75rem] font-mono",
+                      idMode === "auto" && "text-[var(--color-muted-foreground)]",
+                    )}
                     {...register("id")}
                   />
-                </Field>
+                  <div className="absolute inset-y-0 right-1.5 flex items-center gap-1">
+                    {idMode === "auto" ? (
+                      <button
+                        type="button"
+                        onClick={unlockIdentifier}
+                        className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium
+                          text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-accent)]
+                          hover:text-[var(--color-foreground)] cursor-pointer outline-none
+                          focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
+                      >
+                        <Pencil className="size-3" aria-hidden /> Edit
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={relockIdentifier}
+                        className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium
+                          text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-accent)]
+                          hover:text-[var(--color-foreground)] cursor-pointer outline-none
+                          focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
+                      >
+                        <Lock className="size-3" aria-hidden /> Auto
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </Field>
 
-                <Field
-                  id="ct-name"
-                  label="Display name"
-                  required
-                  error={errors.name?.message}
-                >
-                  <Input
-                    id="ct-name"
-                    placeholder="Acme Corp"
-                    {...register("name")}
-                  />
-                </Field>
-
-                <Field
+              <Field
+                id="ct-adminEmail"
+                label="Admin email"
+                required
+                error={errors.adminEmail?.message}
+              >
+                <Input
                   id="ct-adminEmail"
-                  label="Admin email"
-                  required
-                  error={errors.adminEmail?.message}
-                >
-                  <Input
-                    id="ct-adminEmail"
-                    type="email"
-                    placeholder="admin@acme.example"
-                    className="font-mono"
-                    {...register("adminEmail")}
-                  />
-                </Field>
+                  type="email"
+                  autoComplete="off"
+                  placeholder="admin@acme.example"
+                  className="font-mono"
+                  {...register("adminEmail")}
+                />
+              </Field>
 
-                <Field
-                  id="ct-adminPassword"
-                  label="Initial admin password"
-                  required
-                  hint="The first admin signs in with this. They can rotate it after first login."
-                  error={errors.adminPassword?.message}
-                >
+              {/* Password — generate + show/hide */}
+              <Field
+                id="ct-adminPassword"
+                label="Initial admin password"
+                required
+                hint="The first admin signs in with this and can rotate it after first login."
+                error={errors.adminPassword?.message}
+              >
+                <div className="relative">
                   <Input
                     id="ct-adminPassword"
-                    type="password"
+                    type={showPassword ? "text" : "password"}
                     autoComplete="new-password"
                     placeholder="Min 8 characters"
+                    className="pr-16 font-mono"
                     {...register("adminPassword")}
                   />
-                </Field>
-              </div>
-            </div>
+                  <div className="absolute inset-y-0 right-1.5 flex items-center gap-0.5">
+                    <AdornButton label="Generate strong password" onClick={fillGeneratedPassword}>
+                      <Wand2 aria-hidden />
+                    </AdornButton>
+                    <AdornButton
+                      label={showPassword ? "Hide password" : "Show password"}
+                      onClick={() => setShowPassword((s) => !s)}
+                    >
+                      {showPassword ? <EyeOff aria-hidden /> : <Eye aria-hidden />}
+                    </AdornButton>
+                  </div>
+                </div>
+              </Field>
 
-            {/* ── Plan section ── */}
-            <div className="space-y-3">
-              <SectionLabel
-                icon={CreditCard}
-                title="Plan"
-                description="Subscription plan to bill. The tenant's validity is set from the plan term and a term invoice is issued."
-              />
-              <div className="h-px bg-[var(--color-border)] opacity-60" />
+              {/* Plan */}
               <Field
                 id="ct-plan"
                 label="Billing plan"
                 hint={
                   plansQuery.isError
                     ? "Could not load plans — the tenant will fall back to the default plan."
-                    : "Determines the first invoice and how long the tenant stays valid. Defaults to the trial plan."
+                    : "Sets the first invoice and how long the tenant stays valid. Defaults to the trial plan."
                 }
                 error={errors.planKey?.message}
               >
@@ -321,7 +508,7 @@ export function CreateTenantDialog({
                   render={({ field }) => (
                     <Select
                       id="ct-plan"
-                      value={field.value}
+                      value={field.value ?? ""}
                       onValueChange={field.onChange}
                       options={planOptions}
                       emptyLabel={
@@ -336,69 +523,88 @@ export function CreateTenantDialog({
                   )}
                 />
               </Field>
+
+              {/* Advanced disclosure — issuer + dedicated database */}
+              <div className="rounded-lg border border-[var(--color-border)]">
+                <button
+                  type="button"
+                  onClick={() => setAdvancedOpen((o) => !o)}
+                  aria-expanded={advancedOpen}
+                  className="flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2.5 text-left outline-none
+                    transition-colors hover:bg-[var(--color-accent)] cursor-pointer
+                    focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
+                >
+                  <span className="text-[12.5px] font-medium text-[var(--color-foreground)]">
+                    Advanced
+                    <span className="ml-1.5 font-normal text-[var(--color-muted-foreground)]">
+                      issuer, dedicated database
+                    </span>
+                  </span>
+                  <ChevronDown
+                    aria-hidden
+                    className={cn(
+                      "size-4 shrink-0 text-[var(--color-muted-foreground)] transition-transform duration-[var(--duration-fast)]",
+                      advancedOpen && "rotate-180",
+                    )}
+                  />
+                </button>
+
+                {advancedOpen && (
+                  <div className="space-y-4 border-t border-[var(--color-border)] px-3 py-3.5">
+                    <Field
+                      id="ct-issuer"
+                      label="JWT issuer"
+                      required
+                      hint="Mirrors the identifier by default. Issued in tokens to scope sessions."
+                      error={errors.issuer?.message}
+                    >
+                      <Input
+                        id="ct-issuer"
+                        placeholder="acme-corp"
+                        className="font-mono"
+                        {...issuerField}
+                        onChange={(e) => {
+                          setIssuerDirty(true);
+                          void issuerField.onChange(e);
+                        }}
+                      />
+                    </Field>
+
+                    <Field
+                      id="ct-connectionString"
+                      label="Connection string"
+                      hint="Optional. Leave blank to use the shared catalog database."
+                      error={errors.connectionString?.message}
+                    >
+                      <Input
+                        id="ct-connectionString"
+                        placeholder="Host=…;Database=…"
+                        className="font-mono"
+                        {...register("connectionString")}
+                      />
+                    </Field>
+                  </div>
+                )}
+              </div>
             </div>
 
-            {/* ── Security section ── */}
-            <div className="space-y-3">
-              <SectionLabel
-                icon={KeyRound}
-                title="Security"
-                description="JWT issuer claim emitted by tokens for this tenant. Used to scope sessions."
-              />
-              <div className="h-px bg-[var(--color-border)] opacity-60" />
-              <Field
-                id="ct-issuer"
-                label="JWT issuer"
-                required
-                error={errors.issuer?.message}
-              >
-                <Input
-                  id="ct-issuer"
-                  placeholder="acme-corp.issuer"
-                  className="font-mono"
-                  {...register("issuer")}
-                />
-              </Field>
-            </div>
-
-            {/* ── Database section ── */}
-            <div className="space-y-3">
-              <SectionLabel
-                icon={Database}
-                title="Database"
-                description="Optional dedicated connection string. Leave blank to share the default database."
-              />
-              <div className="h-px bg-[var(--color-border)] opacity-60" />
-              <Field
-                id="ct-connectionString"
-                label="Connection string"
-                hint="Optional. Leave blank to use the shared catalog."
-                error={errors.connectionString?.message}
-              >
-                <Input
-                  id="ct-connectionString"
-                  placeholder="Host=…;Database=…"
-                  className="font-mono"
-                  {...register("connectionString")}
-                />
-              </Field>
-            </div>
-          </DialogBody>
-
-          {/* ── Footer ── */}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleClose}
-              disabled={submitting}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={submitting}>
-              {submitting ? "Provisioning…" : "Create tenant"}
-            </Button>
-          </DialogFooter>
+            {/* Footer */}
+            <DialogFooter className="px-6">
+              <Button type="button" variant="outline" onClick={handleClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitting} className="min-w-[8.5rem]">
+                {submitting ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" aria-hidden />
+                    <span>Provisioning…</span>
+                  </>
+                ) : (
+                  "Create tenant"
+                )}
+              </Button>
+            </DialogFooter>
+          </div>
         </form>
       </DialogContent>
     </Dialog>

--- a/clients/admin/src/env.ts
+++ b/clients/admin/src/env.ts
@@ -6,7 +6,20 @@ type RuntimeConfig = {
   apiBase: string;
   defaultTenant: string;
   dashboardUrl: string;
+  /** Idle time (ms) before the inactivity warning appears. Admin = sensitive operator console. */
+  inactivityIdleMs: number;
+  /** Warning-countdown length (ms) before auto sign-out. */
+  inactivityWarningMs: number;
 };
+
+// Admin defaults: 10 minutes idle, then a 60-second warning.
+const DEFAULT_INACTIVITY_IDLE_MS = 10 * 60_000;
+const DEFAULT_INACTIVITY_WARNING_MS = 60_000;
+
+/** Accept a positive finite number from config, else fall back. */
+function positiveOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
 
 let cached: RuntimeConfig | null = null;
 
@@ -23,6 +36,8 @@ export async function loadRuntimeConfig(): Promise<void> {
     // Dashboard origin used by the impersonation handoff. Dev default
     // mirrors clients/dashboard/package.json's vite port.
     dashboardUrl: (cfg.dashboardUrl ?? "http://localhost:5174").replace(/\/$/, ""),
+    inactivityIdleMs: positiveOr(cfg.inactivityIdleMs, DEFAULT_INACTIVITY_IDLE_MS),
+    inactivityWarningMs: positiveOr(cfg.inactivityWarningMs, DEFAULT_INACTIVITY_WARNING_MS),
   };
 }
 
@@ -39,4 +54,6 @@ export const env = {
   get apiBase(): string { return get().apiBase; },
   get defaultTenant(): string { return get().defaultTenant; },
   get dashboardUrl(): string { return get().dashboardUrl; },
+  get inactivityIdleMs(): number { return get().inactivityIdleMs; },
+  get inactivityWarningMs(): number { return get().inactivityWarningMs; },
 };

--- a/clients/admin/src/pages/auth/confirm-email.tsx
+++ b/clients/admin/src/pages/auth/confirm-email.tsx
@@ -86,7 +86,7 @@ export function ConfirmEmailPage() {
           <div className="flex items-center gap-2.5">
             <img
               src="/logo-fullstackhero.png"
-              alt="FullStackHero"
+              alt="fullstackhero"
               className="size-9 object-contain"
             />
             <span className="font-display text-[26px] font-semibold tracking-tight text-[var(--color-foreground)]">

--- a/clients/admin/src/pages/auth/forgot-password.tsx
+++ b/clients/admin/src/pages/auth/forgot-password.tsx
@@ -79,7 +79,7 @@ export function ForgotPasswordPage() {
           <div className="flex items-center gap-2.5">
             <img
               src="/logo-fullstackhero.png"
-              alt="FullStackHero"
+              alt="fullstackhero"
               className="size-9 object-contain"
             />
             <span className="font-display text-[26px] font-semibold tracking-tight text-[var(--color-foreground)]">

--- a/clients/admin/src/pages/auth/reset-password.tsx
+++ b/clients/admin/src/pages/auth/reset-password.tsx
@@ -121,7 +121,7 @@ export function ResetPasswordPage() {
           <div className="flex items-center gap-2.5">
             <img
               src="/logo-fullstackhero.png"
-              alt="FullStackHero"
+              alt="fullstackhero"
               className="size-9 object-contain"
             />
             <span className="font-display text-[26px] font-semibold tracking-tight text-[var(--color-foreground)]">

--- a/clients/admin/src/pages/login.tsx
+++ b/clients/admin/src/pages/login.tsx
@@ -108,7 +108,7 @@ export function LoginPage() {
             <div className="flex items-center gap-2.5">
               <img
                 src="/logo-fullstackhero.png"
-                alt="FullStackHero"
+                alt="fullstackhero"
                 className="size-9 object-contain"
               />
               <span className="font-display text-[26px] font-semibold tracking-tight text-[var(--color-foreground)]">
@@ -278,7 +278,7 @@ export function LoginPage() {
             <span>Encrypted in transit · JWT-secured session</span>
           </div>
           <p className="mt-4 text-center text-[10px] font-medium uppercase tracking-wider text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]">
-            FullStackHero Administration
+            fullstackhero Administration
           </p>
         </div>
       </div>

--- a/clients/admin/src/pages/login.tsx
+++ b/clients/admin/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import {
   AlertCircle,
@@ -8,8 +8,10 @@ import {
   Loader2,
   ShieldCheck,
   Sparkles,
+  TimerOff,
 } from "lucide-react";
 import { useAuth } from "@/auth/use-auth";
+import { consumeSignedOutReason } from "@/auth/inactivity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -44,6 +46,14 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [demoOpen, setDemoOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // Surface why the previous session ended (read-and-clear, one-shot).
+  useEffect(() => {
+    if (consumeSignedOutReason() === "inactivity") {
+      setNotice("You were signed out due to inactivity.");
+    }
+  }, []);
 
   if (isAuthenticated) {
     return <Navigate to={from} replace />;
@@ -133,6 +143,16 @@ export function LoginPage() {
                   Sign in to your operator account
                 </p>
               </div>
+
+              {notice && (
+                <div
+                  role="status"
+                  className="mb-5 flex items-start gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2.5 text-[12.5px] leading-snug text-[var(--color-muted-foreground)] fsh-enter"
+                >
+                  <TimerOff className="mt-0.5 size-3.5 shrink-0 text-[var(--color-muted-foreground)]" />
+                  <span>{notice}</span>
+                </div>
+              )}
 
               <form
                 onSubmit={onSubmit}

--- a/clients/admin/src/pages/settings/security.tsx
+++ b/clients/admin/src/pages/settings/security.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -7,6 +7,8 @@ import {
   AlertCircle,
   ClipboardCheck,
   Copy,
+  Eye,
+  EyeOff,
   KeyRound,
   ShieldCheck,
   ShieldOff,
@@ -20,10 +22,11 @@ import {
   type TwoFactorEnrollmentResponse,
 } from "@/api/two-factor";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Input, type InputProps } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -90,6 +93,37 @@ const passwordSchema = z
   });
 
 type PasswordValues = z.infer<typeof passwordSchema>;
+
+/**
+ * RevealInput — password Input with a first-class show/hide eye toggle
+ * (mirrors the login screen). Forwards the ref so react-hook-form can
+ * register the field for `reset()` and validation focus.
+ */
+const RevealInput = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    const [show, setShow] = useState(false);
+    return (
+      <div className="relative">
+        <Input
+          ref={ref}
+          type={show ? "text" : "password"}
+          className={cn("pr-10", className)}
+          {...props}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => setShow((s) => !s)}
+          aria-label={show ? "Hide password" : "Show password"}
+          className="absolute right-1.5 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-md text-[var(--color-muted-foreground)] outline-none transition-colors hover:text-[var(--color-foreground)] focus-visible:ring-2 focus-visible:ring-[oklch(from_var(--color-ring)_l_c_h_/_0.5)]"
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    );
+  },
+);
+RevealInput.displayName = "RevealInput";
 
 function PasswordSection() {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -168,56 +202,60 @@ function ChangePasswordDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Change password</DialogTitle>
+          <div className="flex items-center gap-3">
+            <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-[oklch(from_var(--color-primary)_l_c_h_/_0.10)] ring-1 ring-inset ring-[oklch(from_var(--color-primary)_l_c_h_/_0.20)]">
+              <KeyRound className="size-4 text-[var(--color-primary)]" />
+            </span>
+            <DialogTitle>Change password</DialogTitle>
+          </div>
           <DialogDescription>
             Sign-out events for other devices aren't fired automatically — visit the Sessions tab
             below to end them after rotating your password.
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={onSubmit} className="space-y-3" noValidate>
-          <Field id="pw-current" label="Current password" required error={errors.current?.message}>
-            <Input
-              id="pw-current"
-              type="password"
-              autoComplete="current-password"
-              className="font-mono"
-              aria-invalid={errors.current ? true : undefined}
-              autoFocus
-              {...register("current")}
-            />
-          </Field>
-          <Field
-            id="pw-next"
-            label="New password"
-            required
-            hint="At least 8 characters."
-            error={errors.next?.message}
-          >
-            <Input
+        <form onSubmit={onSubmit} className="contents" noValidate>
+          <DialogBody className="space-y-4">
+            <Field id="pw-current" label="Current password" required error={errors.current?.message}>
+              <RevealInput
+                id="pw-current"
+                autoComplete="current-password"
+                className="font-mono"
+                aria-invalid={errors.current ? true : undefined}
+                autoFocus
+                {...register("current")}
+              />
+            </Field>
+            <Field
               id="pw-next"
-              type="password"
-              autoComplete="new-password"
-              className="font-mono"
-              aria-invalid={errors.next ? true : undefined}
-              {...register("next")}
-            />
-          </Field>
-          <Field
-            id="pw-confirm"
-            label="Confirm new password"
-            required
-            error={errors.confirm?.message}
-          >
-            <Input
+              label="New password"
+              required
+              hint="At least 8 characters."
+              error={errors.next?.message}
+            >
+              <RevealInput
+                id="pw-next"
+                autoComplete="new-password"
+                className="font-mono"
+                aria-invalid={errors.next ? true : undefined}
+                {...register("next")}
+              />
+            </Field>
+            <Field
               id="pw-confirm"
-              type="password"
-              autoComplete="new-password"
-              className="font-mono"
-              aria-invalid={errors.confirm ? true : undefined}
-              {...register("confirm")}
-            />
-          </Field>
+              label="Confirm new password"
+              required
+              error={errors.confirm?.message}
+            >
+              <RevealInput
+                id="pw-confirm"
+                autoComplete="new-password"
+                className="font-mono"
+                aria-invalid={errors.confirm ? true : undefined}
+                {...register("confirm")}
+              />
+            </Field>
+          </DialogBody>
 
           <DialogFooter>
             <Button

--- a/clients/admin/src/styles/globals.css
+++ b/clients/admin/src/styles/globals.css
@@ -506,6 +506,14 @@
     cursor: not-allowed;
   }
 
+  /* Hide the browser's native password reveal/clear controls (Edge/IE).
+     We ship our own eye toggle on password fields, so the built-in one
+     would just double up the affordance. */
+  input::-ms-reveal,
+  input::-ms-clear {
+    display: none;
+  }
+
   html {
     font-family: var(--font-sans);
     font-feature-settings: var(--font-feature-default);

--- a/clients/admin/tests/auth/inactivity.spec.ts
+++ b/clients/admin/tests/auth/inactivity.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { seedAuthedSession, TEST_USER } from "../helpers/auth-seed";
+import { installAdminShellMocks, ADMIN_PERMS } from "../helpers/shell-mocks";
+
+// Drive the inactivity feature with tiny durations injected via /config.json:
+// idle 2s → a 3s warning countdown → auto sign-out. The guard mounts in the
+// authenticated AppShell, so any protected page exercises it.
+const IDLE_MS = 2_000;
+const WARNING_MS = 3_000;
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/config.json", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiBase: "",
+        defaultTenant: "root",
+        inactivityIdleMs: IDLE_MS,
+        inactivityWarningMs: WARNING_MS,
+      }),
+    }),
+  );
+  await seedAuthedSession(page, { ...TEST_USER, permissions: [...ADMIN_PERMS] });
+  // Defensive catch-all so a stray protected call can't 401→logout and race the
+  // idle timer; the specific shell mocks register after this and win.
+  await page.route("**/api/v1/**", (route) =>
+    route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: "[]" }),
+  );
+  await installAdminShellMocks(page);
+});
+
+test.describe("inactivity auto-logout", () => {
+  test("shows the warning modal after the idle threshold", async ({ page }) => {
+    await page.goto("/settings/security");
+    // The warning only appears if we're authenticated AND went idle — no
+    // interaction after load, so the idle timer elapses.
+    await expect(page.getByRole("dialog").getByText("Still there?")).toBeVisible({
+      timeout: 9_000,
+    });
+    await expect(page.getByRole("button", { name: "I'm here" })).toBeVisible();
+  });
+
+  test("'I'm here' dismisses the warning and keeps the session", async ({ page }) => {
+    await page.goto("/settings/security");
+    const stay = page.getByRole("button", { name: "I'm here" });
+    await expect(stay).toBeVisible({ timeout: 9_000 });
+
+    await stay.click();
+
+    await expect(page.getByText("Still there?")).toBeHidden();
+    await expect(page).not.toHaveURL(/\/login$/);
+  });
+
+  test("signs out to /login with a notice when the countdown elapses", async ({ page }) => {
+    await page.goto("/settings/security");
+    // Let the warning appear, then wait it out without interacting.
+    await expect(page.getByRole("button", { name: "I'm here" })).toBeVisible({ timeout: 9_000 });
+
+    await expect(page).toHaveURL(/\/login$/, { timeout: WARNING_MS + 6_000 });
+    await expect(page.getByText(/signed out due to inactivity/i)).toBeVisible();
+  });
+});

--- a/clients/admin/tests/tenants/tenant-billing.spec.ts
+++ b/clients/admin/tests/tenants/tenant-billing.spec.ts
@@ -82,11 +82,12 @@ test.describe("create tenant — plan selector", () => {
     await planSelect.click();
     await page.getByRole("menuitem", { name: "Pro" }).first().click();
 
-    await dialog.getByLabel(/^Identifier/).fill("acme-corp");
+    // Identifier (and JWT issuer) auto-derive from the display name — no need to
+    // type the slug by hand.
     await dialog.getByLabel(/^Display name/).fill("Acme Corp");
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveValue("acme-corp");
     await dialog.getByLabel(/^Admin email/).fill("admin@acme.example");
     await dialog.getByLabel(/^Initial admin password/).fill("Sup3rSecret!");
-    await dialog.getByLabel(/^JWT issuer/).fill("acme-corp.issuer");
 
     const reqPromise = page.waitForRequest(
       (r) => r.url().endsWith("/api/v1/tenants/") && r.method() === "POST",

--- a/clients/admin/tests/tenants/tenant-create.spec.ts
+++ b/clients/admin/tests/tenants/tenant-create.spec.ts
@@ -15,10 +15,33 @@ test.beforeEach(async ({ page }) => {
       body: JSON.stringify(paged([])),
     }),
   );
+  // The dialog loads active billing plans on open (to populate the plan picker
+  // and preselect the trial plan). Mock it so the query resolves cleanly — an
+  // unmocked call would 401 against a real dev backend and log the session out
+  // mid-test.
+  await page.route("**/api/v1/billing/plans**", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([
+        {
+          id: "plan-free",
+          key: "free",
+          name: "Free",
+          currency: "USD",
+          monthlyBasePrice: 0,
+          overageRates: {},
+          isActive: true,
+          interval: "Monthly",
+          annualPrice: null,
+        },
+      ]),
+    }),
+  );
 });
 
 test.describe("tenant create dialog", () => {
-  test("renders all required fields and the create action", async ({ page }) => {
+  test("renders the core fields and tucks issuer/database behind Advanced", async ({ page }) => {
     await page.goto("/tenants");
 
     // Open the create dialog from the list-page trigger. `exact` keeps this off
@@ -32,18 +55,23 @@ test.describe("tenant create dialog", () => {
       dialog.getByRole("heading", { name: "New tenant", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
 
-    await expect(dialog.getByLabel(/^Identifier/)).toBeVisible();
     await expect(dialog.getByLabel(/^Display name/)).toBeVisible();
+    await expect(dialog.getByLabel(/^Identifier/)).toBeVisible();
     await expect(dialog.getByLabel(/^Admin email/)).toBeVisible();
     await expect(dialog.getByLabel(/^Initial admin password/)).toBeVisible();
+
+    // JWT issuer + connection string now live under a collapsed "Advanced" section.
+    await expect(dialog.getByLabel(/^JWT issuer/)).toBeHidden();
+    await dialog.getByRole("button", { name: /^Advanced/ }).click();
     await expect(dialog.getByLabel(/^JWT issuer/)).toBeVisible();
+    await expect(dialog.getByLabel(/^Connection string/)).toBeVisible();
 
     await expect(
       dialog.getByRole("button", { name: "Create tenant", exact: true }),
     ).toBeVisible();
   });
 
-  test("filling the form and submitting POSTs to /api/v1/tenants/", async ({ page }) => {
+  test("auto-derives the identifier (and issuer) from the display name", async ({ page }) => {
     await page.route("**/api/v1/tenants/", async (route) => {
       if (route.request().method() !== "POST") {
         await route.fallback();
@@ -66,7 +94,7 @@ test.describe("tenant create dialog", () => {
           adminEmail: "admin@acme.example",
           isActive: true,
           validUpto: "2027-01-01T00:00:00Z",
-          issuer: "acme-corp.issuer",
+          issuer: "acme-corp",
         }),
       }),
     );
@@ -90,13 +118,15 @@ test.describe("tenant create dialog", () => {
       .click();
 
     const dialog = page.getByRole("dialog");
-    await expect(dialog.getByLabel(/^Identifier/)).toBeVisible({ timeout: 10_000 });
+    await expect(dialog.getByLabel(/^Display name/)).toBeVisible({ timeout: 10_000 });
 
-    await dialog.getByLabel(/^Identifier/).fill("acme-corp");
+    // Typing the display name fills the identifier automatically — the operator
+    // never has to type the slug by hand.
     await dialog.getByLabel(/^Display name/).fill("Acme Corp");
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveValue("acme-corp");
+
     await dialog.getByLabel(/^Admin email/).fill("admin@acme.example");
     await dialog.getByLabel(/^Initial admin password/).fill("Sup3rSecret!");
-    await dialog.getByLabel(/^JWT issuer/).fill("acme-corp.issuer");
 
     const reqPromise = page.waitForRequest(
       (r) => r.url().endsWith("/api/v1/tenants/") && r.method() === "POST",
@@ -106,13 +136,56 @@ test.describe("tenant create dialog", () => {
     const req = await reqPromise;
 
     const body = JSON.parse(req.postData() ?? "{}");
+    // Identifier and issuer are both derived from the display name.
     expect(body).toMatchObject({
       id: "acme-corp",
       name: "Acme Corp",
       adminEmail: "admin@acme.example",
       adminPassword: "Sup3rSecret!",
-      issuer: "acme-corp.issuer",
+      issuer: "acme-corp",
     });
+  });
+
+  test("unlocking the identifier lets you type a custom slug", async ({ page }) => {
+    await page.goto("/tenants");
+    await page
+      .getByRole("button", { name: "New tenant", exact: true })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByLabel(/^Display name/)).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByLabel(/^Display name/).fill("Acme Corp");
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveValue("acme-corp");
+
+    // Auto-derived identifier is read-only until unlocked.
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveAttribute("readonly", "");
+    await dialog.getByRole("button", { name: "Edit" }).click();
+    await dialog.getByLabel(/^Identifier/).fill("acme-emea");
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveValue("acme-emea");
+
+    // Re-locking snaps it back to the slug derived from the display name.
+    await dialog.getByRole("button", { name: "Auto" }).click();
+    await expect(dialog.getByLabel(/^Identifier/)).toHaveValue("acme-corp");
+  });
+
+  test("the password generator fills a strong value and reveals it", async ({ page }) => {
+    await page.goto("/tenants");
+    await page
+      .getByRole("button", { name: "New tenant", exact: true })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    const password = dialog.getByLabel(/^Initial admin password/);
+    await expect(password).toBeVisible({ timeout: 10_000 });
+
+    await expect(password).toHaveAttribute("type", "password");
+    await dialog.getByRole("button", { name: "Generate strong password" }).click();
+
+    // Generating reveals the field and writes a non-trivial secret.
+    await expect(password).toHaveAttribute("type", "text");
+    const value = await password.inputValue();
+    expect(value.length).toBeGreaterThanOrEqual(12);
   });
 
   test("client-side validation blocks submit on an invalid identifier", async ({ page }) => {
@@ -132,16 +205,16 @@ test.describe("tenant create dialog", () => {
       .click();
 
     const dialog = page.getByRole("dialog");
-    await expect(dialog.getByLabel(/^Identifier/)).toBeVisible({ timeout: 10_000 });
+    await expect(dialog.getByLabel(/^Display name/)).toBeVisible({ timeout: 10_000 });
 
-    // Invalid identifier (uppercase + too short) and a too-short password.
+    // Drive an invalid identifier by unlocking the field and typing a bad slug.
     // We leave the email blank so the browser's native <input type=email>
     // constraint doesn't pre-empt react-hook-form's submit handler — that lets
     // zod report the field-level errors we assert on.
-    await dialog.getByLabel(/^Identifier/).fill("A");
     await dialog.getByLabel(/^Display name/).fill("Acme Corp");
+    await dialog.getByRole("button", { name: "Edit" }).click();
+    await dialog.getByLabel(/^Identifier/).fill("A");
     await dialog.getByLabel(/^Initial admin password/).fill("short");
-    await dialog.getByLabel(/^JWT issuer/).fill("acme-corp.issuer");
 
     await dialog.getByRole("button", { name: "Create tenant", exact: true }).click();
 

--- a/clients/dashboard/public/config.json
+++ b/clients/dashboard/public/config.json
@@ -1,5 +1,7 @@
 {
   "apiBase": "",
   "defaultTenant": "root",
-  "demoMode": true
+  "demoMode": true,
+  "inactivityIdleMs": 1200000,
+  "inactivityWarningMs": 60000
 }

--- a/clients/dashboard/src/auth/auth-context.tsx
+++ b/clients/dashboard/src/auth/auth-context.tsx
@@ -51,8 +51,14 @@ export type AuthContextValue = {
     targetTenantId: string;
     reason?: string;
   }) => Promise<void>;
-  /** Stop impersonating and restore the operator session. */
-  stopImpersonation: () => Promise<void>;
+  /**
+   * Stop impersonating. Restores the operator's dashboard session for an
+   * intra-app impersonation, or signs out (→ /login) when there is no dashboard
+   * session to return to — e.g. a root operator who handed off from the admin
+   * app, since a SuperAdmin must never hold a tenant-dashboard session.
+   * Resolves with `{ signedOut }` so the caller can route accordingly.
+   */
+  stopImpersonation: () => Promise<{ signedOut: boolean }>;
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -259,7 +265,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [queryClient],
   );
 
-  const stopImpersonation = useCallback(async () => {
+  const stopImpersonation = useCallback(async (): Promise<{ signedOut: boolean }> => {
     // No stash ⇒ the operator arrived via a cross-app handoff (e.g. a root
     // SuperAdmin started impersonation from the admin app), so there is no
     // dashboard session to return to. The local impersonation token is
@@ -274,14 +280,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         /* best-effort: token expires shortly, nothing to recover here */
       });
       logout();
-      return;
+      return { signedOut: true };
     }
 
     // Intra-app impersonation: we genuinely need the server-minted operator
     // tokens to restore the original dashboard session, so await the call.
     try {
       const fresh = await endImpersonation();
+      // Defence-in-depth: the End endpoint mints fresh tokens for the *original
+      // operator*. If that operator is a root SuperAdmin (e.g. a cross-app
+      // handoff that nonetheless left a stash), installing them would drop a
+      // root account into the tenant dashboard — exactly what `login` forbids.
+      // Sign out and route to /login instead of restoring.
+      const claims = decodeJwt(fresh.accessToken);
+      if (claims?.tenant === "root") {
+        logout();
+        return { signedOut: true };
+      }
       tokenStore.endImpersonationWithFreshTokens(fresh.accessToken, fresh.refreshToken);
+      return { signedOut: false };
     } catch {
       // End endpoint failed (server unreachable / token invalid). Fall
       // back to whatever we stashed locally; the operator may need to

--- a/clients/dashboard/src/auth/inactivity.ts
+++ b/clients/dashboard/src/auth/inactivity.ts
@@ -1,0 +1,75 @@
+// Inactivity auto-logout — shared, app-agnostic primitives.
+//
+// localStorage/sessionStorage is per-origin, so the admin and dashboard apps
+// never share these keys (different hosts). That lets us use short, un-prefixed
+// key names without colliding — and, importantly, the activity heartbeat key
+// does NOT start with "fsh.{app}." so it won't trip each app's auth storage
+// listeners on every cross-tab tick.
+
+/** Shared "last user activity" timestamp — one value across every tab of this origin. */
+const LAST_ACTIVITY_KEY = "fsh.lastActivity";
+/** Ephemeral, per-tab reason stash read once by the login page after a sign-out. */
+const SIGNED_OUT_REASON_KEY = "fsh.signedOutReason";
+
+export type InactivityPhase = "active" | "warning" | "expired";
+
+/**
+ * Pure phase evaluation — given the current time and the last activity stamp,
+ * decide whether the session is active, in its warning window, or expired.
+ * `secondsLeft` is the whole seconds remaining until expiry during `warning`.
+ */
+export function evaluateInactivity(
+  now: number,
+  lastActivity: number,
+  idleMs: number,
+  warningMs: number,
+): { phase: InactivityPhase; secondsLeft: number } {
+  const idle = now - lastActivity;
+  if (idle >= idleMs + warningMs) return { phase: "expired", secondsLeft: 0 };
+  if (idle >= idleMs) {
+    const remainingMs = idleMs + warningMs - idle;
+    return { phase: "warning", secondsLeft: Math.max(0, Math.ceil(remainingMs / 1000)) };
+  }
+  return { phase: "active", secondsLeft: 0 };
+}
+
+/** Cross-tab shared activity timestamp. Writes are best-effort (private mode). */
+export const activityStore = {
+  key: LAST_ACTIVITY_KEY,
+  get(): number {
+    try {
+      const raw = localStorage.getItem(LAST_ACTIVITY_KEY);
+      const parsed = raw ? Number(raw) : Number.NaN;
+      return Number.isFinite(parsed) ? parsed : 0;
+    } catch {
+      return 0;
+    }
+  },
+  set(ts: number): void {
+    try {
+      localStorage.setItem(LAST_ACTIVITY_KEY, String(ts));
+    } catch {
+      /* storage unavailable (private mode / quota) — degrade to single-tab timing */
+    }
+  },
+};
+
+/** Stash why the session ended so the login page can explain it. */
+export function markSignedOut(reason: string): void {
+  try {
+    sessionStorage.setItem(SIGNED_OUT_REASON_KEY, reason);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Read-and-clear the sign-out reason (one-shot). */
+export function consumeSignedOutReason(): string | null {
+  try {
+    const value = sessionStorage.getItem(SIGNED_OUT_REASON_KEY);
+    if (value) sessionStorage.removeItem(SIGNED_OUT_REASON_KEY);
+    return value;
+  } catch {
+    return null;
+  }
+}

--- a/clients/dashboard/src/auth/use-inactivity-timeout.ts
+++ b/clients/dashboard/src/auth/use-inactivity-timeout.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { activityStore, evaluateInactivity, type InactivityPhase } from "@/auth/inactivity";
+
+// Genuine user-intent signals. Throttled before they touch storage so a
+// mousemove storm can't hammer localStorage.
+const ACTIVITY_EVENTS = [
+  "pointerdown",
+  "keydown",
+  "wheel",
+  "touchstart",
+  "scroll",
+  "mousemove",
+] as const;
+
+const WRITE_THROTTLE_MS = 1_000;
+const TICK_MS = 1_000;
+
+type Options = {
+  /** Watch only while signed in. When false the hook is fully inert. */
+  enabled: boolean;
+  idleMs: number;
+  warningMs: number;
+  /** Fired once when the session crosses the expiry threshold. */
+  onExpire: () => void;
+};
+
+/**
+ * Drives the inactivity state machine. Tracks a cross-tab "last activity"
+ * timestamp, ticks once a second, and surfaces the current phase + seconds
+ * left so a warning modal can render. Activity in any tab keeps every tab
+ * alive; while THIS tab shows the warning it stops recording passive activity
+ * so the prompt stays meaningful (only an explicit reset, or real activity in
+ * another tab, dismisses it).
+ */
+export function useInactivityTimeout({ enabled, idleMs, warningMs, onExpire }: Options) {
+  const [phase, setPhase] = useState<InactivityPhase>("active");
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  // Mutable mirrors so the event/interval wiring can stay mount-scoped.
+  const phaseRef = useRef<InactivityPhase>("active");
+  const lastWriteRef = useRef(0);
+  const expiredRef = useRef(false);
+  const idleRef = useRef(idleMs);
+  const warnRef = useRef(warningMs);
+  const onExpireRef = useRef(onExpire);
+  idleRef.current = idleMs;
+  warnRef.current = warningMs;
+  onExpireRef.current = onExpire;
+
+  const evaluateNow = useCallback(() => {
+    const { phase: next, secondsLeft: left } = evaluateInactivity(
+      Date.now(),
+      activityStore.get(),
+      idleRef.current,
+      warnRef.current,
+    );
+    phaseRef.current = next;
+    setPhase(next);
+    setSecondsLeft(left);
+    if (next === "expired" && !expiredRef.current) {
+      expiredRef.current = true;
+      onExpireRef.current();
+    }
+  }, []);
+
+  const recordActivity = useCallback(() => {
+    // Freeze passive activity once we're warning/expired in this tab.
+    if (phaseRef.current !== "active") return;
+    const now = Date.now();
+    if (now - lastWriteRef.current < WRITE_THROTTLE_MS) return;
+    lastWriteRef.current = now;
+    activityStore.set(now);
+  }, []);
+
+  /** Explicit "I'm here" — refresh the shared stamp and drop back to active. */
+  const reset = useCallback(() => {
+    const now = Date.now();
+    lastWriteRef.current = now;
+    activityStore.set(now);
+    expiredRef.current = false;
+    phaseRef.current = "active";
+    setPhase("active");
+    setSecondsLeft(0);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      phaseRef.current = "active";
+      expiredRef.current = false;
+      setPhase("active");
+      setSecondsLeft(0);
+      return;
+    }
+
+    // Seed the shared stamp on first enable so a fresh login isn't instantly idle.
+    if (activityStore.get() <= 0) activityStore.set(Date.now());
+    expiredRef.current = false;
+
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, recordActivity, { passive: true, capture: true });
+    }
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === activityStore.key) evaluateNow();
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") evaluateNow();
+    };
+    window.addEventListener("storage", onStorage);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    evaluateNow();
+    const intervalId = window.setInterval(evaluateNow, TICK_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+      for (const evt of ACTIVITY_EVENTS) {
+        window.removeEventListener(evt, recordActivity, {
+          capture: true,
+        } as EventListenerOptions);
+      }
+      window.removeEventListener("storage", onStorage);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [enabled, recordActivity, evaluateNow]);
+
+  return { phase, secondsLeft, dismiss: reset };
+}

--- a/clients/dashboard/src/components/auth/auth-shell.tsx
+++ b/clients/dashboard/src/components/auth/auth-shell.tsx
@@ -68,7 +68,7 @@ export function AuthShell({
           <div className="flex items-center gap-2.5">
             <img
               src="/logo-fullstackhero.png"
-              alt="FullStackHero"
+              alt="fullstackhero"
               className="size-9 object-contain"
             />
             <span className="font-display text-[26px] font-semibold tracking-tight text-[var(--color-foreground)]">
@@ -98,7 +98,7 @@ export function AuthShell({
           <span>Encrypted in transit · JWT-secured session</span>
         </div>
         <p className="mt-4 text-center text-[10px] font-medium uppercase tracking-wider text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]">
-          FullStackHero Administration
+          fullstackhero Administration
         </p>
       </div>
     </div>

--- a/clients/dashboard/src/components/auth/demo-accounts-dialog.tsx
+++ b/clients/dashboard/src/components/auth/demo-accounts-dialog.tsx
@@ -78,7 +78,7 @@ export function DemoAccountsDialog({ open, onOpenChange, onPick }: DemoAccountsD
             Step into any role.
           </h2>
           <p className="mt-1.5 max-w-[80%] text-[12.5px] leading-relaxed text-muted-foreground/80">
-            Explore FullStackHero as any user across the demo tenants — we'll sign you in instantly.
+            Explore fullstackhero as any user across the demo tenants — we'll sign you in instantly.
           </p>
         </header>
 

--- a/clients/dashboard/src/components/auth/inactivity-dialog.tsx
+++ b/clients/dashboard/src/components/auth/inactivity-dialog.tsx
@@ -1,0 +1,131 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+/**
+ * InactivityDialog — the inactivity warning. A forced-choice modal (no Esc,
+ * no overlay-dismiss, no close X) built on the raw Radix primitives so it can
+ * opt out of the shared DialogContent's close affordance. The centerpiece is
+ * an SVG countdown ring that drains as the seconds tick and shifts tone
+ * primary → amber → red, pulsing in the final stretch. Respects
+ * prefers-reduced-motion (the ring steps per second instead of animating).
+ */
+
+const RING_RADIUS = 52;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function ringTone(fraction: number): string {
+  if (fraction > 0.5) return "var(--color-primary)";
+  if (fraction > 0.2) return "var(--color-warning)";
+  return "var(--color-destructive)";
+}
+
+export function InactivityDialog({
+  open,
+  secondsLeft,
+  totalSeconds,
+  onStay,
+  onSignOut,
+}: {
+  open: boolean;
+  secondsLeft: number;
+  totalSeconds: number;
+  onStay: () => void;
+  onSignOut: () => void;
+}) {
+  const fraction =
+    totalSeconds > 0 ? Math.max(0, Math.min(1, secondsLeft / totalSeconds)) : 0;
+  const dashOffset = RING_CIRCUMFERENCE * (1 - fraction);
+  const tone = ringTone(fraction);
+  const urgent = secondsLeft <= 10;
+
+  return (
+    <DialogPrimitive.Root open={open}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-[oklch(0_0_0_/_0.45)] backdrop-blur-[6px]",
+            "data-[state=open]:animate-fsh-overlay-in data-[state=closed]:animate-fsh-overlay-out",
+          )}
+        />
+        <DialogPrimitive.Content
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          aria-describedby="inactivity-desc"
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-[400px] -translate-x-1/2 -translate-y-1/2",
+            "rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-7 text-center shadow-xl outline-none",
+            "data-[state=open]:animate-fsh-dialog-in data-[state=closed]:animate-fsh-dialog-out",
+          )}
+        >
+          {/* Countdown ring */}
+          <div className="relative mx-auto mb-5 size-[132px]">
+            <svg viewBox="0 0 120 120" className="size-full -rotate-90" aria-hidden>
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                strokeWidth="7"
+                className="stroke-[var(--color-muted)]"
+              />
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                strokeWidth="7"
+                strokeLinecap="round"
+                stroke={tone}
+                strokeDasharray={RING_CIRCUMFERENCE}
+                strokeDashoffset={dashOffset}
+                className={cn(
+                  "motion-safe:transition-[stroke-dashoffset,stroke] motion-safe:duration-1000 motion-safe:ease-linear",
+                  urgent && "motion-safe:animate-pulse",
+                )}
+              />
+            </svg>
+            <div className="absolute inset-0 grid place-items-center">
+              <div className="flex flex-col items-center">
+                <span
+                  className="font-display text-[34px] font-bold leading-none tabular-nums tracking-tight"
+                  style={{ color: tone }}
+                >
+                  {Math.max(0, secondsLeft)}
+                </span>
+                <span className="mt-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--color-muted-foreground)]">
+                  seconds
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="mb-1.5 flex items-center justify-center gap-2">
+            <ShieldAlert className="size-4 text-[var(--color-primary)]" aria-hidden />
+            <DialogPrimitive.Title className="font-display text-[18px] font-semibold tracking-tight text-[var(--color-foreground)]">
+              Still there?
+            </DialogPrimitive.Title>
+          </div>
+          <DialogPrimitive.Description
+            id="inactivity-desc"
+            className="mx-auto max-w-[300px] text-[13px] leading-relaxed text-[var(--color-muted-foreground)]"
+          >
+            You&apos;ve been inactive for a while. We&apos;ll sign you out shortly to keep your
+            account secure.
+          </DialogPrimitive.Description>
+
+          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-center">
+            <Button variant="outline" onClick={onSignOut} className="sm:min-w-[120px]">
+              Sign out now
+            </Button>
+            <Button onClick={onStay} className="sm:min-w-[120px]" autoFocus>
+              I&apos;m here
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/clients/dashboard/src/components/auth/inactivity-guard.tsx
+++ b/clients/dashboard/src/components/auth/inactivity-guard.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useAuth } from "@/auth/use-auth";
+import { env } from "@/env";
+import { markSignedOut } from "@/auth/inactivity";
+import { useInactivityTimeout } from "@/auth/use-inactivity-timeout";
+import { InactivityDialog } from "@/components/auth/inactivity-dialog";
+
+/**
+ * InactivityGuard — mounted once inside the authenticated shell. Watches for
+ * inactivity while signed in, shows the warning modal in the final window, and
+ * signs the user out (with an "inactivity" reason for the login page) when the
+ * countdown elapses. Durations come from runtime config so operators can tune
+ * them per deployment without a rebuild.
+ */
+export function InactivityGuard() {
+  const { isAuthenticated, logout } = useAuth();
+  const idleMs = env.inactivityIdleMs;
+  const warningMs = env.inactivityWarningMs;
+
+  const signOut = useCallback(() => {
+    markSignedOut("inactivity");
+    logout();
+  }, [logout]);
+
+  const { phase, secondsLeft, dismiss } = useInactivityTimeout({
+    enabled: isAuthenticated,
+    idleMs,
+    warningMs,
+    onExpire: signOut,
+  });
+
+  return (
+    <InactivityDialog
+      open={isAuthenticated && phase === "warning"}
+      secondsLeft={secondsLeft}
+      totalSeconds={Math.round(warningMs / 1000)}
+      onStay={dismiss}
+      onSignOut={signOut}
+    />
+  );
+}

--- a/clients/dashboard/src/components/layout/app-shell.tsx
+++ b/clients/dashboard/src/components/layout/app-shell.tsx
@@ -11,6 +11,7 @@ import { SseProvider } from "@/sse/sse-context";
 import { RealtimeProvider } from "@/realtime/realtime-context";
 import { ChatGlobalNotifier } from "@/components/notifications/chat-global-notifier";
 import { CommandPaletteRoot } from "@/components/command-palette/command-palette";
+import { InactivityGuard } from "@/components/auth/inactivity-guard";
 import { cn } from "@/lib/cn";
 
 export function AppShell() {
@@ -66,6 +67,9 @@ export function AppShell() {
       {/* Mounted inside the router subtree so useNavigate inside the
           palette resolves correctly. */}
       <CommandPaletteRoot />
+
+      {/* Inactivity auto-logout — warning modal + countdown, signed-in only. */}
+      <InactivityGuard />
       </RealtimeProvider>
     </SseProvider>
   );

--- a/clients/dashboard/src/components/layout/impersonation-banner.tsx
+++ b/clients/dashboard/src/components/layout/impersonation-banner.tsx
@@ -33,14 +33,22 @@ export function ImpersonationBanner() {
     mutationFn: async () => {
       setPending(true);
       try {
-        await stopImpersonation();
+        return await stopImpersonation();
       } finally {
         setPending(false);
       }
     },
-    onSuccess: () => {
-      toast.success("Returned to your session");
-      navigate("/", { replace: true });
+    onSuccess: (result) => {
+      // No dashboard session to return to (root operator handed off from the
+      // admin app) → land on /login. Otherwise the operator's own session was
+      // restored → back to the dashboard home.
+      if (result.signedOut) {
+        toast.success("Impersonation ended");
+        navigate("/login", { replace: true });
+      } else {
+        toast.success("Returned to your session");
+        navigate("/", { replace: true });
+      }
     },
     onError: (err) => {
       toast.error("Could not end impersonation cleanly", {

--- a/clients/dashboard/src/components/layout/topbar.tsx
+++ b/clients/dashboard/src/components/layout/topbar.tsx
@@ -365,7 +365,7 @@ export function Topbar() {
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Sign out of FullStackHero?</DialogTitle>
+            <DialogTitle>Sign out of fullstackhero?</DialogTitle>
             <DialogDescription>
               You'll need to sign in again to access this tenant. Any unsaved
               work in this session will be lost.

--- a/clients/dashboard/src/env.ts
+++ b/clients/dashboard/src/env.ts
@@ -11,7 +11,20 @@ type RuntimeConfig = {
    * staging config.json and false (or omit it) in production.
    */
   demoMode: boolean;
+  /** Idle time (ms) before the inactivity warning appears. */
+  inactivityIdleMs: number;
+  /** Warning-countdown length (ms) before auto sign-out. */
+  inactivityWarningMs: number;
 };
+
+// Dashboard defaults: 20 minutes idle, then a 60-second warning.
+const DEFAULT_INACTIVITY_IDLE_MS = 20 * 60_000;
+const DEFAULT_INACTIVITY_WARNING_MS = 60_000;
+
+/** Accept a positive finite number from config, else fall back. */
+function positiveOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
 
 let cached: RuntimeConfig | null = null;
 
@@ -26,6 +39,8 @@ export async function loadRuntimeConfig(): Promise<void> {
     apiBase: (cfg.apiBase ?? "").replace(/\/$/, ""),
     defaultTenant: cfg.defaultTenant ?? "root",
     demoMode: cfg.demoMode ?? false,
+    inactivityIdleMs: positiveOr(cfg.inactivityIdleMs, DEFAULT_INACTIVITY_IDLE_MS),
+    inactivityWarningMs: positiveOr(cfg.inactivityWarningMs, DEFAULT_INACTIVITY_WARNING_MS),
   };
 }
 
@@ -42,4 +57,6 @@ export const env = {
   get apiBase(): string { return get().apiBase; },
   get defaultTenant(): string { return get().defaultTenant; },
   get demoMode(): boolean { return get().demoMode; },
+  get inactivityIdleMs(): number { return get().inactivityIdleMs; },
+  get inactivityWarningMs(): number { return get().inactivityWarningMs; },
 };

--- a/clients/dashboard/src/lib/api-client.ts
+++ b/clients/dashboard/src/lib/api-client.ts
@@ -23,6 +23,21 @@ export class ApiRequestError extends Error {
   }
 }
 
+/**
+ * True when an error is the API's "tenant has been deactivated" 403. The
+ * deactivated-tenant guard (MultitenancyModule) rejects *every* request once a
+ * tenant is switched off, so this can surface from any query/mutation while a
+ * user is mid-session. There is no machine-readable code on the ProblemDetails,
+ * so we match the guard's detail text. A global query/mutation error hook uses
+ * this to route the user to the dedicated `/tenant-deactivated` page rather than
+ * leaving the dead 403 banner stuck under a half-loaded surface.
+ */
+export function isTenantDeactivatedError(error: unknown): boolean {
+  if (!(error instanceof ApiRequestError) || error.status !== 403) return false;
+  const detail = error.problem?.detail ?? error.message ?? "";
+  return detail.toLowerCase().includes("tenant has been deactivated");
+}
+
 type RequestInitEx = RequestInit & {
   skipAuth?: boolean;
   /**

--- a/clients/dashboard/src/lib/query-client.ts
+++ b/clients/dashboard/src/lib/query-client.ts
@@ -1,7 +1,22 @@
-import { QueryClient } from "@tanstack/react-query";
-import { ApiRequestError } from "@/lib/api-client";
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
+import { ApiRequestError, isTenantDeactivatedError } from "@/lib/api-client";
+import { router } from "@/routes";
+
+const TENANT_DEACTIVATED_PATH = "/tenant-deactivated";
+
+// Once a tenant is deactivated every request 403s, so this hook can fire from
+// many queries/mutations at once. Route to the dedicated page from the first
+// one and no-op the rest by guarding on the current location. Navigation goes
+// through the data router instance directly because this runs outside React.
+function handleGlobalError(error: unknown) {
+  if (!isTenantDeactivatedError(error)) return;
+  if (router.state.location.pathname === TENANT_DEACTIVATED_PATH) return;
+  void router.navigate(TENANT_DEACTIVATED_PATH, { replace: true });
+}
 
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({ onError: handleGlobalError }),
+  mutationCache: new MutationCache({ onError: handleGlobalError }),
   defaultOptions: {
     queries: {
       retry: (failureCount, error) => {

--- a/clients/dashboard/src/pages/login.tsx
+++ b/clients/dashboard/src/pages/login.tsx
@@ -1,7 +1,8 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
-import { AlertCircle, ArrowRight, Eye, EyeOff, Loader2, Sparkles } from "lucide-react";
+import { AlertCircle, ArrowRight, Eye, EyeOff, Loader2, Sparkles, TimerOff } from "lucide-react";
 import { useAuth } from "@/auth/use-auth";
+import { consumeSignedOutReason } from "@/auth/inactivity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -36,6 +37,14 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [demoOpen, setDemoOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // Surface why the previous session ended (read-and-clear, one-shot).
+  useEffect(() => {
+    if (consumeSignedOutReason() === "inactivity") {
+      setNotice("You were signed out due to inactivity.");
+    }
+  }, []);
 
   if (isAuthenticated) {
     return <Navigate to={from} replace />;
@@ -85,6 +94,16 @@ export function LoginPage() {
             Sign in to your account
           </p>
         </div>
+
+        {notice && (
+          <div
+            role="status"
+            className="mb-5 flex items-start gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2.5 text-[12.5px] leading-snug text-[var(--color-muted-foreground)] fsh-enter"
+          >
+            <TimerOff className="mt-0.5 size-3.5 shrink-0 text-[var(--color-muted-foreground)]" />
+            <span>{notice}</span>
+          </div>
+        )}
 
         <form
           onSubmit={onSubmit}

--- a/clients/dashboard/src/pages/tenant-deactivated.tsx
+++ b/clients/dashboard/src/pages/tenant-deactivated.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from "react-router-dom";
+import { Building2, LogIn } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/auth/use-auth";
+
+/**
+ * TenantDeactivatedPage — calm centered terminal-state card shown when the
+ * signed-in user's tenant is switched off mid-session.
+ *
+ * The deactivated-tenant guard (MultitenancyModule) starts rejecting every
+ * request with a 403 once a tenant is deactivated. A global query/mutation
+ * error hook (query-client.ts) detects that 403 and routes here, replacing the
+ * dead error banner that would otherwise sit under a half-loaded dashboard.
+ *
+ * Mounted as a top-level route (outside ProtectedRoute / AppShell): the access
+ * token is still technically valid, but nothing the user can do inside the app
+ * will work, so there is no shell to render. The single action clears the
+ * session and returns to sign-in. Mirrors the not-found.tsx empty-state
+ * vocabulary: one muted icon tile, an Outfit headline, a soft body line, and a
+ * single primary affordance.
+ */
+export function TenantDeactivatedPage() {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const backToSignIn = () => {
+    // Drop the now-useless session so /login starts clean and a stale token
+    // can't bounce the user straight back into a 403 loop.
+    logout();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[var(--color-background)] px-5 py-8 sm:py-12">
+      {/* Atmospheric background — same rose/saffron orbs as the auth pages */}
+      <div className="pointer-events-none absolute inset-0" aria-hidden>
+        <div
+          className="absolute -top-[25%] -left-[15%] h-[70vw] w-[70vw] rounded-full blur-[140px]"
+          style={{ backgroundColor: "oklch(from var(--color-primary) l c h / 0.05)" }}
+        />
+        <div
+          className="absolute -bottom-[20%] -right-[10%] h-[55vw] w-[55vw] rounded-full blur-[120px]"
+          style={{ backgroundColor: "oklch(from var(--color-saffron) l c h / 0.07)" }}
+        />
+      </div>
+
+      <div className="relative z-10 flex w-full max-w-[460px] flex-col items-center text-center fsh-enter fsh-enter-1">
+        {/* Icon tile — same muted bg + size-14 rounded-2xl as the not-found page */}
+        <div className="mb-5 grid size-14 place-items-center rounded-2xl bg-[var(--color-muted)]">
+          <Building2 className="size-6 text-[oklch(from_var(--color-muted-foreground)_l_c_h_/_0.5)]" />
+        </div>
+
+        <h1 className="mb-2 font-display text-display-stat font-semibold tracking-tight text-[var(--color-foreground)]">
+          Tenant deactivated
+        </h1>
+        <p className="mb-7 max-w-[380px] text-[14px] leading-relaxed text-[var(--color-muted-foreground)]">
+          This tenant has been deactivated and is no longer available. If you
+          think this is a mistake, please contact your administrator.
+        </p>
+
+        {/* Primary action */}
+        <Button
+          type="button"
+          onClick={backToSignIn}
+          className="group h-11 px-5 text-[14px] font-semibold"
+        >
+          <LogIn className="size-4" />
+          <span>Back to sign in</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/dashboard/src/routes.tsx
+++ b/clients/dashboard/src/routes.tsx
@@ -60,6 +60,10 @@ const ProductDetailPage = lazyNamed(
   "ProductDetailPage",
 );
 const NotFoundPage = lazyNamed(() => import("@/pages/not-found"), "NotFoundPage");
+const TenantDeactivatedPage = lazyNamed(
+  () => import("@/pages/tenant-deactivated"),
+  "TenantDeactivatedPage",
+);
 const SettingsLayout = lazyNamed(
   () => import("@/pages/settings/settings-layout"),
   "SettingsLayout",
@@ -156,6 +160,15 @@ export const router = createBrowserRouter([
   {
     path: "/confirm-email",
     element: withSuspense(<ConfirmEmailPage />),
+    errorElement: <RouteError />,
+  },
+  {
+    // Terminal state when the signed-in user's tenant is deactivated mid-session.
+    // Top-level (outside ProtectedRoute/AppShell) — the token is still valid but
+    // every request 403s, so there is no shell to render. query-client.ts routes
+    // here on detecting the deactivated-tenant 403.
+    path: "/tenant-deactivated",
+    element: withSuspense(<TenantDeactivatedPage />),
     errorElement: <RouteError />,
   },
   {

--- a/clients/dashboard/tests/auth/inactivity.spec.ts
+++ b/clients/dashboard/tests/auth/inactivity.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { seedAuthedSession, TEST_USER } from "../helpers/auth-seed";
+import { installShellMocks } from "../helpers/shell-mocks";
+
+// Drive the inactivity feature with tiny durations injected via /config.json:
+// idle 2s → a 3s warning countdown → auto sign-out. The guard mounts in the
+// authenticated AppShell, so any protected page exercises it.
+const IDLE_MS = 2_000;
+const WARNING_MS = 3_000;
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/config.json", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiBase: "",
+        defaultTenant: "root",
+        demoMode: false,
+        inactivityIdleMs: IDLE_MS,
+        inactivityWarningMs: WARNING_MS,
+      }),
+    }),
+  );
+  await seedAuthedSession(page, TEST_USER);
+  // Defensive catch-all so a stray protected call can't 401→logout and race the
+  // idle timer; the specific shell mocks register after this and win.
+  await page.route("**/api/v1/**", (route) =>
+    route.fulfill({ status: 200, headers: { "Content-Type": "application/json" }, body: "[]" }),
+  );
+  await installShellMocks(page);
+});
+
+test.describe("inactivity auto-logout", () => {
+  test("shows the warning modal after the idle threshold", async ({ page }) => {
+    await page.goto("/settings/security");
+    await expect(page.getByRole("dialog").getByText("Still there?")).toBeVisible({
+      timeout: 9_000,
+    });
+    await expect(page.getByRole("button", { name: "I'm here" })).toBeVisible();
+  });
+
+  test("'I'm here' dismisses the warning and keeps the session", async ({ page }) => {
+    await page.goto("/settings/security");
+    const stay = page.getByRole("button", { name: "I'm here" });
+    await expect(stay).toBeVisible({ timeout: 9_000 });
+
+    await stay.click();
+
+    await expect(page.getByText("Still there?")).toBeHidden();
+    await expect(page).not.toHaveURL(/\/login$/);
+  });
+
+  test("signs out to /login with a notice when the countdown elapses", async ({ page }) => {
+    await page.goto("/settings/security");
+    await expect(page.getByRole("button", { name: "I'm here" })).toBeVisible({ timeout: 9_000 });
+
+    await expect(page).toHaveURL(/\/login$/, { timeout: WARNING_MS + 6_000 });
+    await expect(page.getByText(/signed out due to inactivity/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

A session of client-side work across both React apps: **inactivity auto-logout**, an **admin UX polish** pass, and the original **dashboard tenant-lifecycle fixes**.

---

### 1. Inactivity auto-logout (admin + dashboard) — new

Idle sessions now warn and sign out automatically.

- Idle → a forced-choice **warning modal with an animated SVG countdown ring** (drains primary → amber → red, pulses in the final 10s, respects `prefers-reduced-motion`) → auto sign-out to `/login` with a "signed out due to inactivity" notice.
- **Per-app durations via runtime `config.json`** (overridable per deployment without a rebuild): admin **10 min** idle, dashboard **20 min** idle, **60s** warning both.
- **Cross-tab:** activity in any tab keeps every tab alive; a sign-out in one tab drops them all. While the warning shows in a tab it freezes that tab's passive activity so the prompt stays meaningful.
- New per app: `auth/inactivity.ts` (pure state machine + cross-tab activity store), `auth/use-inactivity-timeout.ts`, `components/auth/inactivity-dialog.tsx`, `components/auth/inactivity-guard.tsx` (mounted in each `AppShell`), `env.ts` config knobs, login-page notice. Added the missing cross-tab `storage` logout listener to the **admin** auth-context (dashboard already had one).

### 2. Admin UX polish

- **Create-tenant dialog** redesigned into a two-pane layout with a live preview rail (monogram, slug, plan, status), identifier + JWT issuer auto-derived from the display name (unlock to edit), a strong-password generator + show/hide, and an inline slug-format check. Submit shows a real spinner (fixes the "stuck for a second" perception).
- **Change-password dialog**: added a first-class show/hide eye toggle and fixed the field padding to match the dashboard (wrapped in `DialogBody`, `pr-10` + eye at `right-1.5`).
- **Topbar avatar** renders the uploaded profile image with an initials fallback, reading the shared `["identity","profile"]` query so it updates the instant a new image is uploaded.
- Hid the native browser password-reveal pseudo-elements (`::-ms-reveal`/`::-ms-clear`) now that we ship our own toggle.

### 3. Dashboard — tenant-deactivated page + safe impersonation exit

**3a. Dedicated "tenant deactivated" page**
When a signed-in user's tenant is deactivated mid-session, the backend's deactivated-tenant guard (`MultitenancyModule`) starts rejecting **every** request with `403 — "This tenant has been deactivated…"`. Previously the raw 403 banner sat under a half-loaded surface.

- New `isTenantDeactivatedError()` in `api-client.ts` (matches the guard's detail text — no machine-readable code exists on the ProblemDetails).
- Global `QueryCache`/`MutationCache` `onError` in `query-client.ts` redirects to a new standalone `/tenant-deactivated` route (outside `ProtectedRoute`/`AppShell`).
- New `pages/tenant-deactivated.tsx` mirrors the `not-found.tsx` empty-state vocabulary; single **"Back to sign in"** button clears the session and routes to `/login`.

**3b. Safe End-impersonation exit**
Ending a cross-app impersonation installed a **root SuperAdmin token into the tenant dashboard** — exactly what `login()` forbids, but the impersonation-end path bypassed that guard.

- `stopImpersonation()` now decodes the server-minted fresh actor token and **signs out → `/login`** when the operator is `root` (or there's no dashboard session to return to), while still restoring genuine intra-app (tenant-user) impersonations.
- Returns `{ signedOut }`; the banner routes to `/login` vs `/` accordingly.

### 4. Brand text
Lowercased the "fullstackhero" brand text across admin + dashboard.

---

## Test plan

- **Admin Playwright: 109/109 pass** — incl. 3 new inactivity specs and updated tenant-create/-billing specs for the redesigned dialog.
- **Dashboard Playwright: 138 pass** + 1 pre-existing flake (`tickets/user-picker.spec.ts` — reproduced identically on a clean tree with this branch stashed, so it is not from this work).
- `tsc -b` + ESLint clean in both apps (only the pre-existing fast-refresh warning on the auth-context export).
- Manual (dashboard): deactivate a tenant mid-session → redirect to `/tenant-deactivated` → "Back to sign in" → `/login`. Root operator impersonation → End impersonation → lands on `/login`.

## Notes
Per AGENTS.md rule #10, changelog + docs (`fullstackhero/docs`) entries for the user-facing changes (inactivity auto-logout + the two dashboard fixes) are still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
