### PR TITLE
ci+deploy: publish DbMigrator image, fix GHCR push, run migrator on AWS

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -314,7 +314,8 @@ jobs:
           dotnet publish src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj \
             -c Release -r linux-x64 \
             /t:PublishContainer \
-            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-api \
+            -p:ContainerRegistry=ghcr.io \
+            -p:ContainerRepository=${{ github.repository_owner }}/fsh-api \
             -p:ContainerImageTags='"dev-${{ github.sha }};dev-latest"'
 
       - name: Publish DbMigrator container image
@@ -322,7 +323,8 @@ jobs:
           dotnet publish src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj \
             -c Release -r linux-x64 \
             /t:PublishContainer \
-            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-db-migrator \
+            -p:ContainerRegistry=ghcr.io \
+            -p:ContainerRepository=${{ github.repository_owner }}/fsh-db-migrator \
             -p:ContainerImageTags='"dev-${{ github.sha }};dev-latest"'
 
   publish-release:
@@ -396,7 +398,8 @@ jobs:
           dotnet publish src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj \
             -c Release -r linux-x64 \
             /t:PublishContainer \
-            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-api \
+            -p:ContainerRegistry=ghcr.io \
+            -p:ContainerRepository=${{ github.repository_owner }}/fsh-api \
             -p:ContainerImageTags='"${{ steps.version.outputs.version }};latest"'
 
       - name: Build and push DbMigrator container
@@ -404,7 +407,8 @@ jobs:
           dotnet publish src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj \
             -c Release -r linux-x64 \
             /t:PublishContainer \
-            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-db-migrator \
+            -p:ContainerRegistry=ghcr.io \
+            -p:ContainerRepository=${{ github.repository_owner }}/fsh-db-migrator \
             -p:ContainerImageTags='"${{ steps.version.outputs.version }};latest"'
 
   # Single required status check. Always runs (even when the heavy jobs are

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -317,6 +317,14 @@ jobs:
             -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-api \
             -p:ContainerImageTags='"dev-${{ github.sha }};dev-latest"'
 
+      - name: Publish DbMigrator container image
+        run: |
+          dotnet publish src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj \
+            -c Release -r linux-x64 \
+            /t:PublishContainer \
+            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-db-migrator \
+            -p:ContainerImageTags='"dev-${{ github.sha }};dev-latest"'
+
   publish-release:
     name: Publish Release (NuGet + Containers)
     needs: [changes, test, integration-test]
@@ -389,6 +397,14 @@ jobs:
             -c Release -r linux-x64 \
             /t:PublishContainer \
             -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-api \
+            -p:ContainerImageTags='"${{ steps.version.outputs.version }};latest"'
+
+      - name: Build and push DbMigrator container
+        run: |
+          dotnet publish src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj \
+            -c Release -r linux-x64 \
+            /t:PublishContainer \
+            -p:ContainerRepository=ghcr.io/${{ github.repository_owner }}/fsh-db-migrator \
             -p:ContainerImageTags='"${{ steps.version.outputs.version }};latest"'
 
   # Single required status check. Always runs (even when the heavy jobs are

--- a/deploy/terraform/apps/starter/README.md
+++ b/deploy/terraform/apps/starter/README.md
@@ -6,6 +6,7 @@ shared modules in `../../modules`.
 What it provisions:
 
 - **API** — ECS Fargate service behind an ALB (+ WAF, RDS PostgreSQL, ElastiCache Redis, app S3 bucket).
+- **DbMigrator** — a one-shot ECS Fargate task definition (`modules/ecs_task`, no service). The deploy scripts run it with `aws ecs run-task` after `apply` and wait for exit 0. Command is per-environment: dev runs `apply --seed`, prod runs `apply` (migrate only).
 - **Dashboard SPA** (`clients/dashboard`) — private S3 + CloudFront (OAC), tenant-facing.
 - **Admin SPA** (`clients/admin`) — private S3 + CloudFront (OAC), operator-facing.
 
@@ -30,21 +31,29 @@ Provisions infra **and** publishes the API image + both SPAs in a single step
 
 ```bash
 # bash
-./deploy.sh dev                      # use the API image tag from tfvars
-./deploy.sh prod --build-api --auto-approve   # also build+push the API image at the current git SHA
+./deploy.sh dev                      # use the image tag from tfvars; dev auto-seeds (apply --seed)
+./deploy.sh dev --seed-demo           # also seed acme/globex demo tenants
+./deploy.sh prod --build-api --auto-approve   # also build+push the API + migrator images at the current git SHA
 ```
 
 ```powershell
 # PowerShell
 ./deploy.ps1 -Environment dev
+./deploy.ps1 -Environment dev -SeedDemo
 ./deploy.ps1 -Environment prod -BuildApi -AutoApprove
 ```
 
-The script: `terraform init` + `apply` → (optional) build & push the API
-container → `npm run build` each SPA → `aws s3 sync` to its bucket → CloudFront
-invalidation. Requires Terraform >= 1.15.4, the AWS CLI (configured), `jq`, and
-Node; `--build-api` additionally needs the .NET SDK + a registry login. State
-backend is bootstrapped once via `../../bootstrap`.
+The script: `terraform init` + `apply` → (optional) build & push the API +
+migrator containers → **run the DbMigrator task and wait for exit 0** →
+`npm run build` each SPA → `aws s3 sync` to its bucket → CloudFront invalidation.
+Requires Terraform >= 1.15.4, the AWS CLI (configured), `jq`, and Node;
+`--build-api` additionally needs the .NET SDK + a registry login. State backend
+is bootstrapped once via `../../bootstrap`.
+
+**Migration flags:** `--skip-migrate` / `-SkipMigrate` skips the migrator run;
+`--seed-demo` / `-SeedDemo` runs the migrator's `seed-demo` verb after migrating.
+The migrator image must be published **and public** in GHCR at the deployed tag
+(see the repo's `backend.yml` publish jobs) before the task can pull it.
 
 ## Manual Terraform (if you prefer)
 

--- a/deploy/terraform/apps/starter/app_stack/main.tf
+++ b/deploy/terraform/apps/starter/app_stack/main.tf
@@ -14,6 +14,10 @@ locals {
   # Container image constructed from registry, name, and tag.
   api_container_image = "${var.container_registry}/${var.api_image_name}:${var.container_image_tag}"
 
+  # DbMigrator image — same registry + tag as the API, different repository.
+  # Run as a one-shot ECS task (apply / apply --seed) by the deploy scripts.
+  migrator_container_image = "${var.container_registry}/${var.migrator_image_name}:${var.container_image_tag}"
+
   # Public origin of the API (no /api suffix) — used for the app OriginUrl and
   # as the apiBase the React SPAs read from their runtime config.json.
   api_origin = var.enable_https && var.domain_name != null ? "https://${var.domain_name}" : "http://${module.alb.dns_name}"
@@ -467,6 +471,54 @@ module "api_service" {
   )
 
   # When using managed password, inject the full connection string from Secrets Manager
+  secrets = var.db_manage_master_user_password ? [
+    {
+      name      = "DatabaseOptions__ConnectionString"
+      valueFrom = aws_secretsmanager_secret.db_connection_string[0].arn
+    }
+  ] : []
+
+  tags = local.common_tags
+}
+
+################################################################################
+# DbMigrator — one-shot ECS task
+#
+# Registers a runnable task definition only (no service). The deploy scripts
+# invoke it with `aws ecs run-task` after `apply` and wait for exit code 0.
+# Command is environment-driven: dev runs `apply --seed`, prod runs `apply`
+# (set per-env in terraform.tfvars via `migrator_command`). The seed path reads
+# Seed:* / JwtOptions:SigningKey from appsettings.Development.json (baked into
+# the image, active because dev sets ASPNETCORE_ENVIRONMENT=Development);
+# override for non-dev seeding via `migrator_extra_environment_variables`.
+################################################################################
+
+module "migrator" {
+  count  = var.enable_migrator ? 1 : 0
+  source = "../../../modules/ecs_task"
+
+  name            = "${var.environment}-db-migrator"
+  region          = var.region
+  vpc_id          = module.network.vpc_id
+  container_image = local.migrator_container_image
+  command         = var.migrator_command
+  cpu             = var.migrator_cpu
+  memory          = var.migrator_memory
+
+  environment_variables = merge(
+    {
+      ASPNETCORE_ENVIRONMENT              = local.aspnetcore_environment
+      DatabaseOptions__Provider           = "POSTGRESQL"
+      DatabaseOptions__MigrationsAssembly = "FSH.Starter.Migrations.PostgreSQL"
+    },
+    # Plain connection string only when NOT using a managed (Secrets Manager)
+    # password; otherwise it arrives via `secrets` below — same as the API.
+    var.db_manage_master_user_password ? {} : {
+      DatabaseOptions__ConnectionString = local.db_connection_string_plain
+    },
+    var.migrator_extra_environment_variables
+  )
+
   secrets = var.db_manage_master_user_password ? [
     {
       name      = "DatabaseOptions__ConnectionString"

--- a/deploy/terraform/apps/starter/app_stack/outputs.tf
+++ b/deploy/terraform/apps/starter/app_stack/outputs.tf
@@ -69,6 +69,18 @@ output "api_service_name" {
   value       = module.api_service.service_name
 }
 
+output "migrator" {
+  description = "DbMigrator one-shot task details for `aws ecs run-task` (deploy scripts), or null when not provisioned."
+  value = var.enable_migrator ? {
+    cluster_arn            = module.ecs_cluster.arn
+    task_definition_family = module.migrator[0].task_definition_family
+    container_name         = module.migrator[0].container_name
+    security_group_id      = module.migrator[0].security_group_id
+    subnet_ids             = module.network.private_subnet_ids
+    log_group_name         = module.migrator[0].log_group_name
+  } : null
+}
+
 ################################################################################
 # Database Outputs
 ################################################################################

--- a/deploy/terraform/apps/starter/app_stack/variables.tf
+++ b/deploy/terraform/apps/starter/app_stack/variables.tf
@@ -482,6 +482,46 @@ variable "api_image_name" {
   default     = "fsh-api"
 }
 
+variable "migrator_image_name" {
+  type        = string
+  description = "DbMigrator container image name (without registry or tag)."
+  default     = "fsh-db-migrator"
+}
+
+################################################################################
+# DbMigrator (one-shot ECS task) Variables
+################################################################################
+
+variable "enable_migrator" {
+  type        = bool
+  description = "Register the DbMigrator one-shot ECS task definition."
+  default     = true
+}
+
+variable "migrator_command" {
+  type        = list(string)
+  description = "Migrator container command. Dev typically [\"apply\", \"--seed\"]; prod [\"apply\"] (migrate only)."
+  default     = ["apply"]
+}
+
+variable "migrator_cpu" {
+  type        = number
+  description = "DbMigrator task CPU units."
+  default     = 512
+}
+
+variable "migrator_memory" {
+  type        = number
+  description = "DbMigrator task memory (MiB)."
+  default     = 1024
+}
+
+variable "migrator_extra_environment_variables" {
+  type        = map(string)
+  description = "Extra env vars for the migrator (e.g. Seed__DefaultAdminPassword / JwtOptions__SigningKey when seeding outside the dev Development profile)."
+  default     = {}
+}
+
 ################################################################################
 # API Service Variables
 ################################################################################

--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -9,8 +9,9 @@
 .DESCRIPTION
   Runs, in order:
     1. terraform init + apply (VPC, ALB+WAF, ECS API, RDS, Redis, S3, the two SPA CloudFront sites)
-    2. (optional) build & push the API container image
-    3. build the React apps, publish to their S3 buckets, invalidate CloudFront
+    2. (optional) build & push the API + DbMigrator container images
+    3. run the DbMigrator one-shot ECS task (apply / apply --seed) and wait for exit 0
+    4. build the React apps, publish to their S3 buckets, invalidate CloudFront
 
   Requires: terraform >= 1.15.4, aws cli (configured), jq, node/npm, and
   (with -BuildApi) the .NET SDK + a registry login.
@@ -22,6 +23,8 @@ param(
   [switch]$BuildApi,
   [string]$ImageTag,
   [string]$Registry = 'ghcr.io/fullstackhero',
+  [switch]$SkipMigrate,
+  [switch]$SeedDemo,
   [switch]$SkipFrontend,
   [switch]$AutoApprove
 )
@@ -29,6 +32,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $MinTfVersion = [version]'1.15.4'
 $ApiImageName = 'fsh-api'
+$MigratorImageName = 'fsh-db-migrator'
 
 $ScriptDir = $PSScriptRoot
 $RepoRoot = (Resolve-Path "$ScriptDir/../../../..").Path
@@ -62,7 +66,13 @@ if ($BuildApi) {
     /t:PublishContainer `
     -p:ContainerRepository="$Registry/$ApiImageName" `
     -p:ContainerImageTags="$ImageTag"
-  $tfImageArgs = @('-var', "container_registry=$Registry", '-var', "api_image_name=$ApiImageName", '-var', "container_image_tag=$ImageTag")
+  Write-Host "==> Building & pushing migrator image $Registry/$MigratorImageName`:$ImageTag"
+  dotnet publish "$RepoRoot/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj" `
+    -c Release -r linux-x64 `
+    /t:PublishContainer `
+    -p:ContainerRepository="$Registry/$MigratorImageName" `
+    -p:ContainerImageTags="$ImageTag"
+  $tfImageArgs = @('-var', "container_registry=$Registry", '-var', "api_image_name=$ApiImageName", '-var', "migrator_image_name=$MigratorImageName", '-var', "container_image_tag=$ImageTag")
 }
 elseif ($ImageTag) {
   $tfImageArgs = @('-var', "container_image_tag=$ImageTag")
@@ -77,6 +87,58 @@ if ($AutoApprove) { $applyArgs += '-auto-approve' }
 
 Write-Host '==> terraform apply'
 terraform -chdir="$AppStackDir" apply @applyArgs
+
+# ---- 2.5 db migrator (one-shot ECS task) ------------------------------------
+function Invoke-EcsTask($label, $overridesJson) {
+  Write-Host "==> Running DbMigrator task ($label)"
+  $runArgs = @(
+    'ecs', 'run-task',
+    '--cluster', $migCluster,
+    '--task-definition', $migTaskDef,
+    '--launch-type', 'FARGATE',
+    '--network-configuration', "awsvpcConfiguration={subnets=[$migSubnets],securityGroups=[$migSg],assignPublicIp=DISABLED}",
+    '--query', 'tasks[0].taskArn', '--output', 'text'
+  )
+  if ($overridesJson) {
+    $tmp = New-TemporaryFile
+    Set-Content -Path $tmp.FullName -Value $overridesJson -Encoding utf8
+    $runArgs += @('--overrides', "file://$($tmp.FullName)")
+  }
+  $taskArn = (aws @runArgs).Trim()
+  if (-not $taskArn -or $taskArn -eq 'None') { Die "run-task failed to start ($label)" }
+  Write-Host "    task: $taskArn — waiting for it to stop..."
+  aws ecs wait tasks-stopped --cluster $migCluster --tasks $taskArn
+  $exitCode = (aws ecs describe-tasks --cluster $migCluster --tasks $taskArn --query 'tasks[0].containers[0].exitCode' --output text).Trim()
+  if ($exitCode -ne '0') {
+    $reason = (aws ecs describe-tasks --cluster $migCluster --tasks $taskArn --query 'tasks[0].stoppedReason' --output text).Trim()
+    Die "migrator ($label) exited $exitCode — $reason (logs: CloudWatch $migLogGroup)"
+  }
+  Write-Host "    migrator ($label) succeeded."
+}
+
+if ($SkipMigrate) {
+  Write-Host '==> Skipping DB migration (-SkipMigrate)'
+}
+else {
+  $migJson = terraform -chdir="$AppStackDir" output -json migrator 2>$null
+  if (-not $migJson -or $migJson -eq 'null') {
+    Write-Host '==> Migrator not provisioned (enable_migrator=false) — skipping'
+  }
+  else {
+    $mig = $migJson | ConvertFrom-Json
+    $migCluster = $mig.cluster_arn
+    $migTaskDef = $mig.task_definition_family
+    $migCName = $mig.container_name
+    $migSg = $mig.security_group_id
+    $migSubnets = ($mig.subnet_ids -join ',')
+    $migLogGroup = $mig.log_group_name
+    Invoke-EcsTask 'migrate' $null
+    if ($SeedDemo) {
+      $ov = "{`"containerOverrides`":[{`"name`":`"$migCName`",`"command`":[`"seed-demo`"]}]}"
+      Invoke-EcsTask 'seed-demo' $ov
+    }
+  }
+}
 
 # ---- 3. frontends -----------------------------------------------------------
 function Publish-Spa($outputName, $clientDir) {

--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -59,18 +59,27 @@ Write-Host "==> Deploying '$Environment' in $Region"
 $tfImageArgs = @()
 if ($BuildApi) {
   if (-not $ImageTag) { $ImageTag = (git -C $RepoRoot rev-parse --short=12 HEAD).Trim() }
-  Write-Host "==> Building & pushing API image $Registry/$ApiImageName`:$ImageTag"
   if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) { Die 'dotnet SDK required for -BuildApi' }
+  # The SDK pushes to a REMOTE registry only when ContainerRegistry is set; the
+  # registry host must be split out of the repository name (folding it into
+  # ContainerRepository silently loads to the local Docker daemon instead).
+  $registryHost = $Registry.Split('/')[0]                                   # e.g. ghcr.io
+  $registryPath = $Registry.Substring($registryHost.Length).TrimStart('/')  # e.g. fullstackhero
+  $apiRepo = if ($registryPath) { "$registryPath/$ApiImageName" } else { $ApiImageName }
+  $migratorRepo = if ($registryPath) { "$registryPath/$MigratorImageName" } else { $MigratorImageName }
+  Write-Host "==> Building & pushing API image $registryHost/$apiRepo`:$ImageTag"
   dotnet publish "$RepoRoot/src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj" `
     -c Release -r linux-x64 `
     /t:PublishContainer `
-    -p:ContainerRepository="$Registry/$ApiImageName" `
+    -p:ContainerRegistry="$registryHost" `
+    -p:ContainerRepository="$apiRepo" `
     -p:ContainerImageTags="$ImageTag"
-  Write-Host "==> Building & pushing migrator image $Registry/$MigratorImageName`:$ImageTag"
+  Write-Host "==> Building & pushing migrator image $registryHost/$migratorRepo`:$ImageTag"
   dotnet publish "$RepoRoot/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj" `
     -c Release -r linux-x64 `
     /t:PublishContainer `
-    -p:ContainerRepository="$Registry/$MigratorImageName" `
+    -p:ContainerRegistry="$registryHost" `
+    -p:ContainerRepository="$migratorRepo" `
     -p:ContainerImageTags="$ImageTag"
   $tfImageArgs = @('-var', "container_registry=$Registry", '-var', "api_image_name=$ApiImageName", '-var', "migrator_image_name=$MigratorImageName", '-var', "container_image_tag=$ImageTag")
 }

--- a/deploy/terraform/apps/starter/deploy.sh
+++ b/deploy/terraform/apps/starter/deploy.sh
@@ -81,18 +81,27 @@ echo "==> Deploying '$ENVIRONMENT' in $REGION"
 TF_IMAGE_ARGS=()
 if [[ "$BUILD_API" == true ]]; then
   [[ -n "$IMAGE_TAG" ]] || IMAGE_TAG="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD)"
-  echo "==> Building & pushing API image $REGISTRY/$API_IMAGE_NAME:$IMAGE_TAG"
   command -v dotnet >/dev/null || die "dotnet SDK required for --build-api"
+  # The SDK pushes to a REMOTE registry only when ContainerRegistry is set; the
+  # registry host must be split out of the repository name (folding it into
+  # ContainerRepository silently loads to the local Docker daemon instead).
+  REGISTRY_HOST="${REGISTRY%%/*}"                       # e.g. ghcr.io
+  REGISTRY_PATH="${REGISTRY#"$REGISTRY_HOST"}"; REGISTRY_PATH="${REGISTRY_PATH#/}"  # e.g. fullstackhero
+  API_REPO="${REGISTRY_PATH:+$REGISTRY_PATH/}$API_IMAGE_NAME"
+  MIGRATOR_REPO="${REGISTRY_PATH:+$REGISTRY_PATH/}$MIGRATOR_IMAGE_NAME"
+  echo "==> Building & pushing API image $REGISTRY_HOST/$API_REPO:$IMAGE_TAG"
   dotnet publish "$REPO_ROOT/src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj" \
     -c Release -r linux-x64 \
     /t:PublishContainer \
-    -p:ContainerRepository="$REGISTRY/$API_IMAGE_NAME" \
+    -p:ContainerRegistry="$REGISTRY_HOST" \
+    -p:ContainerRepository="$API_REPO" \
     -p:ContainerImageTags="$IMAGE_TAG"
-  echo "==> Building & pushing migrator image $REGISTRY/$MIGRATOR_IMAGE_NAME:$IMAGE_TAG"
+  echo "==> Building & pushing migrator image $REGISTRY_HOST/$MIGRATOR_REPO:$IMAGE_TAG"
   dotnet publish "$REPO_ROOT/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj" \
     -c Release -r linux-x64 \
     /t:PublishContainer \
-    -p:ContainerRepository="$REGISTRY/$MIGRATOR_IMAGE_NAME" \
+    -p:ContainerRegistry="$REGISTRY_HOST" \
+    -p:ContainerRepository="$MIGRATOR_REPO" \
     -p:ContainerImageTags="$IMAGE_TAG"
   TF_IMAGE_ARGS=(-var "container_registry=$REGISTRY" -var "api_image_name=$API_IMAGE_NAME" -var "migrator_image_name=$MIGRATOR_IMAGE_NAME" -var "container_image_tag=$IMAGE_TAG")
 elif [[ -n "$IMAGE_TAG" ]]; then

--- a/deploy/terraform/apps/starter/deploy.sh
+++ b/deploy/terraform/apps/starter/deploy.sh
@@ -6,13 +6,16 @@
 #
 # It will, in order:
 #   1. terraform init + apply (infra: VPC, ALB+WAF, ECS API, RDS, Redis, S3, the two SPA CloudFront sites)
-#   2. (optional) build & push the API container image
-#   3. build the React apps and publish them to their S3 buckets + invalidate CloudFront
+#   2. (optional) build & push the API + DbMigrator container images
+#   3. run the DbMigrator one-shot ECS task (apply / apply --seed) and wait for exit 0
+#   4. build the React apps and publish them to their S3 buckets + invalidate CloudFront
 #
 # Flags:
-#   --build-api          Build & push the API image at the current git SHA and deploy that tag.
-#   --image-tag TAG      Deploy a specific, already-published API image tag.
+#   --build-api          Build & push the API + migrator images at the current git SHA and deploy that tag.
+#   --image-tag TAG      Deploy a specific, already-published image tag.
 #   --registry REG       Container registry (default: ghcr.io/fullstackhero). Used only with --build-api.
+#   --skip-migrate       Skip running the DbMigrator task after apply.
+#   --seed-demo          After migrating, also run the migrator's `seed-demo` verb (acme/globex demo tenants).
 #   --skip-frontend      Skip building/publishing the SPAs.
 #   --auto-approve       Don't prompt before applying.
 #
@@ -23,6 +26,7 @@ set -euo pipefail
 MIN_TF_VERSION="1.15.4"
 DEFAULT_REGISTRY="ghcr.io/fullstackhero"
 API_IMAGE_NAME="fsh-api"
+MIGRATOR_IMAGE_NAME="fsh-db-migrator"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
@@ -33,6 +37,8 @@ ENVIRONMENT="${1:-}"
 REGION="us-east-1"
 BUILD_API=false
 SKIP_FRONTEND=false
+SKIP_MIGRATE=false
+SEED_DEMO=false
 AUTO_APPROVE=false
 IMAGE_TAG=""
 REGISTRY="$DEFAULT_REGISTRY"
@@ -42,6 +48,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --build-api) BUILD_API=true ;;
     --skip-frontend) SKIP_FRONTEND=true ;;
+    --skip-migrate) SKIP_MIGRATE=true ;;
+    --seed-demo) SEED_DEMO=true ;;
     --auto-approve) AUTO_APPROVE=true ;;
     --image-tag) IMAGE_TAG="${2:-}"; shift ;;
     --registry) REGISTRY="${2:-}"; shift ;;
@@ -80,7 +88,13 @@ if [[ "$BUILD_API" == true ]]; then
     /t:PublishContainer \
     -p:ContainerRepository="$REGISTRY/$API_IMAGE_NAME" \
     -p:ContainerImageTags="$IMAGE_TAG"
-  TF_IMAGE_ARGS=(-var "container_registry=$REGISTRY" -var "api_image_name=$API_IMAGE_NAME" -var "container_image_tag=$IMAGE_TAG")
+  echo "==> Building & pushing migrator image $REGISTRY/$MIGRATOR_IMAGE_NAME:$IMAGE_TAG"
+  dotnet publish "$REPO_ROOT/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj" \
+    -c Release -r linux-x64 \
+    /t:PublishContainer \
+    -p:ContainerRepository="$REGISTRY/$MIGRATOR_IMAGE_NAME" \
+    -p:ContainerImageTags="$IMAGE_TAG"
+  TF_IMAGE_ARGS=(-var "container_registry=$REGISTRY" -var "api_image_name=$API_IMAGE_NAME" -var "migrator_image_name=$MIGRATOR_IMAGE_NAME" -var "container_image_tag=$IMAGE_TAG")
 elif [[ -n "$IMAGE_TAG" ]]; then
   TF_IMAGE_ARGS=(-var "container_image_tag=$IMAGE_TAG")
 fi
@@ -94,6 +108,48 @@ APPLY_ARGS=(-var-file="$ENV_DIR/terraform.tfvars" "${TF_IMAGE_ARGS[@]}" -input=f
 
 echo "==> terraform apply"
 terraform -chdir="$APP_STACK_DIR" apply "${APPLY_ARGS[@]}"
+
+# ---- 2.5 db migrator (one-shot ECS task) ------------------------------------
+run_ecs_task() {
+  # $1 = label, $2 = optional --overrides JSON ("" for the task's baked command)
+  local label="$1" overrides="${2:-}"
+  local run_args task_arn exit_code reason
+  echo "==> Running DbMigrator task ($label)"
+  run_args=(--cluster "$MIG_CLUSTER" --task-definition "$MIG_TASKDEF" --launch-type FARGATE
+    --network-configuration "awsvpcConfiguration={subnets=[$MIG_SUBNETS],securityGroups=[$MIG_SG],assignPublicIp=DISABLED}"
+    --query 'tasks[0].taskArn' --output text)
+  [[ -n "$overrides" ]] && run_args+=(--overrides "$overrides")
+  task_arn="$(aws ecs run-task "${run_args[@]}")"
+  [[ -n "$task_arn" && "$task_arn" != "None" ]] || die "run-task failed to start ($label)"
+  echo "    task: $task_arn — waiting for it to stop..."
+  aws ecs wait tasks-stopped --cluster "$MIG_CLUSTER" --tasks "$task_arn"
+  exit_code="$(aws ecs describe-tasks --cluster "$MIG_CLUSTER" --tasks "$task_arn" --query 'tasks[0].containers[0].exitCode' --output text)"
+  if [[ "$exit_code" != "0" ]]; then
+    reason="$(aws ecs describe-tasks --cluster "$MIG_CLUSTER" --tasks "$task_arn" --query 'tasks[0].stoppedReason' --output text)"
+    die "migrator ($label) exited ${exit_code} — ${reason} (logs: CloudWatch ${MIG_LOG_GROUP})"
+  fi
+  echo "    migrator ($label) succeeded."
+}
+
+if [[ "$SKIP_MIGRATE" == true ]]; then
+  echo "==> Skipping DB migration (--skip-migrate)"
+else
+  MIG="$(terraform -chdir="$APP_STACK_DIR" output -json migrator 2>/dev/null || echo null)"
+  if [[ "$MIG" == "null" || -z "$MIG" ]]; then
+    echo "==> Migrator not provisioned (enable_migrator=false) — skipping"
+  else
+    MIG_CLUSTER="$(echo "$MIG" | jq -r .cluster_arn)"
+    MIG_TASKDEF="$(echo "$MIG" | jq -r .task_definition_family)"
+    MIG_CNAME="$(echo "$MIG" | jq -r .container_name)"
+    MIG_SG="$(echo "$MIG" | jq -r .security_group_id)"
+    MIG_SUBNETS="$(echo "$MIG" | jq -r '.subnet_ids | join(",")')"
+    MIG_LOG_GROUP="$(echo "$MIG" | jq -r .log_group_name)"
+    run_ecs_task "migrate" ""
+    if [[ "$SEED_DEMO" == true ]]; then
+      run_ecs_task "seed-demo" "{\"containerOverrides\":[{\"name\":\"${MIG_CNAME}\",\"command\":[\"seed-demo\"]}]}"
+    fi
+  fi
+fi
 
 # ---- 3. frontends -----------------------------------------------------------
 if [[ "$SKIP_FRONTEND" == true ]]; then

--- a/deploy/terraform/apps/starter/envs/dev/us-east-1/backend.hcl
+++ b/deploy/terraform/apps/starter/envs/dev/us-east-1/backend.hcl
@@ -1,4 +1,4 @@
-bucket       = "fsh-state-bucket"
+bucket       = "fsh-tfstate"
 key          = "dev/us-east-1/terraform.tfstate"
 region       = "us-east-1"
 encrypt      = true

--- a/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
+++ b/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
@@ -58,6 +58,15 @@ db_manage_master_user_password = true
 container_image_tag = "1d2c9f9d3b85bb86229f1bc1b9cd8196054f2166"
 
 ################################################################################
+# DbMigrator — dev migrates AND seeds (admin + default tenant) on every deploy.
+# Seeding is idempotent; Seed:* / JwtOptions config comes from the image's
+# appsettings.Development.json (ASPNETCORE_ENVIRONMENT=Development on dev).
+# Demo tenants (acme/globex) are opt-in: run deploy with --seed-demo / -SeedDemo.
+################################################################################
+
+migrator_command = ["apply", "--seed"]
+
+################################################################################
 # Services (Fargate Spot for cost savings)
 ################################################################################
 

--- a/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
+++ b/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
@@ -53,8 +53,18 @@ db_manage_master_user_password = true
 
 ################################################################################
 # Container Images
+#
+# Final image refs are "<registry>/<image_name>:<tag>", e.g.
+#   ghcr.io/fullstackhero/fsh-api:<tag>
+#   ghcr.io/fullstackhero/fsh-db-migrator:<tag>
+# The tag is SHARED by both images (built together from the same commit) and must
+# be immutable. CI publishes "dev-<full-sha>"; `deploy.sh --build-api` publishes a
+# bare 12-char short SHA. Set the tag to whichever was actually pushed to GHCR.
 ################################################################################
 
+container_registry  = "ghcr.io/fullstackhero"
+api_image_name      = "fsh-api"
+migrator_image_name = "fsh-db-migrator"
 container_image_tag = "1d2c9f9d3b85bb86229f1bc1b9cd8196054f2166"
 
 ################################################################################

--- a/deploy/terraform/bootstrap/.terraform.lock.hcl
+++ b/deploy/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.49.0"
+  constraints = "~> 6.46"
+  hashes = [
+    "h1:zBF6IqpUiJAszE5L4HpWuOgG6nSnqGRnwr08frehB40=",
+    "zh:11a636bb415bf780f0ad300cab83d687aebdc51381112ae7b29862e0bee43017",
+    "zh:2d6c4bb861c073d9900a2afc39cc1e38492c6996653e53c7a2083b526fb10ae9",
+    "zh:49f7ee4a7488f3d31342c5e9dbb577c40e0847a0cab152a0082e9aeef45f5c0f",
+    "zh:561283c9c9bd36b9d09832e50769b941eb45c43c6ab031f27c8bf78256af4af1",
+    "zh:576bf944e66d097b29fc45b25a5bbc53e7d4e71a486e2cb126304cf77b51fe79",
+    "zh:6c6bf8860773c121b9ca22743f733feea943f890fa3aba8740a59579dea16fc4",
+    "zh:88b963a659e42daac7384a6abb99b3383f9f6c8abad5dedafcd443536b122b84",
+    "zh:947e9404235ca094e39e7f3f464f99436320a168e1607c550e581fbc70553d48",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a9c5a37bd1e5e81e85ad3dc3141f1b453b96e9cb8e500bc15bfb9c488fc95dcc",
+    "zh:b7b8a028fb2eafb98c676f9438808318f7ff0ea76eba03a6653d0940848a31c7",
+    "zh:be29f31827d6d5567aaec26034e6cceb994460446778ba1d0a435fc7ccd8a9f5",
+    "zh:c24c60ecffe3a7d44c762e62a29a802aec604096715ad3110b7ca2207124eb3a",
+    "zh:e2a247c5c7815437969e87cdce1f27f323eea75b97ed53f7605fef05d6406071",
+    "zh:e590ce9aca3f4fd964f7bf908a24dc3bc88e0b03a8554ccc81b9edcc84690670",
+  ]
+}

--- a/deploy/terraform/modules/ecs_task/main.tf
+++ b/deploy/terraform/modules/ecs_task/main.tf
@@ -1,0 +1,152 @@
+################################################################################
+# One-shot ECS (Fargate) task — registers a runnable task definition only.
+#
+# Unlike the ecs_service module there is NO service, ALB target group, listener
+# rule, or autoscaling: this is a job you invoke on demand with `aws ecs
+# run-task` (see the deploy scripts) and wait for to exit. Used for the DB
+# migrator (apply / apply --seed).
+################################################################################
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.kms_key_id
+
+  tags = var.tags
+}
+
+################################################################################
+# Security Group (egress only — the task makes outbound calls to RDS / Redis /
+# Secrets Manager / the registry; nothing connects in to it).
+################################################################################
+
+resource "aws_security_group" "this" {
+  name        = "${var.name}-ecs"
+  description = "Security group for one-shot ECS task ${var.name}"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-ecs-sg"
+  })
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.this.id
+  description       = "Allow all outbound traffic"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = var.tags
+}
+
+################################################################################
+# IAM - Task Execution Role
+################################################################################
+
+data "aws_iam_policy_document" "task_execution_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.task_execution_assume.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "task_execution_secrets" {
+  count = length(var.secrets) > 0 ? 1 : 0
+
+  name = "${var.name}-secrets-access"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = [for s in var.secrets : s.valueFrom]
+      }
+    ]
+  })
+}
+
+################################################################################
+# Task Definition
+################################################################################
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  cpu                      = var.cpu
+  memory                   = var.memory
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.name
+      image     = var.container_image
+      essential = true
+
+      command = var.command
+
+      environment = [
+        for k, v in var.environment_variables :
+        {
+          name  = k
+          value = v
+        }
+      ]
+
+      secrets = length(var.secrets) > 0 ? [
+        for s in var.secrets :
+        {
+          name      = s.name
+          valueFrom = s.valueFrom
+        }
+      ] : []
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = var.name
+        }
+      }
+
+      readonlyRootFilesystem = var.readonly_root_filesystem
+
+      # Init process for proper signal handling (PID 1 zombie reaping).
+      linuxParameters = {
+        initProcessEnabled = true
+      }
+    }
+  ])
+
+  runtime_platform {
+    cpu_architecture        = var.cpu_architecture
+    operating_system_family = "LINUX"
+  }
+
+  tags = var.tags
+}

--- a/deploy/terraform/modules/ecs_task/outputs.tf
+++ b/deploy/terraform/modules/ecs_task/outputs.tf
@@ -1,0 +1,24 @@
+output "task_definition_arn" {
+  description = "Full ARN (with revision) of the registered task definition."
+  value       = aws_ecs_task_definition.this.arn
+}
+
+output "task_definition_family" {
+  description = "Task definition family. Pass to `aws ecs run-task --task-definition` to always launch the latest revision."
+  value       = aws_ecs_task_definition.this.family
+}
+
+output "container_name" {
+  description = "Container name (use for `run-task` container overrides)."
+  value       = var.name
+}
+
+output "security_group_id" {
+  description = "Security group ID for the task's awsvpc network configuration."
+  value       = aws_security_group.this.id
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group the task streams to."
+  value       = aws_cloudwatch_log_group.this.name
+}

--- a/deploy/terraform/modules/ecs_task/variables.tf
+++ b/deploy/terraform/modules/ecs_task/variables.tf
@@ -1,0 +1,119 @@
+################################################################################
+# Required Variables
+################################################################################
+
+variable "name" {
+  type        = string
+  description = "Name of the ECS task (family + log group + security group)."
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]+$", var.name))
+    error_message = "Task name must contain only alphanumeric characters, hyphens, and underscores."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region (used for the awslogs log driver)."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID the task's security group lives in."
+}
+
+variable "container_image" {
+  type        = string
+  description = "Container image to run."
+
+  validation {
+    condition     = length(var.container_image) > 0
+    error_message = "Container image must not be empty."
+  }
+}
+
+################################################################################
+# Optional Variables - Task Sizing
+################################################################################
+
+variable "cpu" {
+  type        = number
+  description = "Fargate task CPU units."
+  default     = 512
+}
+
+variable "memory" {
+  type        = number
+  description = "Fargate task memory (MiB)."
+  default     = 1024
+}
+
+variable "cpu_architecture" {
+  type        = string
+  description = "CPU architecture for the task (X86_64 or ARM64)."
+  default     = "X86_64"
+
+  validation {
+    condition     = contains(["X86_64", "ARM64"], var.cpu_architecture)
+    error_message = "cpu_architecture must be X86_64 or ARM64."
+  }
+}
+
+################################################################################
+# Optional Variables - Runtime
+################################################################################
+
+variable "command" {
+  type        = list(string)
+  description = "Command (args) passed to the container entrypoint. Empty uses the image default."
+  default     = []
+}
+
+variable "environment_variables" {
+  type        = map(string)
+  description = "Plain environment variables. Sensitive values should use the secrets variable instead."
+  default     = {}
+}
+
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Secrets from Secrets Manager / Parameter Store, injected by the task execution role."
+  default     = []
+}
+
+variable "task_role_arn" {
+  type        = string
+  description = "Optional task role ARN (app-level AWS permissions). Null = no task role."
+  default     = null
+}
+
+variable "readonly_root_filesystem" {
+  type        = bool
+  description = "Mount the container root filesystem read-only."
+  default     = false
+}
+
+################################################################################
+# Optional Variables - Logging & Tagging
+################################################################################
+
+variable "log_retention_in_days" {
+  type        = number
+  description = "CloudWatch log group retention."
+  default     = 30
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "Optional KMS key ARN for log group encryption."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to created resources."
+  default     = {}
+}

--- a/deploy/terraform/modules/ecs_task/versions.tf
+++ b/deploy/terraform/modules/ecs_task/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  # Floor only — reusable child module. The root config pins the exact
+  # Terraform core and provider versions (see app_stack/versions.tf).
+  required_version = ">= 1.15"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Makes the AWS/Terraform deployment path actually viable: publishes the DbMigrator container image, **fixes a latent bug where no container image ever reached GHCR**, and wires the migrator to run against RDS as a one-shot ECS task.

## The bug (why `fsh-api` was never in Packages)

The publish jobs ran green for months but **never pushed to GHCR**. The .NET SDK container tooling only pushes to a *remote* registry when `ContainerRegistry` is set; folding the registry into `ContainerRepository` (`ghcr.io/owner/fsh-api`) left `ContainerRegistry` unset, so the SDK loaded the image into the runner's local Docker daemon and discarded it:

```
Pushed image 'ghcr.io/fullstackhero/fsh-api:dev-…' to local registry via 'docker'.
```

Fix: split `ContainerRegistry=ghcr.io` + `ContainerRepository=<owner>/<name>` in all four publish steps and both deploy scripts.

## Changes

**Pipeline (`backend.yml`)**
- Publish `fsh-db-migrator` alongside `fsh-api` in both `publish-dev-containers` (dev-`<sha>`) and `publish-release` (`<version>`).
- Fix registry/repository split so images push to GHCR for real. (migrator-smoke stays local-only by design.)

**Terraform**
- New `modules/ecs_task` — a runnable Fargate task definition only (log group, egress-only SG, execution role + secrets). No service/ALB/autoscaling.
- `app_stack` wires it as the DbMigrator, reusing the API's private subnets + DB connection-string secret. New vars: `enable_migrator`, `migrator_command`, `migrator_cpu/memory`, `migrator_image_name`, `migrator_extra_environment_variables`.
- Dev `terraform.tfvars` auto-seeds (`apply --seed`); prod stays migrate-only.

**Deploy scripts (`deploy.sh` / `deploy.ps1`)**
- After `apply`, run the migrator via `aws ecs run-task` and wait for exit 0 (fails deploy on non-zero; prints stoppedReason + log group).
- `--build-api` now builds/pushes both images. New `--skip-migrate` and `--seed-demo` flags.

## Verification
- `terraform validate` passes (new module + full `app_stack`); `terraform fmt` clean.
- `deploy.sh` (`bash -n`) and `deploy.ps1` (PS parser) both parse clean.

## Follow-ups (not in this PR)
- After merge, the fixed `publish-dev-containers` run creates the GHCR packages — they must be set **public** (per-package, one-time) before ECS can pull.
- Update env tfvars `container_image_tag` to the `dev-<full-sha>` CI produces.
- Docs repo (`fullstackhero/docs`) update + changelog entry per AGENTS rule #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
