### PR TITLE
fix(clients): inactivity guard signs new logins straight back out

### DIFF
--- a/clients/admin/src/auth/use-inactivity-timeout.ts
+++ b/clients/admin/src/auth/use-inactivity-timeout.ts
@@ -92,8 +92,15 @@ export function useInactivityTimeout({ enabled, idleMs, warningMs, onExpire }: O
       return;
     }
 
-    // Seed the shared stamp on first enable so a fresh login isn't instantly idle.
-    if (activityStore.get() <= 0) activityStore.set(Date.now());
+    // Seed the shared stamp on enable so a fresh login isn't instantly idle.
+    // The stamp lives in localStorage and survives logout, so a value left over
+    // from a previous (possibly expired) session would otherwise make the next
+    // login evaluate as "warning"/"expired" on the first tick and sign the user
+    // straight back out. Refresh it when it's missing OR already past the idle
+    // threshold; a still-fresh stamp from an active sibling tab is preserved.
+    const seeded = activityStore.get();
+    const stale = seeded <= 0 || Date.now() - seeded >= idleRef.current;
+    if (stale) activityStore.set(Date.now());
     expiredRef.current = false;
 
     for (const evt of ACTIVITY_EVENTS) {

--- a/clients/dashboard/src/auth/use-inactivity-timeout.ts
+++ b/clients/dashboard/src/auth/use-inactivity-timeout.ts
@@ -92,8 +92,15 @@ export function useInactivityTimeout({ enabled, idleMs, warningMs, onExpire }: O
       return;
     }
 
-    // Seed the shared stamp on first enable so a fresh login isn't instantly idle.
-    if (activityStore.get() <= 0) activityStore.set(Date.now());
+    // Seed the shared stamp on enable so a fresh login isn't instantly idle.
+    // The stamp lives in localStorage and survives logout, so a value left over
+    // from a previous (possibly expired) session would otherwise make the next
+    // login evaluate as "warning"/"expired" on the first tick and sign the user
+    // straight back out. Refresh it when it's missing OR already past the idle
+    // threshold; a still-fresh stamp from an active sibling tab is preserved.
+    const seeded = activityStore.get();
+    const stale = seeded <= 0 || Date.now() - seeded >= idleRef.current;
+    if (stale) activityStore.set(Date.now());
     expiredRef.current = false;
 
     for (const evt of ACTIVITY_EVENTS) {


### PR DESCRIPTION
## Problem

After the inactivity auto-logout feature (#1281), logging in immediately bounced back to the login screen with **"You were signed out due to inactivity."** — on both the admin and dashboard apps.

## Root cause

The "last activity" timestamp lives in `localStorage` (`fsh.lastActivity`) and **survives logout**. The guard only seeded a fresh stamp when it was *missing* (`activityStore.get() <= 0`). A **stale** value left over from a previous (expired) session is `> 0`, so it wasn't refreshed — and on the next login `evaluateInactivity()` saw `idle ≥ idleMs (+ warningMs)` on the very first tick → `warning`/`expired` → instant sign-out. A self-perpetuating loop.

## Fix

Reseed the stamp on enable when it's **missing OR already past the idle threshold**, so a fresh login always starts `active`. A still-fresh stamp from an active sibling tab is preserved, keeping the cross-tab keep-alive behaviour intact. Applied identically to `clients/admin` and `clients/dashboard`.

## Test plan
- `tsc --noEmit` clean (both apps); ESLint clean on the changed hook.
- Manual: get signed out by inactivity → sign back in → stays signed in (no instant bounce). Repeat after leaving the tab idle past the timeout, then logging in fresh.

## Note
This fix briefly landed directly on `main` by mistake; `main` was force-rolled back to the #1281 merge and the change re-routed through this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
