### PR TITLE
fix(deploy): pin AWS region, fix migrator env/seed, drop chiseled image; trim comments repo-wide

### DIFF
--- a/deploy/terraform/apps/starter/app_stack/.terraform.lock.hcl
+++ b/deploy/terraform/apps/starter/app_stack/.terraform.lock.hcl
@@ -27,3 +27,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:e3ac26177953ddf1d72e28b9a1f33d029675e9ea6652f7cc844a86c02b0ebd68",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/deploy/terraform/apps/starter/app_stack/main.tf
+++ b/deploy/terraform/apps/starter/app_stack/main.tf
@@ -385,6 +385,70 @@ locals {
 }
 
 ################################################################################
+# Application Auth Secrets (generated → Secrets Manager → injected into tasks)
+#
+# The API hard-requires JwtOptions:SigningKey and HangfireOptions:Username/
+# Password (Require() in Production + ValidateOnStart in every env). Rather than
+# lean on the public dev appsettings (forgeable JWTs), generate them here and
+# inject via the task execution role like the DB connection string.
+################################################################################
+
+resource "random_password" "jwt_signing_key" {
+  length  = 64
+  special = false # consumed as ASCII bytes for HMAC — keep it alphanumeric
+}
+
+resource "random_password" "hangfire" {
+  length           = 24
+  special          = true
+  override_special = "!@#%^-_=+"
+}
+
+resource "aws_secretsmanager_secret" "jwt_signing_key" {
+  name        = "${var.environment}-jwt-signing-key"
+  description = "HMAC signing key for FSH API JWTs."
+  tags        = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "jwt_signing_key" {
+  secret_id     = aws_secretsmanager_secret.jwt_signing_key.id
+  secret_string = random_password.jwt_signing_key.result
+}
+
+resource "aws_secretsmanager_secret" "hangfire_password" {
+  name        = "${var.environment}-hangfire-password"
+  description = "Hangfire dashboard password for the FSH API."
+  tags        = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "hangfire_password" {
+  secret_id     = aws_secretsmanager_secret.hangfire_password.id
+  secret_string = random_password.hangfire.result
+}
+
+locals {
+  # Auth secrets injected into BOTH the API and the migrator task (the migrator
+  # otherwise self-injects a placeholder signing key; a real one is harmless).
+  app_auth_secrets = [
+    {
+      name      = "JwtOptions__SigningKey"
+      valueFrom = aws_secretsmanager_secret.jwt_signing_key.arn
+    },
+    {
+      name      = "HangfireOptions__Password"
+      valueFrom = aws_secretsmanager_secret.hangfire_password.arn
+    },
+  ]
+
+  # Optional dev seed credentials — injected only when set (prod runs `apply`
+  # without --seed, so it never reads them).
+  seed_environment_variables = merge(
+    var.seed_default_admin_password != null ? { "Seed__DefaultAdminPassword" = var.seed_default_admin_password } : {},
+    var.seed_demo_password != null ? { "Seed__DemoPassword" = var.seed_demo_password } : {},
+  )
+}
+
+################################################################################
 # ElastiCache Redis
 ################################################################################
 
@@ -401,6 +465,7 @@ module "redis" {
 
   node_type                  = var.redis_node_type
   num_cache_clusters         = var.redis_num_cache_clusters
+  engine                     = var.redis_engine
   engine_version             = var.redis_engine_version
   automatic_failover_enabled = var.redis_automatic_failover_enabled
   transit_encryption_enabled = var.redis_transit_encryption_enabled
@@ -458,6 +523,9 @@ module "api_service" {
       Storage__S3__Bucket        = var.app_s3_bucket_name
       Storage__S3__PublicBaseUrl = module.app_s3.cloudfront_domain_name != "" ? "https://${module.app_s3.cloudfront_domain_name}" : ""
       OriginOptions__OriginUrl   = local.api_origin
+      # Hangfire dashboard user (password arrives via `secrets` below). Both are
+      # [Required] + ValidateOnStart, so the API won't boot without them.
+      HangfireOptions__Username = var.hangfire_username
     },
     # Connection string is injected via env var only when NOT using a managed
     # (Secrets Manager) password; otherwise it arrives via `secrets` below.
@@ -470,13 +538,17 @@ module "api_service" {
     var.api_extra_environment_variables
   )
 
-  # When using managed password, inject the full connection string from Secrets Manager
-  secrets = var.db_manage_master_user_password ? [
-    {
-      name      = "DatabaseOptions__ConnectionString"
-      valueFrom = aws_secretsmanager_secret.db_connection_string[0].arn
-    }
-  ] : []
+  # Injected from Secrets Manager by the task execution role: the JWT signing
+  # key + Hangfire password always, plus the DB connection string when managed.
+  secrets = concat(
+    local.app_auth_secrets,
+    var.db_manage_master_user_password ? [
+      {
+        name      = "DatabaseOptions__ConnectionString"
+        valueFrom = aws_secretsmanager_secret.db_connection_string[0].arn
+      }
+    ] : []
+  )
 
   tags = local.common_tags
 }
@@ -487,10 +559,9 @@ module "api_service" {
 # Registers a runnable task definition only (no service). The deploy scripts
 # invoke it with `aws ecs run-task` after `apply` and wait for exit code 0.
 # Command is environment-driven: dev runs `apply --seed`, prod runs `apply`
-# (set per-env in terraform.tfvars via `migrator_command`). The seed path reads
-# Seed:* / JwtOptions:SigningKey from appsettings.Development.json (baked into
-# the image, active because dev sets ASPNETCORE_ENVIRONMENT=Development);
-# override for non-dev seeding via `migrator_extra_environment_variables`.
+# (set per-env in terraform.tfvars via `migrator_command`). Seed credentials come
+# from seed_default_admin_password / seed_demo_password when set (else the baked
+# dev appsettings); the JWT signing key is injected from Secrets Manager.
 ################################################################################
 
 module "migrator" {
@@ -510,21 +581,28 @@ module "migrator" {
       ASPNETCORE_ENVIRONMENT              = local.aspnetcore_environment
       DatabaseOptions__Provider           = "POSTGRESQL"
       DatabaseOptions__MigrationsAssembly = "FSH.Starter.Migrations.PostgreSQL"
+      HangfireOptions__Username           = var.hangfire_username
     },
     # Plain connection string only when NOT using a managed (Secrets Manager)
     # password; otherwise it arrives via `secrets` below — same as the API.
     var.db_manage_master_user_password ? {} : {
       DatabaseOptions__ConnectionString = local.db_connection_string_plain
     },
+    # Seed credentials (when configured) so seeding doesn't depend on the baked
+    # dev appsettings; empty when unset → falls back to image config.
+    local.seed_environment_variables,
     var.migrator_extra_environment_variables
   )
 
-  secrets = var.db_manage_master_user_password ? [
-    {
-      name      = "DatabaseOptions__ConnectionString"
-      valueFrom = aws_secretsmanager_secret.db_connection_string[0].arn
-    }
-  ] : []
+  secrets = concat(
+    local.app_auth_secrets,
+    var.db_manage_master_user_password ? [
+      {
+        name      = "DatabaseOptions__ConnectionString"
+        valueFrom = aws_secretsmanager_secret.db_connection_string[0].arn
+      }
+    ] : []
+  )
 
   tags = local.common_tags
 }

--- a/deploy/terraform/apps/starter/app_stack/main.tf
+++ b/deploy/terraform/apps/starter/app_stack/main.tf
@@ -578,7 +578,8 @@ module "migrator" {
 
   environment_variables = merge(
     {
-      ASPNETCORE_ENVIRONMENT              = local.aspnetcore_environment
+      # Generic-host migrator selects its env from DOTNET_ENVIRONMENT, not ASPNETCORE_ENVIRONMENT.
+      DOTNET_ENVIRONMENT                  = local.aspnetcore_environment
       DatabaseOptions__Provider           = "POSTGRESQL"
       DatabaseOptions__MigrationsAssembly = "FSH.Starter.Migrations.PostgreSQL"
       HangfireOptions__Username           = var.hangfire_username

--- a/deploy/terraform/apps/starter/app_stack/outputs.tf
+++ b/deploy/terraform/apps/starter/app_stack/outputs.tf
@@ -101,6 +101,21 @@ output "rds_secret_arn" {
 }
 
 ################################################################################
+# Application Secrets (generated)
+################################################################################
+
+output "hangfire_password" {
+  description = "Generated Hangfire dashboard password (also in Secrets Manager)."
+  value       = random_password.hangfire.result
+  sensitive   = true
+}
+
+output "jwt_signing_key_secret_arn" {
+  description = "Secrets Manager ARN holding the API's JWT signing key."
+  value       = aws_secretsmanager_secret.jwt_signing_key.arn
+}
+
+################################################################################
 # Redis Outputs
 ################################################################################
 

--- a/deploy/terraform/apps/starter/app_stack/variables.tf
+++ b/deploy/terraform/apps/starter/app_stack/variables.tf
@@ -376,10 +376,16 @@ variable "redis_num_cache_clusters" {
   default     = 1
 }
 
+variable "redis_engine" {
+  type        = string
+  description = "ElastiCache engine: 'valkey' (default) or 'redis'. Valkey is Redis-compatible and matches the Aspire/compose stack."
+  default     = "valkey"
+}
+
 variable "redis_engine_version" {
   type        = string
-  description = "Redis engine version."
-  default     = "7.2"
+  description = "ElastiCache engine version. Valkey: 8.0 / 7.2. Redis (legacy): max 7.1."
+  default     = "8.0"
 }
 
 variable "redis_automatic_failover_enabled" {
@@ -520,6 +526,30 @@ variable "migrator_extra_environment_variables" {
   type        = map(string)
   description = "Extra env vars for the migrator (e.g. Seed__DefaultAdminPassword / JwtOptions__SigningKey when seeding outside the dev Development profile)."
   default     = {}
+}
+
+################################################################################
+# Application Auth / Seed Variables
+################################################################################
+
+variable "hangfire_username" {
+  type        = string
+  description = "Hangfire dashboard username (the password is generated into Secrets Manager)."
+  default     = "admin"
+}
+
+variable "seed_default_admin_password" {
+  type        = string
+  sensitive   = true
+  description = "Root admin password for the migrator seed (`apply --seed`). Null = use the image's baked dev appsettings. Must satisfy the Identity password policy."
+  default     = null
+}
+
+variable "seed_demo_password" {
+  type        = string
+  sensitive   = true
+  description = "Shared password for demo-tenant users (`seed-demo`). Null = use the image's baked dev appsettings."
+  default     = null
 }
 
 ################################################################################

--- a/deploy/terraform/apps/starter/app_stack/versions.tf
+++ b/deploy/terraform/apps/starter/app_stack/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.46"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }

--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -49,6 +49,11 @@ foreach ($tool in 'terraform', 'aws') {
   if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) { Die "$tool is required but not installed" }
 }
 
+# Pin the region for every `aws` CLI call (else it falls back to ~/.aws/config →
+# "Invalid Region in ARN" when that default differs from $Region).
+$env:AWS_REGION = $Region
+$env:AWS_DEFAULT_REGION = $Region
+
 $tfVersion = [version](terraform version -json | ConvertFrom-Json).terraform_version
 if ($tfVersion -lt $MinTfVersion) {
   Die "Terraform >= $MinTfVersion required (found $tfVersion). Upgrade with e.g. 'choco upgrade terraform'."
@@ -119,7 +124,9 @@ function Invoke-EcsTask($label, $overridesJson) {
     Set-Content -Path $tmp.FullName -Value $overridesJson -Encoding utf8
     $runArgs += @('--overrides', "file://$($tmp.FullName)")
   }
-  $taskArn = (aws @runArgs).Trim()
+  $taskArn = (aws @runArgs)
+  if ($LASTEXITCODE -ne 0 -or -not $taskArn) { Die "run-task failed to start ($label) — see aws error above (region: $env:AWS_REGION)" }
+  $taskArn = "$taskArn".Trim()
   if (-not $taskArn -or $taskArn -eq 'None') { Die "run-task failed to start ($label)" }
   Write-Host "    task: $taskArn — waiting for it to stop..."
   aws ecs wait tasks-stopped --cluster $migCluster --tasks $taskArn

--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -13,7 +13,7 @@
     3. run the DbMigrator one-shot ECS task (apply / apply --seed) and wait for exit 0
     4. build the React apps, publish to their S3 buckets, invalidate CloudFront
 
-  Requires: terraform >= 1.15.4, aws cli (configured), jq, node/npm, and
+  Requires: terraform >= 1.15.4, aws cli (configured), node/npm, and
   (with -BuildApi) the .NET SDK + a registry login.
 #>
 [CmdletBinding()]
@@ -44,7 +44,8 @@ function Die($msg) { Write-Error $msg; exit 1 }
 if (-not (Test-Path "$EnvDir/backend.hcl")) { Die "no backend.hcl for $Environment/$Region at $EnvDir" }
 if (-not (Test-Path "$EnvDir/terraform.tfvars")) { Die "no terraform.tfvars for $Environment/$Region at $EnvDir" }
 
-foreach ($tool in 'terraform', 'aws', 'jq') {
+# Note: no jq — PowerShell parses Terraform's JSON output with ConvertFrom-Json.
+foreach ($tool in 'terraform', 'aws') {
   if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) { Die "$tool is required but not installed" }
 }
 
@@ -88,14 +89,19 @@ elseif ($ImageTag) {
 }
 
 # ---- 2. terraform -----------------------------------------------------------
+# Native exes don't trip $ErrorActionPreference, so check $LASTEXITCODE
+# explicitly — otherwise a failed apply silently falls through to the
+# migrator/frontend steps (which then find no state and emit confusing errors).
 Write-Host '==> terraform init'
 terraform -chdir="$AppStackDir" init -reconfigure -input=false -backend-config="$EnvDir/backend.hcl"
+if ($LASTEXITCODE -ne 0) { Die "terraform init failed (exit $LASTEXITCODE)" }
 
 $applyArgs = @("-var-file=$EnvDir/terraform.tfvars") + $tfImageArgs + @('-input=false')
 if ($AutoApprove) { $applyArgs += '-auto-approve' }
 
 Write-Host '==> terraform apply'
 terraform -chdir="$AppStackDir" apply @applyArgs
+if ($LASTEXITCODE -ne 0) { Die "terraform apply failed (exit $LASTEXITCODE)" }
 
 # ---- 2.5 db migrator (one-shot ECS task) ------------------------------------
 function Invoke-EcsTask($label, $overridesJson) {

--- a/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
+++ b/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
@@ -69,8 +69,8 @@ container_image_tag = "dev-ba3e9498632df227a04a633e3573b646c9c2aa62"
 
 ################################################################################
 # DbMigrator — dev migrates AND seeds (admin + default tenant) on every deploy.
-# Seeding is idempotent; Seed:* / JwtOptions config comes from the image's
-# appsettings.Development.json (ASPNETCORE_ENVIRONMENT=Development on dev).
+# Seeding is idempotent; Seed:* config comes from the image's appsettings.Development.json.
+# Override explicitly via seed_default_admin_password / seed_demo_password if needed.
 # Demo tenants (acme/globex) are opt-in: run deploy with --seed-demo / -SeedDemo.
 ################################################################################
 

--- a/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
+++ b/deploy/terraform/apps/starter/envs/dev/us-east-1/terraform.tfvars
@@ -65,7 +65,7 @@ db_manage_master_user_password = true
 container_registry  = "ghcr.io/fullstackhero"
 api_image_name      = "fsh-api"
 migrator_image_name = "fsh-db-migrator"
-container_image_tag = "1d2c9f9d3b85bb86229f1bc1b9cd8196054f2166"
+container_image_tag = "dev-ba3e9498632df227a04a633e3573b646c9c2aa62"
 
 ################################################################################
 # DbMigrator — dev migrates AND seeds (admin + default tenant) on every deploy.

--- a/deploy/terraform/modules/elasticache_redis/main.tf
+++ b/deploy/terraform/modules/elasticache_redis/main.tf
@@ -67,8 +67,9 @@ resource "aws_elasticache_subnet_group" "this" {
 resource "aws_elasticache_parameter_group" "this" {
   count = var.create_parameter_group ? 1 : 0
 
-  name   = "${var.name}-params"
-  family = "redis${split(".", var.engine_version)[0]}"
+  name = "${var.name}-params"
+  # Parameter-group family is engine-specific: valkey8 / valkey7 / redis7.
+  family = "${var.engine}${split(".", var.engine_version)[0]}"
 
   dynamic "parameter" {
     for_each = var.parameters
@@ -94,7 +95,7 @@ resource "aws_elasticache_replication_group" "this" {
   description          = var.description != "" ? var.description : "Redis for ${var.name}"
 
   # Engine
-  engine         = "redis"
+  engine         = var.engine
   engine_version = var.engine_version
   node_type      = var.node_type
 

--- a/deploy/terraform/modules/elasticache_redis/variables.tf
+++ b/deploy/terraform/modules/elasticache_redis/variables.tf
@@ -48,10 +48,21 @@ variable "vpc_cidr_block" {
 # Engine Configuration
 ################################################################################
 
+variable "engine" {
+  type        = string
+  description = "ElastiCache engine: 'valkey' (default, Redis-compatible) or 'redis'."
+  default     = "valkey"
+
+  validation {
+    condition     = contains(["valkey", "redis"], var.engine)
+    error_message = "engine must be 'valkey' or 'redis'."
+  }
+}
+
 variable "engine_version" {
   type        = string
-  description = "Redis engine version."
-  default     = "7.2"
+  description = "Engine version. Valkey: 8.0 / 7.2. Redis (legacy): tops out at 7.1 on ElastiCache."
+  default     = "8.0"
 }
 
 variable "node_type" {

--- a/deploy/terraform/modules/waf/main.tf
+++ b/deploy/terraform/modules/waf/main.tf
@@ -229,7 +229,9 @@ resource "aws_wafv2_web_acl" "this" {
 ################################################################################
 
 resource "aws_wafv2_web_acl_association" "this" {
-  count = var.alb_arn != null ? 1 : 0
+  # Keyed off a static bool, NOT (var.alb_arn != null): the ALB ARN is computed
+  # and unknown at plan, so a null-check on it fails with "Invalid count argument".
+  count = var.associate_alb ? 1 : 0
 
   resource_arn = var.alb_arn
   web_acl_arn  = aws_wafv2_web_acl.this.arn

--- a/deploy/terraform/modules/waf/variables.tf
+++ b/deploy/terraform/modules/waf/variables.tf
@@ -18,8 +18,14 @@ variable "name" {
 
 variable "alb_arn" {
   type        = string
-  description = "ARN of the ALB to associate with the WAF. Set to null to skip association."
+  description = "ARN of the ALB to associate with the WAF. Required when associate_alb is true."
   default     = null
+}
+
+variable "associate_alb" {
+  type        = bool
+  description = "Associate the Web ACL with alb_arn. Must be a STATIC value (a count cannot key off the ALB ARN, which is unknown until apply). Set false to create the Web ACL without associating it."
+  default     = true
 }
 
 ################################################################################

--- a/src/BuildingBlocks/Caching/Extensions.cs
+++ b/src/BuildingBlocks/Caching/Extensions.cs
@@ -33,18 +33,16 @@ public static class Extensions
 
         var cacheOptions = configuration.GetSection(nameof(CachingOptions)).Get<CachingOptions>() ?? new CachingOptions();
 
-        // L2: Redis if configured, in-memory distributed cache otherwise.
-        // Note: Microsoft.Extensions.Caching.StackExchangeRedis 9.0+ implements
-        // IBufferDistributedCache, which HybridCache uses for zero-copy reads.
+        // L2: Redis if configured, in-memory distributed cache otherwise. StackExchangeRedis 9.0+
+        // implements IBufferDistributedCache, which HybridCache uses for zero-copy reads.
         if (string.IsNullOrEmpty(cacheOptions.Redis))
         {
             services.AddDistributedMemoryCache();
         }
         else
         {
-            // Connect once at registration time and share the multiplexer across the
-            // Redis cache, Data Protection key persistence, and any future Redis-backed
-            // consumers — one connection pool per host instead of one per feature.
+            // Connect once and share the multiplexer across the Redis cache, Data Protection key
+            // persistence, and future consumers — one connection pool per host, not per feature.
             var redisConfig = ConfigurationOptions.Parse(cacheOptions.Redis);
             redisConfig.AbortOnConnectFail = false;
             if (cacheOptions.EnableSsl.HasValue)
@@ -60,9 +58,8 @@ public static class Extensions
                     Task.FromResult<IConnectionMultiplexer>(sharedMultiplexer);
             });
 
-            // Persist Data Protection keys (auth cookies, password-reset tokens, email-
-            // confirmation tokens, antiforgery) to Redis so multi-instance hosts share a
-            // key ring and tokens survive after a rolling restart on any node.
+            // Persist Data Protection keys (auth cookies, reset/confirmation tokens, antiforgery) to
+            // Redis so multi-instance hosts share a key ring and tokens survive rolling restarts.
             services.AddDataProtection()
                 .PersistKeysToStackExchangeRedis(sharedMultiplexer, "DataProtection-Keys")
                 .SetApplicationName("FSH.Starter");
@@ -80,9 +77,8 @@ public static class Extensions
             options.MaximumPayloadBytes = cacheOptions.MaximumPayloadBytes;
         });
 
-        // Wrap HybridCache with the OTel-emitting decorator. We capture the existing descriptor
-        // (a DefaultHybridCache factory installed by AddHybridCache), remove it, and register a
-        // factory that builds the inner via the original descriptor and returns our wrapper.
+        // Wrap HybridCache with the OTel-emitting decorator: capture the descriptor AddHybridCache
+        // installed, remove it, and register a factory that builds the inner and returns our wrapper.
         DecorateHybridCache(services);
 
         return services;

--- a/src/BuildingBlocks/Caching/ObservableHybridCache.cs
+++ b/src/BuildingBlocks/Caching/ObservableHybridCache.cs
@@ -141,10 +141,8 @@ internal sealed class ObservableHybridCache : HybridCache
         return _inner.RemoveByTagAsync(tags, cancellationToken);
     }
 
-    // State flows through TState so we avoid a per-call closure capturing the surrounding
-    // ObservableHybridCache instance. The StrongBox is a single-field heap allocation used
-    // to observe the "factory invoked?" flag after the inner call returns — unavoidable
-    // because HybridCache does not surface hit/miss directly.
+    // State flows through TState to avoid a per-call closure; the StrongBox observes the
+    // "factory invoked?" flag after the inner call (HybridCache doesn't surface hit/miss).
     private struct FactoryWrapperState<TState, T>
     {
         public FactoryWrapperState(TState state, Func<TState, CancellationToken, ValueTask<T>> factory, bool Invoked)

--- a/src/BuildingBlocks/Eventing/InMemory/InMemoryEventBus.cs
+++ b/src/BuildingBlocks/Eventing/InMemory/InMemoryEventBus.cs
@@ -59,11 +59,8 @@ public sealed partial class InMemoryEventBus : IEventBus
 
         var dispatch = GetDispatch(eventType);
 
-        // Establish the tenant context from the event BEFORE resolving handlers — a
-        // MultiTenantDbContext captures its TenantInfo at construction, so a tenant set
-        // after handler resolution would be too late and the tenant query filter would
-        // dereference a null tenant (NRE). Background publishers (outbox dispatcher,
-        // hosted services) carry no ambient tenant, so this is what makes them work.
+        // Set tenant context BEFORE resolving handlers — MultiTenantDbContext captures TenantInfo at
+        // construction, so a late tenant NREs the query filter. This is what makes background publishers work.
         using (_tenantScope.Begin(@event.TenantId))
         {
             using var scope = _serviceProvider.CreateScope();

--- a/src/BuildingBlocks/Eventing/Serialization/JsonEventSerializer.cs
+++ b/src/BuildingBlocks/Eventing/Serialization/JsonEventSerializer.cs
@@ -15,9 +15,8 @@ public sealed class JsonEventSerializer : IEventSerializer
         WriteIndented = false
     };
 
-    // Resolving an event type from its name repeats constantly on the outbox and inbox path, and the
-    // underlying reflection lookup parses the assembly qualified name and scans loaded assemblies each
-    // time, so the resolved result for each distinct name is cached here.
+    // Resolving an event type by name (hot on outbox/inbox) reflectively parses the assembly-qualified
+    // name and scans loaded assemblies each time, so the result per distinct name is cached here.
     private static readonly ConcurrentDictionary<string, Type?> TypeCache = new(StringComparer.Ordinal);
 
     public string Serialize(IIntegrationEvent @event)

--- a/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
@@ -28,10 +28,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IEventSerializer, JsonEventSerializer>();
 
-        // Tenant context for event dispatch. Default is a no-op; the multitenancy
-        // composition replaces this with a Finbuckle-backed scope so background
-        // publishers (outbox dispatcher, hosted services) establish the tenant before
-        // tenant-filtered handler DbContexts are constructed.
+        // Tenant context for event dispatch (no-op default; multitenancy swaps in a Finbuckle scope)
+        // so background publishers establish the tenant before tenant-filtered handler DbContexts build.
         services.TryAddSingleton<IEventTenantScope, NullEventTenantScope>();
 
         // Register event bus based on configured provider

--- a/src/BuildingBlocks/Mailing/Extensions.cs
+++ b/src/BuildingBlocks/Mailing/Extensions.cs
@@ -13,9 +13,8 @@ public static class Extensions
             .BindConfiguration(nameof(MailOptions))
             .ValidateOnStart();
 
-        // One SendGrid client (and its underlying HttpClient) shared process-wide.
-        // Constructing it per-send leaks sockets / exhausts ephemeral ports under load.
-        // The factory is lazy, so the client is only built when SendGrid is actually used.
+        // One SendGrid client (and its HttpClient) shared process-wide — per-send construction leaks
+        // sockets under load. The factory is lazy, so it's only built when SendGrid is actually used.
         services.AddSingleton<ISendGridClient>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<MailOptions>>().Value;

--- a/src/BuildingBlocks/Persistence/Context/BaseDbContext.cs
+++ b/src/BuildingBlocks/Persistence/Context/BaseDbContext.cs
@@ -34,10 +34,8 @@ public class BaseDbContext(IMultiTenantContextAccessor<AppTenantInfo> multiTenan
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.AppendGlobalQueryFilter<ISoftDeletable>(QueryFilters.SoftDelete, s => !s.IsDeleted);
         base.OnModelCreating(modelBuilder);
-        // Default-on tenant isolation: any entity not marked IGlobalEntity gets
-        // IsMultiTenant() applied. Subclasses must call base.OnModelCreating
-        // AFTER their ApplyConfigurationsFromAssembly so per-entity configs
-        // (unique indexes, owned types) are in place when we adjust them.
+        // Default-on tenant isolation: entities not marked IGlobalEntity get IsMultiTenant().
+        // Subclasses must call base.OnModelCreating AFTER ApplyConfigurationsFromAssembly so per-entity configs are in place.
         modelBuilder.ApplyTenantIsolationByDefault();
     }
 

--- a/src/BuildingBlocks/Persistence/Inteceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/BuildingBlocks/Persistence/Inteceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -101,13 +101,8 @@ public sealed class AuditableEntitySaveChangesInterceptor : SaveChangesIntercept
                 entry.Property(nameof(ISoftDeletable.DeletedOnUtc)).CurrentValue = now;
                 entry.Property(nameof(ISoftDeletable.DeletedBy)).CurrentValue = userId;
 
-                // When EF marks the parent for deletion it cascades the
-                // EntityState.Deleted onto every owned reference. Flipping
-                // the parent back to Modified isn't enough — without
-                // restoring the owned references they'd be NULLed out in
-                // the generated UPDATE (we saw this on Product.Price /
-                // Money, where the soft delete produced a NOT NULL
-                // violation on PriceAmount).
+                // A soft-delete cascades Deleted onto owned references; restore them to Unchanged or the
+                // generated UPDATE NULLs their columns (broke Product.Price/Money with a NOT NULL violation).
                 foreach (var reference in entry.References)
                 {
                     if (reference.TargetEntry is { } target

--- a/src/BuildingBlocks/Persistence/Inteceptors/DomainEventsInterceptor.cs
+++ b/src/BuildingBlocks/Persistence/Inteceptors/DomainEventsInterceptor.cs
@@ -68,9 +68,8 @@ public sealed class DomainEventsInterceptor : SaveChangesInterceptor
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // Domain event handler failures must not roll back or fail the already-committed save.
-                // The event was collected after SaveChanges completed — the data is persisted.
-                // Handlers that need guaranteed delivery should use the outbox pattern.
+                // Handler failures must not fail the already-committed save (events collected post-
+                // SaveChanges). Handlers needing guaranteed delivery should use the outbox pattern.
                 _logger.LogError(ex, "Failed to publish domain event {EventType}", domainEvent.GetType().Name);
             }
         }

--- a/src/BuildingBlocks/Persistence/Pagination/PaginationExtensions.cs
+++ b/src/BuildingBlocks/Persistence/Pagination/PaginationExtensions.cs
@@ -43,9 +43,8 @@ public static class PaginationExtensions
             pageSize = MaxPageSize;
         }
 
-        // Pagination is intentionally decoupled from specifications; the incoming
-        // source is expected to already have any required ordering applied via
-        // specifications or explicit ordering at call sites.
+        // Decoupled from specifications: the source is expected to already have any required
+        // ordering applied via specifications or explicit ordering at call sites.
         return ToPagedResponseInternalAsync(source, pageNumber, pageSize, cancellationToken);
     }
 

--- a/src/BuildingBlocks/Persistence/TenantIsolationExtensions.cs
+++ b/src/BuildingBlocks/Persistence/TenantIsolationExtensions.cs
@@ -35,10 +35,8 @@ public static class TenantIsolationExtensions
         {
             if (entityType.IsOwned()) continue;
             if (entityType.ClrType is null) continue;
-            // Skip value-typed sub-models (e.g. ASP.NET 10's IdentityPasskeyData)
-            // that ride along in the EF model but aren't first-class persisted
-            // entities — calling Entity().IsMultiTenant() on them surfaces
-            // "missing primary key" validation errors at design time.
+            // Skip keyless value-typed sub-models (e.g. IdentityPasskeyData) that ride in the EF
+            // model but aren't persisted entities; IsMultiTenant() on them throws "missing primary key".
             if (entityType.FindPrimaryKey() is null) continue;
             if (typeof(IGlobalEntity).IsAssignableFrom(entityType.ClrType)) continue;
             if (entityType.FindAnnotation(FinbuckleMultiTenantAnnotation) is not null) continue;

--- a/src/BuildingBlocks/Storage/Local/LocalStorageService.cs
+++ b/src/BuildingBlocks/Storage/Local/LocalStorageService.cs
@@ -147,9 +147,8 @@ public sealed partial class LocalStorageService : IStorageService
         return FileNameSanitizer().Replace(fileName, "_");
     }
 
-    // Local presigning is a development fallback when Storage:Provider != s3. Production deployments
-    // use S3StorageService. The token store is process-static so the dev middleware (registered in
-    // the host when Provider=local) can consume the token without re-resolving DI scope.
+    // Dev-only presigning fallback when Storage:Provider != s3 (prod uses S3StorageService). Token
+    // store is process-static so the dev middleware can consume the token without re-resolving DI.
     private static LocalPresignTokenStore? _staticTokenStore;
     public static LocalPresignTokenStore SharedTokenStore => LazyInitializer.EnsureInitialized(ref _staticTokenStore);
 
@@ -182,9 +181,8 @@ public sealed partial class LocalStorageService : IStorageService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(storageKey);
         var normalized = storageKey.TrimStart('/').Replace("\\", "/", StringComparison.Ordinal);
-        // Resolved later by the dashboard's API origin (UserProfileService already does this for
-        // legacy avatar paths). Keeping the leading slash lets clients distinguish absolute URLs
-        // from server-relative ones.
+        // Resolved later against the dashboard's API origin (as UserProfileService does for legacy
+        // avatars). The leading slash lets clients distinguish absolute from server-relative URLs.
         return $"/{normalized}";
     }
 

--- a/src/BuildingBlocks/Storage/QuotaMeteredStorageService.cs
+++ b/src/BuildingBlocks/Storage/QuotaMeteredStorageService.cs
@@ -116,9 +116,8 @@ internal sealed class QuotaMeteredStorageService : IStorageService
         }
     }
 
-    // Presigned URL minting + HEAD are pass-throughs — they don't move bytes, so quota isn't touched.
-    // The Files module debits bytes on finalize (when it knows the actual size from HEAD) and refunds
-    // on hard purge (where the existing RemoveAsync path above already debits negative).
+    // Presigned URL minting + HEAD pass through — no bytes move, so quota isn't touched. The Files
+    // module debits on finalize (size from HEAD) and refunds on hard purge (via RemoveAsync above).
     public Task<PresignedUploadUrl> GenerateUploadUrlAsync(string storageKey, string contentType, long maxBytes, TimeSpan ttl, CancellationToken cancellationToken = default)
         => _inner.GenerateUploadUrlAsync(storageKey, contentType, maxBytes, ttl, cancellationToken);
 

--- a/src/BuildingBlocks/Storage/S3/S3StorageService.cs
+++ b/src/BuildingBlocks/Storage/S3/S3StorageService.cs
@@ -340,9 +340,8 @@ internal sealed partial class S3StorageService : IStorageService
         }
     }
 
-    // MinIO and other S3-compatible services commonly serve over plain HTTP. The SDK defaults
-    // presigned URLs to HTTPS regardless of ServiceURL scheme, which makes them un-PUTable in
-    // those environments. Infer the protocol from the configured ServiceURL.
+    // MinIO and other S3-compatibles often serve plain HTTP, but the SDK defaults presigned URLs to
+    // HTTPS regardless of ServiceURL scheme (un-PUTable there). Infer protocol from ServiceURL.
     private Protocol ResolvePresignProtocol()
     {
         if (!string.IsNullOrWhiteSpace(_options.ServiceUrl)

--- a/src/BuildingBlocks/Web/Cors/Extensions.cs
+++ b/src/BuildingBlocks/Web/Cors/Extensions.cs
@@ -37,14 +37,8 @@ public static class Extensions
                     var settings = corsSettings.Value;
                     if (settings.AllowAll)
                     {
-                        // SetIsOriginAllowed(_ => true) is "permissive like AllowAnyOrigin"
-                        // but echoes the specific request origin in the response. The W3C
-                        // CORS spec forbids `Access-Control-Allow-Origin: *` together with
-                        // credentialed requests, and SignalR's negotiate fetch always runs
-                        // in credentials mode (so it can carry cookie auth) — using
-                        // AllowAnyOrigin here breaks SignalR with a CORS error even though
-                        // regular Bearer-token REST works fine. AllowCredentials must be
-                        // paired with a specific origin, hence this pattern.
+                        // Echo the request origin (not `*`): the CORS spec forbids `*` with credentialed requests,
+                        // and SignalR's negotiate always runs credentialed — so AllowCredentials needs a specific origin.
                         builder
                             .SetIsOriginAllowed(_ => true)
                             .AllowAnyHeader()

--- a/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
+++ b/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
@@ -69,12 +69,8 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
         }
         else if (exception is BadHttpRequestException badRequest)
         {
-            // ASP.NET Core throws BadHttpRequestException for malformed requests:
-            // a missing required header/route/query parameter (e.g. the `tenant`
-            // header on tenant-scoped endpoints), an unreadable body, or a body
-            // that exceeds the size limit. These are client errors and the
-            // exception already carries the correct status (usually 400) — honour
-            // it instead of letting it fall through to a generic 500.
+            // BadHttpRequestException = malformed request (missing required header/param, unreadable/oversized body).
+            // Client error carrying the correct status (usually 400) — honour it instead of falling through to a generic 500.
             statusCode = badRequest.StatusCode;
             problemDetails.Status = statusCode;
             problemDetails.Title = "Bad Request";

--- a/src/BuildingBlocks/Web/Extensions.cs
+++ b/src/BuildingBlocks/Web/Extensions.cs
@@ -152,13 +152,8 @@ public static class Extensions
         app.UseExceptionHandler();
         app.UseResponseCompression();
 
-        // CORS MUST run before UseHttpsRedirection. Preflight (OPTIONS) requests cannot follow
-        // redirects per the Fetch spec, so an HTTP→HTTPS redirect on the preflight makes the
-        // browser block the call ("Redirect is not allowed for a preflight request"). Putting
-        // CORS first means the preflight gets its 204 here and the actual request follows the
-        // HTTPS redirect normally afterwards. Safe to run before routing because we use a
-        // single global policy via app.UseCors(name); endpoint-specific [EnableCors] attributes
-        // would need CORS after UseRouting, but none exist in this codebase.
+        // CORS MUST run before UseHttpsRedirection: preflight OPTIONS can't follow an HTTP→HTTPS redirect, so
+        // the browser would block the call. Safe before routing because we use one global policy (no [EnableCors]).
         if (corsEnabled)
         {
             app.UseHeroCors();

--- a/src/BuildingBlocks/Web/Health/HealthEndpoints.cs
+++ b/src/BuildingBlocks/Web/Health/HealthEndpoints.cs
@@ -34,10 +34,8 @@ public static class HealthEndpoints
                 .WithDescription("Reports if the API process is alive. Does not check dependencies.")
                 .Produces<HealthResult>(StatusCodes.Status200OK);
 
-        // Readiness: includes DB (and any other registered checks). Returns the
-        // full payload on both 200 and 503 so dashboards/operators can see *which*
-        // check failed and why. Probe consumers (k8s, load balancers) only key
-        // off the status code, so adding a body on 503 is safe.
+        // Readiness: includes DB + registered checks. Full payload on both 200 and 503 so
+        // operators see which check failed; probe consumers key off status code, so a 503 body is safe.
         group.MapGet("/ready",
                     async (HealthCheckService hc, CancellationToken cancellationToken) =>
                     {

--- a/src/BuildingBlocks/Web/Idempotency/IdempotencyEndpointFilter.cs
+++ b/src/BuildingBlocks/Web/Idempotency/IdempotencyEndpointFilter.cs
@@ -57,9 +57,8 @@ public sealed class IdempotencyEndpointFilter : IEndpointFilter
         var cacheKey = CacheKeys.IdempotencyEntry(tenantId, idempotencyKey);
         var tags = new[] { CacheKeys.Tags.Idempotency, CacheKeys.Tags.Tenant(tenantId) };
 
-        // Probe-only read: IDistributedCache has a real GetAsync that returns null on miss,
-        // unlike HybridCache which requires a factory. We bypass L1 here because idempotency
-        // replays are rare relative to first-calls and L1 warmth has little value.
+        // Probe-only read via IDistributedCache (real GetAsync, null on miss — unlike HybridCache's
+        // factory). Bypasses L1: replays are rare vs first-calls, so L1 warmth has little value.
         var cachedBytes = await distributedCache.GetAsync(cacheKey, httpContext.RequestAborted).ConfigureAwait(false);
         if (cachedBytes is not null && cachedBytes.Length > 0)
         {

--- a/src/BuildingBlocks/Web/OpenApi/Extensions.cs
+++ b/src/BuildingBlocks/Web/OpenApi/Extensions.cs
@@ -29,9 +29,8 @@ public static class Extensions
 
         var fshOptions = configuration.GetSection(nameof(OpenApiOptions)).Get<OpenApiOptions>();
 
-        // Register a separate OpenAPI document per API version.
-        // The GroupNameFormat "'v'VVV" in Asp.Versioning causes endpoints to be grouped as "v1", "v2", etc.
-        // Each AddOpenApi(groupName) call creates a document that only includes endpoints from that group.
+        // One OpenAPI document per API version. Asp.Versioning's GroupNameFormat "'v'VVV" groups
+        // endpoints as "v1", "v2", …; each AddOpenApi(groupName) includes only that group's endpoints.
         var versions = fshOptions?.Versions is { Length: > 0 } ? fshOptions.Versions : ["v1"];
         foreach (var version in versions)
         {

--- a/src/BuildingBlocks/Web/Realtime/AppHub.cs
+++ b/src/BuildingBlocks/Web/Realtime/AppHub.cs
@@ -86,9 +86,8 @@ public sealed class AppHub : Hub
         await Groups.AddToGroupAsync(Context.ConnectionId, $"user:{userId}", Context.ConnectionAborted)
             .ConfigureAwait(false);
 
-        // Join the tenant group — used for cross-tenant scoped broadcasts
-        // (presence) so a 1000-user tenant doesn't broadcast every connect
-        // to other tenants.
+        // Join the tenant group — scopes cross-tenant broadcasts (presence) so a 1000-user
+        // tenant doesn't broadcast every connect to other tenants.
         var tenantId = GetTenantId();
         if (!string.IsNullOrEmpty(tenantId))
         {
@@ -108,8 +107,7 @@ public sealed class AppHub : Hub
 
         AppHubLog.Connected(_logger, Context.ConnectionId, userId, channelIds.Count);
 
-        // Track presence — if this is the user's first open connection,
-        // broadcast PresenceChanged so any interested clients flip the dot.
+        // On the user's first open connection, broadcast PresenceChanged so clients flip the dot.
         // Scoped to the tenant group, not Clients.All, to avoid global fan-out.
         if (_presence.Connect(userId))
         {

--- a/src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj
+++ b/src/Host/FSH.Starter.Api/FSH.Starter.Api.csproj
@@ -10,7 +10,7 @@
 		     ContainerImageTag from $(Version), which collides with ContainerImageTags). -->
 		<ContainerPort>8080</ContainerPort>
 		<ContainerUser>1654</ContainerUser>
-		<ContainerFamily>noble-chiseled</ContainerFamily>
+		<ContainerFamily>noble</ContainerFamily>
 		<ContainerRepository>fsh-api</ContainerRepository>
 	</PropertyGroup>
 

--- a/src/Host/FSH.Starter.Api/Program.cs
+++ b/src/Host/FSH.Starter.Api/Program.cs
@@ -16,12 +16,8 @@ using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Serialize all enums as their string names on the HTTP API (e.g. "Active" not 0).
-// Reading still accepts both names and integers (allowIntegerValues default = true),
-// so request payloads sending either form keep working. Single-value enums become
-// strings; [Flags] enums (AuditTag, BodyCapture) opt back to numeric via their own
-// [JsonConverter(NumericEnumConverter<>)] attribute, since a comma-joined flag string
-// breaks bitwise consumers. Frontends mirror this contract (string unions).
+// Serialize enums as string names (reads still accept names or integers). [Flags] enums (AuditTag, BodyCapture)
+// opt back to numeric via their own NumericEnumConverter since comma-joined flag strings break bitwise consumers. Frontends mirror this as string unions.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
@@ -95,9 +91,8 @@ builder.AddHeroPlatform(o =>
 
 builder.AddModules(moduleAssemblies);
 
-// Demo data (acme, globex, demo users, sample catalog/tickets/chat) is provisioned
-// by the DbMigrator's `seed-demo` verb — not by the API. The API never mutates data
-// on startup. See src/Host/FSH.Starter.DbMigrator/README.md.
+// Demo data is provisioned by the DbMigrator's `seed-demo` verb, not the API — the API never mutates data on startup.
+// See src/Host/FSH.Starter.DbMigrator/README.md.
 
 var app = builder.Build();
 

--- a/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
+++ b/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
@@ -128,9 +128,8 @@ internal sealed class DemoSeeder
                 existing = tenant;
             }
 
-            // Same code path the migrator's `apply` verb already uses per tenant.
-            // Identity initializer creates the tenant admin user; Catalog/Tickets/Chat
-            // initializers are no-ops in the current design.
+            // Same per-tenant path the migrator's apply verb uses. The Identity initializer creates
+            // the tenant admin, while Catalog/Tickets/Chat initializers are no-ops today.
             await tenantService.MigrateTenantAsync(existing, cancellationToken).ConfigureAwait(false);
             await tenantService.SeedTenantAsync(existing, cancellationToken).ConfigureAwait(false);
 
@@ -209,9 +208,8 @@ internal sealed class DemoSeeder
             return;
         }
 
-        // Reuse the existing active subscription's term if there is one (so re-runs don't re-subscribe
-        // — but still backfill a missing invoice for it); otherwise start a fresh subscription aligned
-        // to the tenant's ValidUpto.
+        // Reuse the existing active subscription's term if present so re-runs don't re-subscribe but
+        // still backfill a missing invoice, otherwise start fresh aligned to the tenant's ValidUpto.
         var existing = await billingDb.Subscriptions
             .FirstOrDefaultAsync(s => s.TenantId == demo.Id && s.Status == SubscriptionStatus.Active, cancellationToken)
             .ConfigureAwait(false);
@@ -230,11 +228,8 @@ internal sealed class DemoSeeder
             }
         }
 
-        // Paid plans get an issued term invoice, matching the real CreateTenant flow. Created directly
-        // (no IBillingService) so we don't publish InvoiceIssuedIntegrationEvent — the migrator has no
-        // outbox dispatcher and demo seeding shouldn't fire notifications/emails. Idempotent (keyed on
-        // the invoice number), so it also backfills an already-subscribed tenant. Free plans (term
-        // price 0) get none, exactly like production.
+        // Paid plans get an issued term invoice (like real CreateTenant), written directly so no InvoiceIssuedIntegrationEvent fires
+        // (no outbox dispatcher; seeding mustn't email). Idempotent on invoice number; free plans (term price 0) get none, as in production.
         if (plan.TermPrice > 0m)
         {
             var invoiceNumber = string.Create(
@@ -388,10 +383,8 @@ internal sealed class DemoSeeder
             }
         }
 
-        // Tenant admin (admin@<tenant>.com) was created by IdentityDbInitializer
-        // with the framework default password. Realign so the dev login panel's
-        // advertised credential is truthful for both the tenant admin AND every
-        // demo user.
+        // Tenant admin (admin@<tenant>.com) was created by IdentityDbInitializer with the framework default password.
+        // Realign it to the shared password so the dev login panel's advertised credential is truthful.
         if (!string.IsNullOrWhiteSpace(tenant.AdminEmail))
         {
             var admin = await userManager.FindByEmailAsync(tenant.AdminEmail).ConfigureAwait(false);

--- a/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj
+++ b/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj
@@ -13,7 +13,7 @@
          legacy "DefaultContainer" profile auto-populates ContainerImageTag
          from $(Version), colliding with ContainerImageTags). -->
     <ContainerUser>1654</ContainerUser>
-    <ContainerFamily>noble-chiseled</ContainerFamily>
+    <ContainerFamily>noble</ContainerFamily>
     <ContainerRepository>fsh-db-migrator</ContainerRepository>
 
     <!-- This is an internal operator-facing CLI — no localization, all

--- a/src/Host/FSH.Starter.DbMigrator/MigratorCommand.cs
+++ b/src/Host/FSH.Starter.DbMigrator/MigratorCommand.cs
@@ -24,9 +24,8 @@ internal sealed record MigratorCommand(
         ArgumentNullException.ThrowIfNull(args);
 
         var rawVerb = args.FirstOrDefault(a => !a.StartsWith('-')) ?? "apply";
-        // Canonicalise to one of the known verbs via case-insensitive match.
-        // Using OrdinalIgnoreCase here (CA1308 forbids ToLowerInvariant for
-        // security-sensitive normalisation) keeps the lookup explicit.
+        // Canonicalise to a known verb via OrdinalIgnoreCase match (CA1308 forbids
+        // ToLowerInvariant for security-sensitive normalisation).
         var verb = KnownVerbs.FirstOrDefault(v => string.Equals(v, rawVerb, StringComparison.OrdinalIgnoreCase))
             ?? rawVerb;
 

--- a/src/Host/FSH.Starter.DbMigrator/PostgresMigratorLock.cs
+++ b/src/Host/FSH.Starter.DbMigrator/PostgresMigratorLock.cs
@@ -14,16 +14,12 @@ namespace FSH.Starter.DbMigrator;
 /// </summary>
 internal static partial class PostgresMigratorLock
 {
-    // Arbitrary 64-bit key — distinct enough to spot in pg_locks views, no
-    // semantic meaning beyond "this is the fsh-db-migrator session lock".
-    // Held at the server level, so the database it's issued against doesn't
-    // affect coordination across the whole instance.
+    // Arbitrary 64-bit key (spottable in pg_locks) for the fsh-db-migrator session lock.
+    // Held at server level, so the target database doesn't affect instance-wide coordination.
     private const long MigratorAdvisoryLockKey = unchecked((long)0xFE514EC0_DEB1ADE4UL);
 
-    // Parameterised SQL — pg_advisory_lock / pg_advisory_unlock take a bigint,
-    // and even though the key is a compile-time constant, using a parameter
-    // satisfies CA2100 (review SQL strings for injection risk) without an
-    // analyzer suppression.
+    // Parameterised SQL: the bigint key is constant, but a parameter satisfies
+    // CA2100 (SQL injection review) without an analyzer suppression.
     private const string AcquireSql = "SELECT pg_advisory_lock(@key)";
     private const string ReleaseSql = "SELECT pg_advisory_unlock(@key)";
 
@@ -159,9 +155,8 @@ internal static partial class PostgresMigratorLock
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    // LoggerMessage source-gen — compile-time message templates avoid
-    // CA1873 (eager argument evaluation) and pair cleanly with S6667
-    // (logging in a catch block passes the exception explicitly).
+    // LoggerMessage source-gen: compile-time templates avoid CA1873 (eager arg eval)
+    // and pair cleanly with S6667 (catch-block logging passes the exception explicitly).
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Information,
         Message = "Postgres ready (attempt {Attempt}).")]

--- a/src/Host/FSH.Starter.DbMigrator/Program.cs
+++ b/src/Host/FSH.Starter.DbMigrator/Program.cs
@@ -26,20 +26,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-// ─────────────────────────────────────────────────────────────────────────
-// FSH DbMigrator — one-shot console that brings every database in the
-// solution up to head, optionally seeds, then exits with code 0 on success
-// or 1 on any failure. Runs as a deployment step (not at API startup), so
-// the runtime app can use a reduced-privilege connection string and the
-// migrator runs with elevated DDL perms.
-//
-// Usage:
-//   dotnet run --project src/Host/FSH.Starter.DbMigrator -- apply
-//   dotnet run --project src/Host/FSH.Starter.DbMigrator -- apply --tenant root
-//   dotnet run --project src/Host/FSH.Starter.DbMigrator -- apply --catalog-only
-//   dotnet run --project src/Host/FSH.Starter.DbMigrator -- list-pending
-//   dotnet run --project src/Host/FSH.Starter.DbMigrator -- seed
-// ─────────────────────────────────────────────────────────────────────────
+// FSH DbMigrator — one-shot console that migrates every DB to head, optionally seeds, then exits 0/1.
+// Runs as a deployment step (not at API startup) so it can use an elevated-DDL connection string. Verbs: see MigratorCommand.HelpText.
 
 var cli = MigratorCommand.Parse(args);
 if (cli.Help)
@@ -49,20 +37,13 @@ if (cli.Help)
 }
 var builder = Host.CreateApplicationBuilder(args);
 
-// The migrator loads every module so DbInitializers/seeders resolve, but runs a
-// deliberately reduced service graph (Mailing, Realtime/SignalR, Jobs disabled
-// via AddHeroPlatform below). The default container's build-time validation —
-// auto-on in Development — walks ALL registered descriptors, including request
-// handlers this process never invokes (Chat handlers needing IHubContext,
-// Identity handlers needing IMailService) and throws at startup. Disable it: the
-// migrator only resolves migration/seed services, so full-graph validation is a
-// false positive here. No-op in Production, where it's already off.
+// Disable build-time DI validation: auto-on in Development, it walks ALL descriptors incl. handlers this
+// reduced-graph process never invokes (Chat→IHubContext, Identity→IMailService) and throws — false positive.
 builder.ConfigureContainer(new DefaultServiceProviderFactory(
     new ServiceProviderOptions { ValidateOnBuild = false, ValidateScopes = false }));
 
-// In local development (dotnet run), the working directory is the project folder,
-// but appsettings.json is linked and copied to the output directory.
-// We explicitly load it from AppContext.BaseDirectory so IdentityModule's JwtOptions validate.
+// Under dotnet run the cwd is the project folder but appsettings.json is copied to the output dir,
+// so load it from AppContext.BaseDirectory for IdentityModule's JwtOptions to validate.
 builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: true);
 builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, $"appsettings.{builder.Environment.EnvironmentName}.json"), optional: true);
 
@@ -70,12 +51,8 @@ builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, $"appse
 builder.Configuration.AddEnvironmentVariables();
 builder.Configuration.AddCommandLine(args);
 
-// The migrator loads the Identity module so its seed initializers can run, but
-// the migrator itself never mints JWTs. IdentityModule wires JwtOptions with
-// ValidateOnStart() (rightly so for the API), which trips on the empty
-// SigningKey now in the base appsettings.json. Inject a deterministic, clearly-
-// labelled placeholder ONLY when nothing real is configured — env vars and
-// JSON-supplied keys both win over this. Same treatment for Issuer/Audience.
+// IdentityModule's JwtOptions.ValidateOnStart() trips on the empty SigningKey in base appsettings, but
+// the migrator never mints JWTs. Inject a labelled placeholder only when nothing real is configured.
 if (string.IsNullOrWhiteSpace(builder.Configuration["JwtOptions:SigningKey"]))
 {
     builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -86,9 +63,8 @@ if (string.IsNullOrWhiteSpace(builder.Configuration["JwtOptions:SigningKey"]))
     });
 }
 
-// Fail-fast before option-validation runs at host build time: if the operator
-// forgot to set DatabaseOptions__ConnectionString, give them a single clear
-// line they'll actually read rather than a validation exception stack trace.
+// Fail-fast with one clear line if DatabaseOptions__ConnectionString is unset, rather than letting
+// host-build-time option validation throw a stack trace.
 if (string.IsNullOrWhiteSpace(builder.Configuration["DatabaseOptions:ConnectionString"]))
 {
     await Console.Error.WriteLineAsync(
@@ -142,10 +118,8 @@ var moduleAssemblies = new Assembly[]
     typeof(FSH.Modules.Notifications.NotificationsModule).Assembly,
 };
 
-// Disable every runtime-only concern. Persistence + multitenancy stay enabled
-// so the modules' DbInitializers resolve cleanly. Caching is left on because
-// some modules' constructor wiring touches IDistributedCache; tolerate the
-// in-memory fallback when Redis isn't configured.
+// Disable runtime-only concerns; persistence + multitenancy stay on so DbInitializers resolve. Caching
+// stays on because some modules' ctor wiring touches IDistributedCache (in-memory fallback if no Redis).
 builder.AddHeroPlatform(o =>
 {
     o.EnableOpenTelemetry = false;
@@ -163,28 +137,12 @@ builder.AddHeroPlatform(o =>
 
 builder.AddModules(moduleAssemblies);
 
-// The Multitenancy module's TenantProvisioningService depends on IJobService —
-// Hangfire's IJobService is only registered when EnableJobs is true, which we 
-// don't want in the migrator (Hangfire needs its own schema bootstrap + workers).
-// Provide a throwing no-op so the DI graph resolves; the migration code paths
-// don't enqueue jobs.
+// TenantProvisioningService needs IJobService, but Hangfire's is gated behind EnableJobs (off here).
+// Provide a throwing no-op so the DI graph resolves; the migration code paths don't enqueue jobs.
 builder.Services.AddSingleton<FSH.Framework.Jobs.Services.IJobService, NoOpJobService>();
 
-// Strip every runtime background worker before host.StartAsync() boots them.
-// This is a one-shot migrator: it does all its work via explicit scopes in
-// Steps 0–3 below and depends on no hosted service. Left running, these
-// long-lived workers begin polling/writing the database the instant the host
-// starts — BEFORE Step 1/2 create the tables — and spew 42P01 "relation does
-// not exist" errors against a fresh DB (OutboxDispatcher → OutboxMessages,
-// AuditBackgroundWorker → AuditRecords, SessionCleanup/RolePermissionSync →
-// identity tables, each also resolving tenant.Tenants before it exists).
-// Removing every BackgroundService catches them all — and any future worker —
-// without an ever-growing name denylist; Hangfire's are already gone via
-// EnableJobs=false. We also drop TenantStoreInitializerHostedService (a plain
-// IHostedService, not a BackgroundService) which races the tenant-catalog
-// MigrateAsync. Non-DB framework IHostedServices are intentionally preserved:
-// the options StartupValidator (so ValidateOnStart still runs at StartAsync)
-// and Serilog's flush-on-shutdown service (so log output reaches stdout/stderr).
+// Strip every BackgroundService (+ TenantStoreInitializerHostedService) before StartAsync: left running they
+// poll/write tables BEFORE Step 1/2 create them (42P01). StartupValidator + Serilog flush IHostedServices stay.
 foreach (var descriptor in builder.Services
     .Where(d => d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService)
         && (typeof(Microsoft.Extensions.Hosting.BackgroundService).IsAssignableFrom(d.ImplementationType)
@@ -207,10 +165,7 @@ await host.StartAsync().ConfigureAwait(false);
 try
 {
     // ── Step 0 — wait for the database to come up ────────────────────────
-    // Aspire / Kubernetes cold-starts can leave Postgres still initialising
-    // when the migrator's container is scheduled. Exponential backoff up to
-    // two minutes catches the common 5–30s startup gap; longer outages
-    // surface as a clean TimeoutException + exit code 1.
+    // Postgres may still be initialising on cold-start; exp. backoff (≤2 min), then TimeoutException + exit 1.
     var connectionString = host.Services.GetRequiredService<IConfiguration>()["DatabaseOptions:ConnectionString"]
         ?? throw new InvalidOperationException("DatabaseOptions:ConnectionString is not configured.");
     await Console.Out.WriteLineAsync("[migrator] waiting for postgres…").ConfigureAwait(false);
@@ -218,16 +173,12 @@ try
         .ConfigureAwait(false);
     await Console.Out.WriteLineAsync("[migrator] postgres ready").ConfigureAwait(false);
 
-    // Log the connected role + database so operators catch a misconfigured low-priv
-    // connection string immediately, rather than at the first "permission denied
-    // for schema public" during MigrateAsync.
+    // Log the connected role + database so a misconfigured low-priv connection string surfaces now,
+    // not as "permission denied for schema public" during MigrateAsync.
     await LogConnectionIdentityAsync(connectionString).ConfigureAwait(false);
 
     // ── Step 0b — acquire the advisory lock ──────────────────────────────
-    // Postgres session-level advisory lock. Concurrent migrator runs
-    // (CI-races, ops-vs-Helm-hook overlap, replicas: 2 by accident) block
-    // here until the holder finishes. The lock auto-releases on connection
-    // close, so even a crashed migrator doesn't leave the lock orphaned.
+    // Session-level lock: concurrent runs block here; auto-releases on connection close (no orphan on crash).
     await Console.Out.WriteLineAsync("[migrator] acquiring advisory lock…").ConfigureAwait(false);
     await using var migratorLock = await PostgresMigratorLock
         .AcquireAsync(connectionString, logger, CancellationToken.None)
@@ -235,8 +186,7 @@ try
     await Console.Out.WriteLineAsync("[migrator] advisory lock acquired").ConfigureAwait(false);
 
     // ── Step 1 — tenant catalog ───────────────────────────────────────────
-    // Always applied first because the per-tenant migrator below reads
-    // every tenant out of this database.
+    // Always applied first: the per-tenant migrator below reads every tenant out of this database.
     using (var scope = host.Services.CreateScope())
     {
         var tenantDb = scope.ServiceProvider.GetRequiredService<TenantDbContext>();
@@ -289,8 +239,7 @@ try
     }
 
     // ── Step 2 — per-tenant migrations + (optional) seeds ────────────────
-    // `seed-demo` short-circuits Step 2 because it provisions its own demo tenants
-    // (acme, globex) by running migrate + seed inline against each — handled below.
+    // `seed-demo` short-circuits this: it provisions its own demo tenants inline (Step 3 below).
     if (!cli.CatalogOnly && cli.Command != "seed-demo")
     {
         var tenantStore = host.Services.GetRequiredService<IMultiTenantStore<AppTenantInfo>>();
@@ -335,10 +284,7 @@ try
     }
 
     // ── Step 3 — demo seed (verb: `seed-demo`) ───────────────────────────
-    // Dev-only. Provisions acme + globex tenants with rich demo content
-    // (users, custom roles, catalog, tickets, chat) so a fresh dev DB
-    // comes up feeling lived-in. Hard-fails outside Development to keep
-    // demo data out of staging / prod by accident.
+    // Dev-only: provisions acme + globex with rich demo content; hard-fails outside Development.
     if (cli.Command == "seed-demo")
     {
         var env = host.Services.GetRequiredService<IHostEnvironment>();

--- a/src/Modules/Auditing/Modules.Auditing/AuditingModule.cs
+++ b/src/Modules/Auditing/Modules.Auditing/AuditingModule.cs
@@ -92,9 +92,8 @@ public class AuditingModule : IModule
         group.MapGetExceptionAuditsEndpoint();
         group.MapGetAuditSummaryEndpoint();
 
-        // Schedule the retention purge. The job is a no-op when
-        // AuditRetentionOptions.Enabled is false, so registering
-        // unconditionally is safe — operators flip the switch in config.
+        // Schedule the retention purge. Registering unconditionally is safe — the job is a no-op
+        // when AuditRetentionOptions.Enabled is false; operators flip the switch in config.
         var jobManager = endpoints.ServiceProvider.GetService<IRecurringJobManager>();
         var retentionOpts = endpoints.ServiceProvider.GetService<AuditRetentionOptions>();
         if (jobManager is not null && retentionOpts is not null)

--- a/src/Modules/Auditing/Modules.Auditing/Core/Audit.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Core/Audit.cs
@@ -12,9 +12,8 @@ public static class Audit
     public static IAuditPublisher Publisher { get; private set; } = new NoopPublisher();
     public static IAuditSerializer Serializer { get; private set; } = new SystemTextJsonAuditSerializer();
 
-    // Immutable snapshot swapped atomically by Configure(). Readers (WriteAsync) take a single
-    // volatile read of the reference and enumerate that — never the live, mutating collection —
-    // so reconfiguration can never throw "Collection was modified" mid-enrich.
+    // Immutable snapshot swapped atomically by Configure(). Readers take one volatile read and
+    // enumerate that — never the live collection — so reconfig can't throw "Collection modified".
     private static volatile IAuditEnricher[] _enrichers = [];
 
     public static void Configure(

--- a/src/Modules/Auditing/Modules.Auditing/Core/AuditBackgroundWorker.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Core/AuditBackgroundWorker.cs
@@ -78,9 +78,8 @@ public sealed class AuditBackgroundWorker : BackgroundService
         Task delayTask,
         CancellationToken stoppingToken)
     {
-        // Security lane is drained first so back-pressured publishers
-        // unblock as quickly as possible. Default lane fills the rest of
-        // the batch so a single flush amortizes both lanes' I/O.
+        // Security lane drained first so back-pressured publishers unblock fast, then the
+        // default lane fills the rest so one flush amortizes both lanes' I/O.
         DrainAvailableItems(_publisher.SecurityReader, batch);
         DrainAvailableItems(_publisher.Reader, batch);
 
@@ -90,10 +89,8 @@ public sealed class AuditBackgroundWorker : BackgroundService
             return (true, Task.Delay(_flushInterval, stoppingToken));
         }
 
-        // Wait until either lane has data or the flush interval elapses.
-        // Neither channel is ever closed by the publisher (the only signal
-        // is stoppingToken cancellation, which we catch in ExecuteAsync),
-        // so any non-delay completion means "more data is ready".
+        // Wait until either lane has data or the flush interval elapses. Channels are never
+        // closed (only stoppingToken signals), so any non-delay completion means data is ready.
         var securityWait = _publisher.SecurityReader.WaitToReadAsync(stoppingToken).AsTask();
         var defaultWait = _publisher.Reader.WaitToReadAsync(stoppingToken).AsTask();
         var winner = await Task.WhenAny(securityWait, defaultWait, delayTask);

--- a/src/Modules/Auditing/Modules.Auditing/Core/ChannelAuditPublisher.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Core/ChannelAuditPublisher.cs
@@ -82,10 +82,8 @@ public sealed class ChannelAuditPublisher : IAuditPublisher
             return;
         }
 
-        // Default-lane drop detection: DropOldest never returns false from
-        // TryWrite, so we approximate the drop signal by comparing reader
-        // depth to capacity *before* writing. Slightly racy under multi-
-        // writer load, but the rate is what matters for alarming.
+        // DropOldest never returns false from TryWrite, so approximate drops by comparing
+        // reader depth to capacity before writing — racy under multi-writer, but rate is what matters.
         if (_default.Reader.Count >= _defaultCapacity)
         {
             AuditingTelemetry.Dropped.Add(1, typeTag);

--- a/src/Modules/Auditing/Modules.Auditing/Core/HttpAuditScope.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Core/HttpAuditScope.cs
@@ -67,9 +67,8 @@ public sealed class HttpAuditScope : IAuditScope
 
     public string? Source =>
         _http.HttpContext?.GetEndpoint()?.DisplayName
-        // Background path: the activator names the activity after the job
-        // method (e.g. "MonthlyInvoiceJob.RunAsync"). Use it as a stable
-        // source key when no HTTP endpoint is in scope.
+        // Background path: the activator names the activity after the job method
+        // (e.g. "MonthlyInvoiceJob.RunAsync"); a stable source key when no HTTP endpoint is in scope.
         ?? Activity.Current?.OperationName
         ?? "background";
 

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditById/GetAuditByIdQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditById/GetAuditByIdQueryHandler.cs
@@ -31,9 +31,8 @@ public sealed class GetAuditByIdQueryHandler : IQueryHandler<GetAuditByIdQuery, 
 
         if (record is null)
         {
-            // KeyNotFoundException is mapped to 404 by the global exception handler. Kept (rather
-            // than the framework NotFoundException) because the audit exception-type fixtures and
-            // severity classification key off this concrete type.
+            // KeyNotFoundException maps to 404 globally. Kept (not framework NotFoundException)
+            // because audit exception-type fixtures and severity classification key off this type.
             throw new KeyNotFoundException($"Audit record {query.Id} not found.");
         }
 

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryHandler.cs
@@ -42,10 +42,8 @@ public sealed class GetAuditSummaryQueryHandler : IQueryHandler<GetAuditSummaryQ
 
         var scoped = baseQuery.Where(a => a.OccurredAtUtc >= fromUtc && a.OccurredAtUtc <= toUtc);
 
-        // Four GROUP BYs against the same filtered set. Each one is pushed to
-        // SQL — no in-memory materialization of the audit table. Sequential
-        // because we share the DbContext; switching to parallel needs four
-        // independent contexts (the marginal latency win is rarely worth it).
+        // Four GROUP BYs pushed to SQL against the same filtered set (no materialization).
+        // Sequential because they share the DbContext; parallel would need four contexts.
         var byType = await scoped
             .GroupBy(a => a.EventType)
             .Select(g => new { Key = g.Key, Count = (long)g.Count() })

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
@@ -100,10 +100,8 @@ public sealed class GetAuditsQueryHandler : IQueryHandler<GetAuditsQuery, PagedR
         if (!string.IsNullOrWhiteSpace(query.Search))
         {
             string term = query.Search;
-            // ILIKE on PayloadJson is sequential without a GIN/trigram index.
-            // The composite (TenantId, OccurredAtUtc) index keeps the planner
-            // honest by scoping the scan; pair this with a GIN index on
-            // PayloadJson in production for sub-second search.
+            // ILIKE on PayloadJson is sequential; the (TenantId, OccurredAtUtc) index
+            // scopes the scan — add a GIN index on PayloadJson in prod for fast search.
             audits = audits.Where(a =>
                 (a.PayloadJson != null && EF.Functions.ILike(AsText(a.PayloadJson), $"%{term}%")) ||
                 (a.Source != null && EF.Functions.ILike(a.Source, $"%{term}%")) ||

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryValidator.cs
@@ -14,9 +14,8 @@ public sealed class GetAuditsQueryValidator : AbstractValidator<GetAuditsQuery>
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
             .WithMessage("FromUtc must be less than or equal to ToUtc.");
 
-        // Reject obviously oversized windows up-front so the user sees a 400
-        // instead of a silently-clamped result. The handler still clamps as a
-        // defence in depth (e.g. when only one endpoint is supplied).
+        // Reject oversized windows up-front (user sees a 400, not a silent clamp). The handler
+        // still clamps as defence in depth (e.g. when only one endpoint is supplied).
         RuleFor(q => q)
             .Must(q =>
                 !q.FromUtc.HasValue

--- a/src/Modules/Auditing/Modules.Auditing/Infrastructure/Http/AuditHttpMiddleware.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Infrastructure/Http/AuditHttpMiddleware.cs
@@ -201,12 +201,8 @@ public sealed class AuditHttpMiddleware
             path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
     }
 
-    // Streaming responses (Server-Sent Events, and the SignalR SSE transport) must never be buffered.
-    // The audit path swaps Response.Body for a MemoryStream and only copies it to the real socket once
-    // the handler returns — but a long-lived stream's handler never returns until the client
-    // disconnects, so the browser would receive nothing (no headers, no events) and sit forever on
-    // "connecting". Detect the SSE handshake by its Accept header and pass the request straight
-    // through, untouched. The stream's token/auth requests are short-lived and still audited normally.
+    // Streaming responses (SSE / SignalR SSE) must never be buffered: the audit path buffers Response.Body and flushes
+    // only when the handler returns, but a long-lived stream never returns, so the client would hang. Detect via Accept header and pass through.
     private static bool IsStreamingResponse(HttpContext ctx) =>
         ctx.Request.Headers.Accept.Any(static v =>
             v is not null && v.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));

--- a/src/Modules/Auditing/Modules.Auditing/Infrastructure/Serialization/JsonMaskingService.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Infrastructure/Serialization/JsonMaskingService.cs
@@ -28,9 +28,8 @@ public sealed class JsonMaskingService : IAuditMaskingService
             int maskedCount = 0;
             MaskNode(json, ref maskedCount);
 
-            // No fields matched — return the original reference so callers can
-            // skip the AuditTag.PiiMasked tag and avoid an extra serialization
-            // hop in the sink.
+            // No fields matched — return the original reference so callers skip the
+            // AuditTag.PiiMasked tag and the extra serialization hop in the sink.
             return maskedCount == 0
                 ? new MaskingResult(payload, 0)
                 : new MaskingResult(json, maskedCount);

--- a/src/Modules/Auditing/Modules.Auditing/Persistence/AuditDbContext.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/AuditDbContext.cs
@@ -27,17 +27,14 @@ public sealed class AuditDbContext : BaseDbContext
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
-        // Required for the trigram GIN indexes on Source / UserName. The
-        // extension is idempotent (CREATE EXTENSION IF NOT EXISTS) — the
-        // role running migrations needs CREATE permission on the database.
+        // Required for the trigram GIN indexes on Source/UserName. Idempotent (IF NOT EXISTS); the
+        // migration role needs CREATE permission on the database.
         modelBuilder.HasPostgresExtension("pg_trgm");
 
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AuditDbContext).Assembly);
 
-        // Map AuditJsonbFunctions.AsText(string) to a SQL `CAST(x AS text)` so the
-        // jsonb PayloadJson column can be searched with text operators (ILIKE).
-        // Without the cast, ILIKE on a jsonb column throws at execution:
-        // "function pg_catalog.like_escape(jsonb, unknown) does not exist" → HTTP 500.
+        // Map AuditJsonbFunctions.AsText to `CAST(x AS text)` so jsonb PayloadJson is ILIKE-searchable.
+        // Without the cast, ILIKE on jsonb throws ("like_escape(jsonb, unknown) does not exist") → HTTP 500.
         var textMapping = this.GetService<IRelationalTypeMappingSource>().FindMapping(typeof(string))!;
         var asTextMethod = typeof(AuditJsonbFunctions)
             .GetMethod(nameof(AuditJsonbFunctions.AsText), BindingFlags.Public | BindingFlags.Static)!;

--- a/src/Modules/Auditing/Modules.Auditing/Persistence/AuditRecordConfiguration.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/AuditRecordConfiguration.cs
@@ -17,33 +17,27 @@ public class AuditRecordConfiguration : IEntityTypeConfiguration<AuditRecord>
         builder.Property(x => x.Tags).HasConversion<long>();
         builder.Property(x => x.PayloadJson).HasColumnType("jsonb");
 
-        // ── Hot-path indexes ─────────────────────────────────────────────
-        // The default audits list query filters on TenantId (via Finbuckle)
-        // and orders by OccurredAtUtc DESC. A composite index that matches
-        // both predicates lets PostgreSQL serve the paged top-N from an
-        // index-only walk.
+        // Hot-path index: default audits list filters on TenantId (Finbuckle) and orders by OccurredAtUtc DESC.
+        // A composite over both lets PostgreSQL serve the paged top-N from an index-only walk.
         builder.HasIndex(x => new { x.TenantId, x.OccurredAtUtc })
             .IsDescending(false, true)
             .HasDatabaseName("IX_AuditRecords_Tenant_OccurredAt");
 
-        // Common dashboard slice: filter by EventType inside a tenant, ordered
-        // by time. Beats falling back to the (TenantId, OccurredAtUtc) index
-        // when EventType is selective (e.g. only Security events).
+        // Common dashboard slice: EventType within a tenant, ordered by time. Beats the
+        // (TenantId, OccurredAtUtc) index when EventType is selective (e.g. only Security events).
         builder.HasIndex(x => new { x.TenantId, x.EventType, x.OccurredAtUtc })
             .IsDescending(false, false, true)
             .HasDatabaseName("IX_AuditRecords_Tenant_EventType_OccurredAt");
 
-        // Trace/correlation lookups for "show me everything tied to this
-        // request". Both columns are sparse so a single-column index is
-        // cheap and frequently selective.
+        // Trace/correlation lookups ("everything tied to this request"). Both columns are sparse,
+        // so single-column indexes are cheap and frequently selective.
         builder.HasIndex(x => x.CorrelationId)
             .HasDatabaseName("IX_AuditRecords_CorrelationId");
         builder.HasIndex(x => x.TraceId)
             .HasDatabaseName("IX_AuditRecords_TraceId");
 
-        // Free-text-ish search on Source / UserName via ILIKE. pg_trgm GIN
-        // indexes turn `%term%` from a sequential scan into an index probe.
-        // The pg_trgm extension is created at the context level.
+        // ILIKE search on Source / UserName: pg_trgm GIN indexes turn `%term%` from a seq scan into a probe.
+        // (pg_trgm extension is created at the context level.)
         builder.HasIndex(x => x.Source)
             .HasMethod("gin")
             .HasOperators("gin_trgm_ops")
@@ -53,11 +47,8 @@ public class AuditRecordConfiguration : IEntityTypeConfiguration<AuditRecord>
             .HasOperators("gin_trgm_ops")
             .HasDatabaseName("IX_AuditRecords_UserName_trgm");
 
-        // GIN over the jsonb payload using jsonb_path_ops — supports the
-        // containment operators (@>, ?) at a fraction of the disk footprint
-        // of the default jsonb_ops. ILIKE on the raw JSON text still does a
-        // sequential scan; for that we recommend extracting indexed columns
-        // (Source, UserName) or denormalizing search-relevant fields.
+        // GIN over jsonb via jsonb_path_ops: supports containment (@>, ?) at far less disk than default jsonb_ops.
+        // ILIKE on raw JSON text still seq-scans — extract indexed columns (Source, UserName) or denormalize for that.
         builder.HasIndex(x => x.PayloadJson)
             .HasMethod("gin")
             .HasOperators("jsonb_path_ops")

--- a/src/Modules/Auditing/Modules.Auditing/Persistence/AuditingSaveChangesInterceptor.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/AuditingSaveChangesInterceptor.cs
@@ -27,9 +27,8 @@ public sealed class AuditingSaveChangesInterceptor : SaveChangesInterceptor
         var ctx = eventData.Context;
         if (ctx is null) return result;
 
-        // Never audit the audit store's own writes — it would recurse: each flush would
-        // capture the AuditRecord inserts, whose PayloadJson embeds the prior PayloadJson,
-        // growing exponentially until System.Text.Json rejects the payload.
+        // Never audit the audit store's own writes — it recurses (each flush captures AuditRecord
+        // inserts whose PayloadJson embeds the prior), growing until System.Text.Json rejects it.
         if (ctx is AuditDbContext) return result;
 
         var entries = ctx.ChangeTracker.Entries()

--- a/src/Modules/Auditing/Modules.Auditing/Persistence/FileAuditDlqSink.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Persistence/FileAuditDlqSink.cs
@@ -82,9 +82,8 @@ public sealed class FileAuditDlqSink : IAuditDlqSink, IDisposable
         }
         catch (Exception ex)
         {
-            // The DLQ is the last line of defence — if it fails too, all we
-            // can do is shout into the logs. Don't rethrow; the worker has
-            // nowhere to escalate.
+            // DLQ is the last line of defence. If it fails too, just log and do not rethrow —
+            // the worker has nowhere to escalate.
             _log.LogError(ex, "Audit DLQ write failed; {Count} events lost.", batch.Count);
         }
     }

--- a/src/Modules/Billing/Modules.Billing.Contracts/BillingEnums.cs
+++ b/src/Modules/Billing/Modules.Billing.Contracts/BillingEnums.cs
@@ -30,9 +30,8 @@ public enum PlanInterval
 
 public enum InvoicePurpose
 {
-    // Usage is 0 (the CLR default) so it doubles as the column default: existing rows backfill to
-    // Usage, and a Subscription invoice (1) is always written explicitly. Do NOT reorder — making
-    // Subscription 0 reintroduces the EF "CLR-default value is omitted, DB default wins" bug.
+    // Usage=0 doubles as the column default (rows backfill to Usage; Subscription=1 always written
+    // explicitly). Do NOT reorder — making Subscription 0 reintroduces the EF default-omitted bug.
     Usage = 0,
     Subscription = 1
 }

--- a/src/Modules/Billing/Modules.Billing/Data/BillingDbInitializer.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/BillingDbInitializer.cs
@@ -21,9 +21,8 @@ public sealed class BillingDbInitializer(
 
     public async Task SeedAsync(CancellationToken cancellationToken)
     {
-        // Plans are a global catalogue (IGlobalEntity). Seed the defaults once — the "free" plan backs
-        // the trial fallback used when a tenant is created without an explicit plan. Keys align with
-        // QuotaOptions plan keys so quota limits resolve.
+        // Plans are a global catalogue (IGlobalEntity); seed defaults once. "free" backs the trial
+        // fallback; keys align with QuotaOptions plan keys so quota limits resolve.
         if (await dbContext.Plans.AnyAsync(cancellationToken).ConfigureAwait(false))
         {
             return;

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
@@ -18,10 +18,8 @@ public sealed class GetInvoiceByIdQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        // BillingDbContext is not tenant-filtered (it extends raw DbContext for cross-tenant admin
-        // visibility). The root operator may read ANY invoice by id (the admin app lists invoices
-        // across every tenant and drills into them); a tenant caller is pinned to its own tenant so
-        // it can't read another tenant's invoice by guessing the id. Mirrors GetSubscriptionQueryHandler.
+        // BillingDbContext isn't tenant-filtered (raw DbContext for cross-tenant admin visibility): root
+        // reads any invoice by id; a tenant caller is pinned to its own so it can't read another's. Mirrors GetSubscriptionQueryHandler.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
             ?? throw new UnauthorizedException("Tenant context is required.");
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
@@ -18,9 +18,8 @@ public sealed class GetInvoicePdfQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        // BillingDbContext is not tenant-filtered (mirrors GetInvoiceById): the root operator may
-        // download ANY tenant's invoice PDF (admin drills into invoices across every tenant); a tenant
-        // caller is pinned to its own tenant so a cross-tenant id resolves to 404, never leaking a PDF.
+        // BillingDbContext is not tenant-filtered: root may download ANY tenant's invoice PDF; a tenant
+        // caller is pinned to its own, so a cross-tenant id resolves to 404 and never leaks a PDF.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
             ?? throw new UnauthorizedException("Tenant context is required.");
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoices/GetInvoicesQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoices/GetInvoicesQueryHandler.cs
@@ -19,9 +19,8 @@ public sealed class GetInvoicesQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        // BillingDbContext is not tenant-filtered. Only the root operator gets the cross-tenant view
-        // (optionally narrowed to one tenant via query.TenantId); any other caller — even with the
-        // IsBasic Billing.View permission — is forced to its own tenant, so it can't list across tenants.
+        // BillingDbContext is not tenant-filtered: only root gets the cross-tenant view (optionally
+        // narrowed via query.TenantId); every other caller is forced to its own tenant.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
             ?? throw new UnauthorizedException("Tenant context is required.");
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/AssignSubscription/AssignSubscriptionCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/AssignSubscription/AssignSubscriptionCommandHandler.cs
@@ -18,9 +18,8 @@ public sealed class AssignSubscriptionCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Only the root operator may assign a subscription to an arbitrary tenant. A tenant caller is
-        // pinned to its own tenant, so it can't (re)assign or cancel another tenant's subscription by
-        // passing a foreign tenant id in the body.
+        // Only root may target an arbitrary tenant; a tenant caller is pinned to its own, so it can't
+        // (re)assign or cancel another tenant's subscription via a foreign tenant id in the body.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
             ?? throw new UnauthorizedException("Tenant context is required.");
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/GetSubscription/GetSubscriptionQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/GetSubscription/GetSubscriptionQueryHandler.cs
@@ -21,9 +21,8 @@ public sealed class GetSubscriptionQueryHandler(
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
             ?? throw new UnauthorizedException("Tenant context is required.");
 
-        // BillingDbContext is not tenant-filtered. A tenant caller may only read its OWN
-        // subscription; only the root operator may pass an arbitrary tenant id. Without this guard
-        // any tenant could read another tenant's subscription by passing its id.
+        // BillingDbContext is not tenant-filtered, so a tenant caller is pinned to its OWN
+        // subscription and only root may pass an arbitrary tenant id (else cross-tenant reads).
         var tenantId = callerTenantId == MultitenancyConstants.Root.Id
             ? query.TenantId ?? callerTenantId
             : callerTenantId;

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -48,10 +48,8 @@ public sealed class BillingService : IBillingService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
 
-        // Scope idempotency to the Usage invoice only. The unique index is
-        // (TenantId, PeriodYear, PeriodMonth, Purpose), so a Subscription invoice can legitimately
-        // share the month — without the Purpose filter the existence check would find that
-        // subscription invoice and skip generating the usage/overage invoice (unbilled overage).
+        // Scope the idempotency check to Purpose==Usage: a Subscription invoice may legitimately share
+        // the month, and without this filter we'd match it and skip the usage/overage invoice (unbilled overage).
         var existing = await _db.Invoices
             .FirstOrDefaultAsync(i => i.TenantId == tenantId && i.PeriodYear == periodYear && i.PeriodMonth == periodMonth
                 && i.Purpose == InvoicePurpose.Usage, cancellationToken)
@@ -180,9 +178,8 @@ public sealed class BillingService : IBillingService
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    // Issue/MarkPaid/Void load through here. BillingDbContext is not tenant-filtered, so scope to the
-    // caller: the root operator may mutate any tenant's invoice; a tenant caller is pinned to its own,
-    // so a cross-tenant id resolves to 404 (mirrors GetInvoiceByIdQueryHandler) and can't be mutated.
+    // Issue/MarkPaid/Void load here. BillingDbContext isn't tenant-filtered, so scope to caller: root
+    // mutates any invoice; a tenant caller is pinned to its own (cross-tenant id → 404, can't mutate).
     private async Task<Invoice> LoadInvoiceAsync(Guid invoiceId, CancellationToken cancellationToken)
     {
         var callerTenantId = _tenantAccessor.MultiTenantContext?.TenantInfo?.Id
@@ -273,9 +270,8 @@ public sealed class BillingService : IBillingService
     private static string BuildSubscriptionInvoiceNumber(string tenantId, DateTime periodStartUtc) =>
         $"SUB-{periodStartUtc:yyyyMM}-{TenantToken(tenantId)}";
 
-    // A stable, collision-resistant token from the full tenant id. A naive prefix truncation collides
-    // for tenants sharing a prefix (e.g. "billing-a", "billing-b"), which would clash on the unique
-    // InvoiceNumber index when the monthly job invoices many tenants for the same period.
+    // Stable, collision-resistant token from the full tenant id; a naive prefix truncation would
+    // collide for shared-prefix tenants and clash on the unique InvoiceNumber index.
     private static string TenantToken(string tenantId)
     {
         var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(tenantId));

--- a/src/Modules/Catalog/Modules.Catalog/Data/CatalogSeedData.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Data/CatalogSeedData.cs
@@ -10,10 +10,8 @@ namespace FSH.Modules.Catalog.Data;
 /// </summary>
 public static class CatalogSeedData
 {
-    // Method (not static property) so each tenant gets fresh Brand instances
-    // with new Ids — Brand.Create generates Guid.CreateVersion7() at construction
-    // time. A shared static list would have the same Ids across tenants and PK-
-    // violate on the second tenant's seed.
+    // Method (not static property) so each tenant gets fresh Brands with new Ids (Brand.Create mints
+    // a Guid per call); a shared static list would reuse Ids and PK-violate on the second tenant's seed.
     public static IReadOnlyList<Brand> BuildBrands() =>
     [
         Brand.Create("Acme Goods",      "Quality essentials for the modern home.",            null),

--- a/src/Modules/Catalog/Modules.Catalog/Data/Configurations/ProductConfiguration.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Data/Configurations/ProductConfiguration.cs
@@ -11,10 +11,8 @@ public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
         ArgumentNullException.ThrowIfNull(builder);
         builder.ToTable("Products");
         builder.HasKey(x => x.Id);
-        // Tenant isolation: applied automatically by BaseDbContext.OnModelCreating
-        // → ApplyTenantIsolationByDefault. The shadow TenantId column makes Sku/Slug
-        // unique-per-tenant (via AdjustUniqueIndexes), so two tenants can each have
-        // SKU "ABC-001" without colliding. Opt out by implementing IGlobalEntity.
+        // Tenant isolation auto-applied by BaseDbContext; the shadow TenantId column makes Sku/Slug
+        // unique-per-tenant, so two tenants can share "ABC-001". Opt out via IGlobalEntity.
 
         builder.Property(x => x.Sku).IsRequired().HasMaxLength(64);
         builder.HasIndex(x => x.Sku).IsUnique().HasFilter("\"IsDeleted\" = FALSE");

--- a/src/Modules/Catalog/Modules.Catalog/Data/Configurations/ProductImageConfiguration.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Data/Configurations/ProductImageConfiguration.cs
@@ -12,10 +12,8 @@ public sealed class ProductImageConfiguration : IEntityTypeConfiguration<Product
         builder.ToTable("ProductImages");
         builder.HasKey(x => x.Id);
 
-        // The application sets Id via Guid.CreateVersion7() in ProductImage.Create. Without this,
-        // EF's default ValueGeneratedOnAdd treats the non-default Guid as "already persisted"
-        // when the entity is reached through a tracked parent's nav collection, so SaveChanges
-        // emits an UPDATE that affects 0 rows → DbUpdateConcurrencyException.
+        // Id is app-assigned (Guid.CreateVersion7). Without ValueGeneratedNever, EF treats the non-default
+        // Guid reached via a tracked parent's nav collection as persisted → UPDATE-0-rows → concurrency ex.
         builder.Property(x => x.Id).ValueGeneratedNever();
 
         builder.Property(x => x.ProductId).IsRequired();
@@ -27,18 +25,8 @@ public sealed class ProductImageConfiguration : IEntityTypeConfiguration<Product
         builder.Property(x => x.SortOrder).IsRequired();
         builder.Property(x => x.CreatedAtUtc).IsRequired();
 
-        // Non-unique index for cheap product-scoped lookups (e.g. cascade delete, queries that
-        // pull all images for a product).
-        //
-        // We intentionally do NOT add a partial UNIQUE INDEX on (ProductId) WHERE IsThumbnail=TRUE
-        // to enforce "single thumbnail per product". Such an index check is per-statement in
-        // Postgres (partial unique indexes can't be DEFERRABLE), and Product.SetThumbnail emits
-        // two UPDATEs in a single SaveChanges — demote-old + promote-new — whose order EF can
-        // pick freely. If EF emits promote-first, the intermediate state has two thumbnails and
-        // the constraint fires. The single-thumbnail invariant is enforced by the aggregate
-        // itself: AddImage promotes only when no images exist, SetThumbnail clears the flag on
-        // every other image via a foreach, RemoveImage auto-promotes the next lowest-sorted
-        // image when the cover is removed.
+        // Non-unique index for cheap product-scoped lookups. No partial UNIQUE on (ProductId) WHERE IsThumbnail:
+        // it can't be DEFERRABLE and fires mid-statement on SetThumbnail; the aggregate enforces single-thumbnail.
         builder.HasIndex(x => x.ProductId);
     }
 }

--- a/src/Modules/Catalog/Modules.Catalog/Domain/Brand.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Domain/Brand.cs
@@ -11,10 +11,8 @@ public sealed class Brand : AggregateRoot<Guid>, ISoftDeletable
     public DateTime CreatedAtUtc { get; private set; }
     public DateTime? UpdatedAtUtc { get; private set; }
 
-    // Soft-delete metadata. Populated by AuditableEntitySaveChangesInterceptor
-    // when the row is removed via dbContext.Remove(); a global query filter
-    // on BaseDbContext hides deleted rows from normal queries (use
-    // IgnoreQueryFilters() to include them in trash views).
+    // Soft-delete metadata, set by AuditableEntitySaveChangesInterceptor on dbContext.Remove(). A
+    // BaseDbContext global query filter hides deleted rows; use IgnoreQueryFilters() for trash views.
     public bool IsDeleted { get; private set; }
     public DateTimeOffset? DeletedOnUtc { get; private set; }
     public string? DeletedBy { get; private set; }

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/ListTrashedBrands/ListTrashedBrandsQueryHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/ListTrashedBrands/ListTrashedBrandsQueryHandler.cs
@@ -19,9 +19,8 @@ public sealed class ListTrashedBrandsQueryHandler(CatalogDbContext dbContext)
         int page = query.PageNumber < 1 ? 1 : query.PageNumber;
         int size = query.PageSize is < 1 or > 200 ? 20 : query.PageSize;
 
-        // Bypasses ONLY the soft-delete filter; tenant scoping (Finbuckle) stays
-        // in force, so a tenant only sees its own trashed rows.
-        // Most-recently-deleted first.
+        // Bypasses ONLY the soft-delete filter; Finbuckle tenant scoping stays in force, so a
+        // tenant sees only its own trashed rows. Most-recently-deleted first.
         var q = dbContext.Brands
             .AsNoTracking()
             .IgnoreQueryFilters([QueryFilters.SoftDelete])

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/SearchBrands/SearchBrandsQueryHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/SearchBrands/SearchBrandsQueryHandler.cs
@@ -49,9 +49,8 @@ public sealed class SearchBrandsQueryHandler(CatalogDbContext dbContext)
         };
     }
 
-    // Whitelist + safe default. Unknown columns or directions fall back to
-    // (name asc) so callers can never trigger a server error or leak the
-    // entity shape via reflection-style sort keys.
+    // Whitelist + safe default: unknown columns/directions fall back to (name asc) so callers
+    // can't trigger a server error or probe the entity shape via reflection-style sort keys.
     private static IQueryable<Brand> ApplySort(IQueryable<Brand> q, string? sortBy, string? sortDir)
     {
         bool desc = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
@@ -13,12 +13,8 @@ public sealed class DeleteProductCommandHandler(CatalogDbContext dbContext)
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // IgnoreAutoIncludes is load-bearing: Product.Images is AutoInclude'd and cascade-deleted.
-        // If we let the images load here, Remove() cascades EntityState.Deleted onto them, and the
-        // soft-delete interceptor only rescues owned references (Price/Money) — not this non-owned
-        // child collection — so EF would HARD-delete the image rows while the product is merely
-        // soft-deleted. Restoring the product would then come back with no images. Leaving the images
-        // untracked means the soft delete is a pure UPDATE and the image rows survive for restore.
+        // IgnoreAutoIncludes is load-bearing: if Product.Images (AutoInclude'd) load here, Remove() cascades Deleted onto them
+        // and the soft-delete interceptor (rescues only owned refs) HARD-deletes them. Untracked keeps the delete a pure UPDATE so rows survive restore.
         var product = await dbContext.Products
             .IgnoreAutoIncludes()
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)

--- a/src/Modules/Chat/Modules.Chat/ChatModule.cs
+++ b/src/Modules/Chat/Modules.Chat/ChatModule.cs
@@ -64,9 +64,8 @@ public sealed class ChatModule : IModule
         // directory stays the single source of truth.
         builder.Services.AddScoped<IMentionResolver, MentionResolver>();
 
-        // File attachments for chat messages — channel members can attach + read; only the
-        // uploader can delete. Registered as IFileAccessPolicy so the Files module's
-        // RequestUploadUrl + finalize + read-URL endpoints route through it for OwnerType=ChatChannel.
+        // File attachments: members attach+read, only the uploader deletes. Registered as
+        // IFileAccessPolicy so Files endpoints route through it for OwnerType=ChatChannel.
         builder.Services.AddScoped<FSH.Modules.Files.Contracts.IFileAccessPolicy, Authorization.ChatChannelFileAccessPolicy>();
 
         builder.Services.AddHealthChecks().AddDbContextCheck<ChatDbContext>(

--- a/src/Modules/Chat/Modules.Chat/Data/Configurations/ChatChannelConfiguration.cs
+++ b/src/Modules/Chat/Modules.Chat/Data/Configurations/ChatChannelConfiguration.cs
@@ -11,9 +11,8 @@ public sealed class ChatChannelConfiguration : IEntityTypeConfiguration<ChatChan
         ArgumentNullException.ThrowIfNull(builder);
         builder.ToTable("Channels");
         builder.HasKey(x => x.Id);
-        // App-generated Guid v7 — per project_ef_value_generation_for_nav_children, the
-        // child Members nav collection requires this on its own Id; doing it on the
-        // aggregate too is harmless and consistent.
+        // App-generated Guid v7. The child Members nav collection requires ValueGeneratedNever on its
+        // own Id; setting it on the aggregate too is harmless and consistent.
         builder.Property(x => x.Id).ValueGeneratedNever();
 
         builder.Property(x => x.Type).IsRequired().HasConversion<int>();

--- a/src/Modules/Chat/Modules.Chat/Domain/Message.cs
+++ b/src/Modules/Chat/Modules.Chat/Domain/Message.cs
@@ -45,9 +45,8 @@ public sealed class Message : AggregateRoot<Guid>
             throw new ArgumentException("ChannelId is required.", nameof(channelId));
         }
 
-        // Body is optional at the aggregate level — the SendMessage validator
-        // enforces "body OR at least one attachment" since attachments attach
-        // AFTER Create via AddAttachment.
+        // Body is optional here; the SendMessage validator enforces "body OR >=1 attachment"
+        // (attachments attach AFTER Create via AddAttachment).
         var trimmed = string.IsNullOrWhiteSpace(body) ? null : body.Trim();
 
         var m = new Message

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/AddChannelMembers/AddChannelMembersCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/AddChannelMembers/AddChannelMembersCommandHandler.cs
@@ -48,9 +48,8 @@ public sealed class AddChannelMembersCommandHandler(
 
         foreach (var uid in newlyAdded)
         {
-            // Notify existing members. The new member doesn't have any active connections in
-            // the channel:{id} group yet — they'll pick the channel up on their next reconnect
-            // (OnConnectedAsync pre-joins all of their channels).
+            // Notify existing members. The new member isn't in the channel:{id} group yet; they pick
+            // it up on next reconnect (OnConnectedAsync pre-joins all their channels).
             await hub.Clients.Group($"channel:{channel.Id}")
                 .SendAsync("ChatChannelMemberAdded", new { channelId = channel.Id, userId = uid }, cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
@@ -33,9 +33,8 @@ public sealed class ListMyChannelsQueryHandler(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Single round-trip: for each channel in the page, count this user's unread messages with a
-        // correlated subquery instead of issuing one CountAsync per channel (was N+1, up to 200 round-trips).
-        // Same shape as SearchTicketsQueryHandler's CommentCount subquery.
+        // Single round-trip: count each channel's unread messages via a correlated subquery instead of
+        // one CountAsync per channel (was N+1, up to 200 round-trips).
         var channelIds = channels.Select(c => c.Id).ToList();
         var unread = await db.Channels.AsNoTracking()
             .Where(c => channelIds.Contains(c.Id))

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/MarkChannelRead/MarkChannelReadCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/MarkChannelRead/MarkChannelReadCommandHandler.cs
@@ -44,10 +44,8 @@ public sealed class MarkChannelReadCommandHandler(
                 cancellationToken)
             .ConfigureAwait(false);
 
-        // Push to the channel group so other members can update read receipts
-        // on their own latest-sent message in real time. The reader's own
-        // connections also get this broadcast (in addition to the user-scoped
-        // one above) — the client handler is idempotent so this is harmless.
+        // Push to the channel group so members update read receipts in real time. The reader's own
+        // connections also receive this (alongside the user-scoped push); the client handler is idempotent.
         await hub.Clients.Group($"channel:{cmd.ChannelId}")
             .SendAsync("ChatChannelMemberRead",
                 new { channelId = cmd.ChannelId, userId = currentUserId, lastReadMessageId = cmd.MessageId },

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
@@ -55,10 +55,8 @@ public sealed class SendMessageCommandHandler(
             }
         }
 
-        // Parse @username tokens and resolve to user ids. Self-mentions and unresolved tokens are
-        // dropped silently — the body text still shows the @ as written. Only mentions that resolve
-        // to a real *other* user attach as MessageMention rows + trigger an integration event.
-        // Body may be null/empty for attachment-only sends.
+        // Parse @username tokens to user ids; self-mentions and unresolved tokens are dropped silently.
+        // Only resolved *other* users attach as MessageMention rows + fire an event. Body may be empty.
         var rawMatches = MentionParser.Parse(cmd.Body ?? string.Empty);
         var distinctNames = rawMatches.Select(m => m.Username)
             .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandValidator.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandValidator.cs
@@ -8,10 +8,8 @@ public sealed class SendMessageCommandValidator : AbstractValidator<SendMessageC
     public SendMessageCommandValidator()
     {
         RuleFor(x => x.ChannelId).NotEmpty();
-        // Body is optional when at least one attachment is present (Slack /
-        // Teams parity — users frequently send "here's the file" with no
-        // accompanying text). Length cap still applies whenever body is
-        // populated.
+        // Body is optional when an attachment is present (Slack/Teams parity — "here's the file" with
+        // no text). Length cap still applies whenever body is populated.
         RuleFor(x => x.Body)
             .NotEmpty()
             .When(x => x.Attachments is null || x.Attachments.Count == 0)

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
@@ -29,9 +29,8 @@ public sealed class SearchMessagesQueryHandler(
         int page = Math.Max(1, query.Page);
         int pageSize = Math.Clamp(query.PageSize, 1, 100);
 
-        // Channel scoping: collect the channel ids the caller is a member of (and, if a specific
-        // channel was requested, intersect with that). We then filter the search to those ids —
-        // this is the leakage guard, so cross-channel search results never reach non-members.
+        // Leakage guard: scope the search to channels the caller is a member of (intersected with the
+        // requested channel if any) so cross-channel results never reach non-members.
         IQueryable<Guid> memberChannelIds = db.Channels.AsNoTracking()
             .Where(c => c.Members.Any(m => m.UserId == currentUserId))
             .Select(c => c.Id);
@@ -47,9 +46,8 @@ public sealed class SearchMessagesQueryHandler(
             return new List<MessageDto>().AsReadOnly();
         }
 
-        // FormattedString interpolation is parameterized — `to_tsquery` gets a sanitized literal,
-        // not raw SQL. Use `websearch_to_tsquery` so the caller can write natural search syntax
-        // (quoted phrases, OR, -exclude) without us pre-processing it.
+        // Interpolation is parameterized (sanitized literal, not raw SQL); websearch_to_tsquery lets
+        // callers use natural syntax (quoted phrases, OR, -exclude) with no pre-processing.
         int offset = (page - 1) * pageSize;
         FormattableString sql = $@"
 SELECT m.*

--- a/src/Modules/Files/Modules.Files/Data/Configurations/FileAssetConfiguration.cs
+++ b/src/Modules/Files/Modules.Files/Data/Configurations/FileAssetConfiguration.cs
@@ -30,9 +30,8 @@ public sealed class FileAssetConfiguration : IEntityTypeConfiguration<FileAsset>
         builder.Property(x => x.DeletedOnUtc);
         builder.Property(x => x.DeletedBy).HasMaxLength(64);
 
-        // (TenantId, OwnerType, OwnerId) would be the natural index in a row-level multitenancy
-        // model. Here we use schema-per-tenant via the framework's BaseDbContext, so the per-tenant
-        // narrowing is implicit and we only need an Owner index.
+        // Schema-per-tenant (BaseDbContext) makes per-tenant narrowing implicit, so only an
+        // Owner index is needed (not the row-level (TenantId, OwnerType, OwnerId)).
         builder.HasIndex(x => new { x.OwnerType, x.OwnerId })
             .HasDatabaseName("IX_FileAsset_Owner");
         builder.HasIndex(x => x.Status)

--- a/src/Modules/Files/Modules.Files/Features/v1/DeleteFile/DeleteFileCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/DeleteFile/DeleteFileCommandHandler.cs
@@ -33,9 +33,8 @@ public sealed class DeleteFileCommandHandler(
             throw new ForbiddenException("not allowed to delete this file");
         }
 
-        // Soft-delete: the framework's AuditableEntitySaveChangesInterceptor sets IsDeleted +
-        // DeletedOnUtc + DeletedBy on Remove() calls for ISoftDeletable entities. The byte purge
-        // happens later via PurgeDeletedFilesJob after the retention window.
+        // Soft-delete: AuditableEntitySaveChangesInterceptor sets IsDeleted/DeletedOnUtc/DeletedBy on
+        // Remove() for ISoftDeletable; byte purge runs later via PurgeDeletedFilesJob post-retention.
         db.FileAssets.Remove(f);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return Unit.Value;

--- a/src/Modules/Files/Modules.Files/Features/v1/GetFileMetadata/GetFileMetadataQueryHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/GetFileMetadata/GetFileMetadataQueryHandler.cs
@@ -39,9 +39,8 @@ public sealed class GetFileMetadataQueryHandler(
             throw new NotFoundException("file not found");
         }
 
-        // Public files get a durable URL so the caller can persist it on a long-lived entity
-        // (e.g. Product.imageUrl). Private files use the auth-gated /url endpoint to mint a
-        // short-lived presigned GET on demand.
+        // Public files get a durable URL safe to persist long-term, while private files mint a
+        // short-lived presigned GET on demand via the auth-gated url endpoint.
         var publicUrl = f.Visibility == Visibility.Public
             ? storage.BuildPublicUrl(f.StorageKey)
             : null;

--- a/src/Modules/Files/Modules.Files/Features/v1/ListSharedFiles/ListSharedFilesQueryHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/ListSharedFiles/ListSharedFilesQueryHandler.cs
@@ -18,9 +18,8 @@ namespace FSH.Modules.Files.Features.v1.ListSharedFiles;
 public sealed class ListSharedFilesQueryHandler(FilesDbContext db, IStorageService storage)
     : IQueryHandler<ListSharedFilesQuery, ReadOnlyCollection<FileAssetDto>>
 {
-    // Owner types that represent "free-standing" tenant files (not bound to a domain entity).
-    // Catalog/Tickets/Chat attachments are intentionally excluded — their visibility is a
-    // function of their owning entity's access policy, not a free-standing share decision.
+    // Free-standing tenant files (not bound to a domain entity). Catalog/Tickets/Chat attachments
+    // are excluded — their visibility follows the owning entity's access policy, not a share decision.
     private static readonly string[] SharedOwnerTypes = ["MyFiles", "User"];
 
     public async ValueTask<ReadOnlyCollection<FileAssetDto>> Handle(ListSharedFilesQuery q, CancellationToken cancellationToken)

--- a/src/Modules/Files/Modules.Files/Jobs/PurgeDeletedFilesJob.cs
+++ b/src/Modules/Files/Modules.Files/Jobs/PurgeDeletedFilesJob.cs
@@ -35,9 +35,8 @@ public sealed class PurgeDeletedFilesJob(
             return;
         }
 
-        // Best-effort byte removal + quota refund per file. Use the tenant id from the connection
-        // context — since we use schema-per-tenant, all rows in this DbContext share the same tenant.
-        // For multi-tenant deployments the job is wired per-tenant by Hangfire.
+        // Best-effort byte removal per file. Schema-per-tenant means all rows share one tenant,
+        // and Hangfire wires the job per-tenant for multi-tenant deployments.
         foreach (var f in candidates)
         {
             try
@@ -55,9 +54,8 @@ public sealed class PurgeDeletedFilesJob(
         var totalBytes = candidates.Sum(f => f.SizeBytes);
         if (totalBytes > 0)
         {
-            // Empty string tenant id: quota service is scoped via DI; we still call with an empty
-            // string to satisfy the contract — the service resolves the tenant from DI context.
-            // (Falls back gracefully if no tenant; we just lose the refund in that case.)
+            // Empty tenant id satisfies the contract; QuotaService resolves the tenant from DI.
+            // Falls back gracefully with no tenant (the refund is simply lost).
             try
             {
                 await quotas.RecordAsync("", QuotaResource.StorageBytes, -totalBytes, cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Files/Modules.Files/Jobs/PurgeOrphanedFilesJob.cs
+++ b/src/Modules/Files/Modules.Files/Jobs/PurgeOrphanedFilesJob.cs
@@ -45,11 +45,8 @@ public sealed class PurgeOrphanedFilesJob(
             {
                 logger.LogWarning(ex, "Failed to remove orphan storage object {Key}", f.StorageKey);
             }
-            // Hard delete — the row never made it to Available, so soft-delete doesn't apply.
-            // We need EF to issue a DELETE, but FileAsset is ISoftDeletable and the interceptor
-            // would convert Remove() to UPDATE IsDeleted=true. Work around by setting IsDeleted
-            // already (forces interceptor to skip) and calling Remove again. Cleaner path: an
-            // explicit ExecuteDelete bulk operation.
+            // Hard delete (row never reached Available, so soft-delete doesn't apply). FileAsset is ISoftDeletable,
+            // so Remove() would become UPDATE IsDeleted=true — we use the bulk ExecuteDelete below to bypass the interceptor instead.
         }
 
         // Bulk hard delete — bypasses the soft-delete interceptor.

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQuery.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQuery.cs
@@ -2,10 +2,8 @@ using Mediator;
 
 namespace FSH.Modules.Identity.Contracts.v1.Impersonation.GetImpersonationGrants;
 
-// Status: filter to Active, Ended, Revoked, or Expired. Null returns all.
-// ImpersonatedTenantId: filter to grants targeting users in this tenant.
-//   Tenant admins are forced to their own tenant server-side regardless.
-// ActorUserId: filter to grants started by this actor user id.
+// Status (null = all) and ActorUserId filters. ImpersonatedTenantId filters by target tenant, but
+// tenant admins are forced to their own tenant server-side regardless.
 public sealed record GetImpersonationGrantsQuery(
     ImpersonationGrantStatus? Status = null,
     string? ImpersonatedTenantId = null,

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/ImpersonationGrantDto.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/ImpersonationGrantDto.cs
@@ -21,10 +21,8 @@ public sealed record ImpersonationGrantDto(
     string? RevokeReason,
     ImpersonationGrantStatus Status);
 
-// Serialize/deserialize as a string ("Active"/"Ended"/...) rather than the
-// underlying int so API consumers (admin client TS types, test deserializers,
-// CLI tools) get readable, reorder-safe values. Pattern matches TicketStatus
-// elsewhere in the codebase.
+// Serialize as a string ("Active"/"Ended"/...) not the int, so consumers get readable, reorder-safe
+// values. Mirrors TicketStatus elsewhere.
 [JsonConverter(typeof(JsonStringEnumConverter<ImpersonationGrantStatus>))]
 public enum ImpersonationGrantStatus
 {

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/StartImpersonation/StartImpersonationCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Impersonation/StartImpersonation/StartImpersonationCommand.cs
@@ -2,9 +2,8 @@ using Mediator;
 
 namespace FSH.Modules.Identity.Contracts.v1.Impersonation.StartImpersonation;
 
-// DurationMinutes: caller-requested impersonation token lifetime in minutes.
-// Server caps at StartImpersonationCommandValidator.MaxImpersonationMinutes
-// (currently 60). Null falls back to JwtOptions.AccessTokenMinutes.
+// DurationMinutes: requested token lifetime, capped server-side at
+// StartImpersonationCommandValidator.MaxImpersonationMinutes (60); null → JwtOptions.AccessTokenMinutes.
 public sealed record StartImpersonationCommand(
     string TargetUserId,
     string TargetTenantId,

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Tokens/RefreshToken/RefreshTokenCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Tokens/RefreshToken/RefreshTokenCommand.cs
@@ -2,9 +2,7 @@
 
 namespace FSH.Modules.Identity.Contracts.v1.Tokens.RefreshToken;
 
-// Token is the (possibly expired) access token. It is optional — when present, the
-// handler cross-checks the access-token subject against the refresh-token subject as
-// an additional safeguard. When absent, refresh proceeds on the strength of the
-// refresh-token validation alone.
+// Token is the (possibly expired) access token, optional. When present, the handler cross-checks its
+// subject against the refresh token's as a safeguard; when absent, refresh relies on refresh-token validation alone.
 public record RefreshTokenCommand(string? Token, string RefreshToken)
     : ICommand<RefreshTokenCommandResponse>;

--- a/src/Modules/Identity/Modules.Identity/Authorization/Jwt/ConfigureJwtBearerOptions.cs
+++ b/src/Modules/Identity/Modules.Identity/Authorization/Jwt/ConfigureJwtBearerOptions.cs
@@ -110,9 +110,8 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                         Instance = context.HttpContext.Request.Path,
                     };
 
-                    // In Development surface the actual JwtBearer rejection reason
-                    // (token expired / signing key invalid / issuer mismatch / etc).
-                    // In Production keep the body opaque to avoid leaking validation internals.
+                    // In Development surface the actual JwtBearer rejection reason; in Production keep the
+                    // body opaque to avoid leaking validation internals.
                     if (isDev)
                     {
                         if (context.HttpContext.Items[FailureKey] is string reason)
@@ -152,12 +151,8 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                 }
                 return Task.CompletedTask;
             },
-            // After JwtBearer validates signature/expiry/issuer/audience, check
-            // whether the token is an impersonation session AND whether the grant
-            // it represents has been revoked or explicitly ended. This is the
-            // server-side teeth behind /impersonation/revoke — without it,
-            // revocation would only stop NEW tokens being issued, not tokens
-            // already in flight.
+            // Server-side teeth behind /impersonation/revoke: for an impersonation token, reject if its
+            // grant is revoked/ended — otherwise revocation wouldn't stop tokens already in flight.
             OnTokenValidated = async context =>
             {
                 var actSub = context.Principal?.FindFirstValue(ClaimConstants.ActorSubject);
@@ -170,25 +165,15 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                 var jti = context.Principal?.FindFirstValue(JwtRegisteredClaimNames.Jti);
                 if (string.IsNullOrEmpty(jti))
                 {
-                    // Impersonation token without a jti shouldn't happen (Start
-                    // mints one explicitly) — reject defensively so a malformed
-                    // or stripped token can't bypass the revocation check.
+                    // jti is always minted by Start; reject defensively so a malformed/stripped token
+                    // can't bypass the revocation check.
                     context.HttpContext.Items[FailureKey] = "Impersonation token missing jti claim";
                     context.Fail("impersonation token missing jti claim");
                     return;
                 }
 
-                // Resolve the grant service in a CHILD scope. This hook fires
-                // during JwtBearer's auth middleware, BEFORE Finbuckle's tenant
-                // resolution middleware. Resolving IImpersonationGrantService
-                // directly off `RequestServices` would construct an IdentityDbContext
-                // in the request scope while the tenant context is still null —
-                // and that null-tenant DbContext would then be cached for the rest
-                // of the request, causing later tenant-aware queries (e.g. /profile,
-                // user lookups) to NRE in their Finbuckle query filters. Using a
-                // child scope here isolates the hook's DbContext lifetime so the
-                // request scope can build a fresh, properly-tenanted DbContext
-                // later, once Finbuckle has resolved the tenant.
+                // Resolve in a CHILD scope: this hook runs before Finbuckle resolves the tenant, so a request-
+                // scoped IdentityDbContext would cache a null-tenant context and NRE later tenant query filters.
                 await using var hookScope = context.HttpContext.RequestServices.CreateAsyncScope();
                 var grants = hookScope.ServiceProvider
                     .GetRequiredService<IImpersonationGrantService>();
@@ -212,10 +197,8 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
                 }
 
                 var path = context.HttpContext.Request.Path;
-                // Browser EventSource / SignalR cannot send an Authorization header from the
-                // browser context — they authenticate via ?access_token=. The path allow-list
-                // keeps that exemption narrow so cookie-style query-string tokens can't leak
-                // into other endpoints via referrer logs.
+                // Browser EventSource/SignalR can't send an Authorization header, so they use
+                // ?access_token=. The narrow path allow-list keeps query-string tokens from leaking elsewhere.
                 if (path.StartsWithSegments("/notifications", StringComparison.OrdinalIgnoreCase)
                     || path.StartsWithSegments("/api/v1/realtime/hub", StringComparison.OrdinalIgnoreCase))
                 {
@@ -226,9 +209,8 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
         };
     }
 
-    // Strip CR/LF and other control characters so attacker-controlled request data
-    // cannot forge log lines (CodeQL cs/log-injection). Kestrel already rejects
-    // truly malformed URIs, but defending in depth keeps console-rendered output safe.
+    // Strip control chars so attacker-controlled request data can't forge log lines
+    // (CodeQL cs/log-injection); defence in depth on top of Kestrel's URI validation.
     private static string SanitizeForLog(string? value)
     {
         if (string.IsNullOrEmpty(value))

--- a/src/Modules/Identity/Modules.Identity/Authorization/Jwt/JwtOptions.cs
+++ b/src/Modules/Identity/Modules.Identity/Authorization/Jwt/JwtOptions.cs
@@ -22,10 +22,8 @@ public class JwtOptions : IValidatableObject
             yield return new ValidationResult("SigningKey must be at least 32 characters long.", [nameof(SigningKey)]);
         }
 
-        // Reject obvious placeholder strings shipped in sample configs. The framework's
-        // own appsettings.json carries a "replace-with-..." sample value; if an operator
-        // forgets to override it in their deployment, tokens are forgeable by anyone
-        // who has read this repo. Better to refuse to start than to silently issue them.
+        // Reject the sample "replace-with-..." placeholder: shipping it unchanged makes tokens
+        // forgeable by anyone with repo access, so refuse to start rather than issue them.
         if (!string.IsNullOrEmpty(SigningKey) &&
             SigningKey.Contains("replace-with", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Modules/Identity/Modules.Identity/Authorization/RequiredPermissionAuthorizationHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Authorization/RequiredPermissionAuthorizationHandler.cs
@@ -21,13 +21,8 @@ public sealed class RequiredPermissionAuthorizationHandler(IUserService userServ
             _ => null,
         };
 
-        // IMPORTANT: this MUST resolve the IRequiredPermissionMetadata from
-        // FSH.Framework.Shared.Identity.Authorization — the SAME interface that
-        // RequiredPermissionAttribute implements. There was previously a duplicate
-        // interface in FSH.Modules.Identity which C# name resolution preferred
-        // (closer namespace), causing every `.RequirePermission()` call to silently
-        // fail-open. The explicit `using FSH.Framework.Shared.Identity.Authorization`
-        // above pins the right one. The orphan duplicate has been removed.
+        // IMPORTANT: resolve IRequiredPermissionMetadata from FSH.Framework.Shared.Identity.Authorization (the
+        // interface the attribute implements) — a duplicate would silently fail-open every .RequirePermission().
         var requiredPermissions = endpoint?.Metadata.GetMetadata<IRequiredPermissionMetadata>()?.RequiredPermissions;
         if (requiredPermissions == null)
         {

--- a/src/Modules/Identity/Modules.Identity/Data/IdentityDbContext.cs
+++ b/src/Modules/Identity/Modules.Identity/Data/IdentityDbContext.cs
@@ -66,12 +66,8 @@ public class IdentityDbContext : MultiTenantIdentityDbContext<FshUser,
         builder.ApplyConfiguration(new OutboxMessageConfiguration(IdentityModuleConstants.SchemaName));
         builder.ApplyConfiguration(new InboxMessageConfiguration(IdentityModuleConstants.SchemaName));
 
-        // Default-on tenant isolation — any entity not marked IGlobalEntity gets
-        // IsMultiTenant() applied automatically. ImpersonationGrant, OutboxMessage,
-        // and InboxMessage opt out via IGlobalEntity. ASP.NET Identity tables
-        // (Users/Roles/Claims/etc.) are already marked IsMultiTenant in
-        // IdentityConfigurations.cs; the auto-apply detects that annotation and
-        // skips re-applying.
+        // Default-on tenant isolation: non-IGlobalEntity entities get IsMultiTenant() automatically (Outbox/Inbox/ImpersonationGrant opt out).
+        // Identity tables are already IsMultiTenant in IdentityConfigurations.cs; auto-apply detects that annotation and skips them.
         builder.ApplyTenantIsolationByDefault();
     }
 

--- a/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
+++ b/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
@@ -210,10 +210,8 @@ internal sealed class IdentityDbInitializer(
             var initialPassword = ResolveInitialAdminPassword(multiTenantContextAccessor.MultiTenantContext.TenantInfo!.Id!);
             var password = new PasswordHasher<FshUser>();
             adminUser.PasswordHash = password.HashPassword(adminUser, initialPassword);
-            // The IdentityResult MUST be checked: a silent failure here (e.g. a password-policy
-            // rejection or a transient DB error) would otherwise mark provisioning "Completed" with no
-            // admin user — an unrecoverable tenant with no login. Throwing surfaces it as a Failed
-            // provisioning step that the operator can retry.
+            // MUST check IdentityResult: a silent failure (password-policy reject, transient DB error)
+            // would mark provisioning "Completed" with no admin user; throwing makes it a retryable Failed.
             var createResult = await userManager.CreateAsync(adminUser);
             if (!createResult.Succeeded)
             {

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
@@ -65,9 +65,8 @@ public sealed class AddUsersToGroupCommandHandler : ICommandHandler<AddUsersToGr
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 
-        // Joining a group can grant new roles (via GroupRoles) which feed the user's
-        // effective role claims at JWT mint time. Invalidate the cached permission set
-        // for each newly-added user so their next request reflects the change.
+        // Joining a group can grant new roles (via GroupRoles) feeding JWT claims; invalidate
+        // each newly-added user's cached permission set so their next request reflects it.
         foreach (var userId in usersToAdd)
         {
             await _userPermissionService.InvalidatePermissionCacheAsync(userId, cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
@@ -34,9 +34,8 @@ public sealed class DeleteGroupCommandHandler : ICommandHandler<DeleteGroupComma
             throw new ForbiddenException("System groups cannot be deleted.");
         }
 
-        // Snapshot members BEFORE delete — the soft-delete flips IsDeleted but
-        // membership rows persist, so this lookup works either way; we capture
-        // first for clarity.
+        // Snapshot members before delete; soft-delete flips IsDeleted but membership rows
+        // persist, so capture first for clarity.
         var memberIds = await _dbContext.UserGroups
             .Where(ug => ug.GroupId == command.Id)
             .Select(ug => ug.UserId)

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandHandler.cs
@@ -31,9 +31,8 @@ public sealed class RemoveUserFromGroupCommandHandler : ICommandHandler<RemoveUs
             throw new NotFoundException($"User '{command.UserId}' is not a member of group '{command.GroupId}'.");
         }
 
-        // Default groups (e.g. the seeded "All Users") hold the invariant that
-        // every user in the tenant is a member. Removing breaks that contract —
-        // the next user to register would join a half-populated group.
+        // Default groups (e.g. seeded "All Users") require every tenant user to be a member, so
+        // removing one breaks that invariant and leaves later registrants in a half-populated group.
         if (membership.Group is not null && membership.Group.IsDefault)
         {
             throw new ForbiddenException("Users cannot be removed from a default group.");

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/EndImpersonation/EndImpersonationCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/EndImpersonation/EndImpersonationCommandHandler.cs
@@ -61,9 +61,8 @@ public sealed class EndImpersonationCommandHandler
 
         if (string.IsNullOrWhiteSpace(actorUserId) || string.IsNullOrWhiteSpace(actorTenantId))
         {
-            // Caller is signed in but their session has no act_sub claim — this is
-            // a client error (called End on a non-impersonation token), must be 4xx
-            // not the default 500 that CustomException assumes.
+            // Signed in but no act_sub claim (End called on a non-impersonation token): client error,
+            // must be 4xx not CustomException's default 500.
             throw new CustomException(
                 "current session is not an impersonation session",
                 errors: null,
@@ -73,12 +72,8 @@ public sealed class EndImpersonationCommandHandler
         var impersonatedUserId = _currentUser.GetUserId().ToString();
         var impersonatedTenantId = _currentUser.GetTenant() ?? string.Empty;
 
-        // Mark the grant as ended BEFORE issuing fresh actor tokens. If a
-        // racing request hits the JWT hook in the window between this call
-        // and token issuance, the cache will already report "ended" — safer
-        // ordering than the reverse. If MarkEnded fails we still proceed:
-        // the grant will naturally expire and the JWT hook treats Unknown
-        // states as revoked.
+        // Mark grant ended BEFORE issuing actor tokens so a racing JWT-hook request sees "ended" (safer than the reverse).
+        // If MarkEnded fails we proceed anyway: the grant expires naturally and the hook treats Unknown states as revoked.
         if (!string.IsNullOrWhiteSpace(jti))
         {
             try

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryHandler.cs
@@ -23,9 +23,8 @@ public sealed class GetImpersonationGrantsQueryHandler(
             ?? throw new UnauthorizedException("missing tenant context");
         var isRoot = string.Equals(callerTenant, MultitenancyConstants.Root.Id, StringComparison.Ordinal);
 
-        // Tenant scoping: root operators can target any tenant via the query
-        // filter; tenant admins are locked to their own regardless of what
-        // they pass in. This mirrors the StartImpersonation cross-tenant rule.
+        // Tenant scoping: root operators target any tenant; tenant admins are locked to their
+        // own regardless of input. Mirrors the StartImpersonation cross-tenant rule.
         var tenantFilter = isRoot ? request.ImpersonatedTenantId : callerTenant;
 
         return await grantService.ListAsync(

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/RevokeImpersonationGrant/RevokeImpersonationGrantCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/RevokeImpersonationGrant/RevokeImpersonationGrantCommandHandler.cs
@@ -34,10 +34,8 @@ public sealed class RevokeImpersonationGrantCommandHandler(
             ?? throw new UnauthorizedException("missing tenant context");
         var isRoot = string.Equals(callerTenantId, MultitenancyConstants.Root.Id, StringComparison.Ordinal);
 
-        // Load before revoking so we can enforce visibility: tenant admins can
-        // only revoke grants targeting their own tenant. Returning 404 (not
-        // 403) for cross-tenant grants avoids confirming existence to callers
-        // outside the grant's scope.
+        // Enforce visibility before revoking: tenant admins may only revoke grants in their own
+        // tenant. Cross-tenant grants return 404 (not 403) so existence isn't confirmed out of scope.
         var grant = await grantService.GetByIdAsync(request.GrantId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("impersonation grant not found");
 
@@ -56,9 +54,8 @@ public sealed class RevokeImpersonationGrantCommandHandler(
             reason: request.Reason,
             ct: cancellationToken).ConfigureAwait(false);
 
-        // Surface revoke as a first-class security event so it's queryable
-        // alongside the Start/End audit entries. The Reason field on the audit
-        // is the revocation reason, not the original impersonation reason.
+        // Surface revoke as a first-class security event, queryable alongside Start/End entries.
+        // The audit Reason is the revocation reason, not the original impersonation reason.
         await securityAudit.ImpersonationEndedAsync(
             actorUserId: grant.ActorUserId,
             actorTenantId: grant.ActorTenantId,

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandHandler.cs
@@ -69,9 +69,8 @@ public sealed class StartImpersonationCommandHandler
             throw new ForbiddenException("cross-tenant impersonation is restricted to platform operators");
         }
 
-        // Prevent self-impersonation (nothing to gain, confuses audit trail). This
-        // is a caller error → must be a 4xx, not the default 500 that CustomException
-        // assumes.
+        // Prevent self-impersonation (pointless, confuses the audit trail). Caller error → explicit 4xx,
+        // not the 500 CustomException defaults to.
         if (string.Equals(actorUserId, request.TargetUserId, StringComparison.Ordinal)
             && string.Equals(actorTenantId, request.TargetTenantId, StringComparison.Ordinal))
         {
@@ -101,10 +100,8 @@ public sealed class StartImpersonationCommandHandler
         var targetUserName = claims.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value
             ?? claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Name)?.Value;
 
-        // We need to know the jti of the issued token so we can persist a
-        // matching ImpersonationGrant. BuildClaimsForUserAsync hands us claims
-        // that already include an auto-generated jti — strip it and inject our
-        // own deterministic value so the grant row + JWT agree on it.
+        // Strip the auto-generated jti from BuildClaimsForUserAsync and inject our own, so the persisted
+        // ImpersonationGrant row and the issued JWT share the same jti.
         var jti = Guid.NewGuid().ToString("N");
         var impersonationClaims = claims
             .Where(c => c.Type != JwtRegisteredClaimNames.Jti)
@@ -117,9 +114,8 @@ public sealed class StartImpersonationCommandHandler
             ])
             .ToList();
 
-        // Caller-supplied duration is capped server-side (defense in depth — the
-        // validator already rejects out-of-range, but a future caller bypassing
-        // validation shouldn't escape the cap).
+        // Cap the caller-supplied duration server-side (defense in depth: the validator already rejects
+        // out-of-range, but a future caller bypassing it must not escape the cap).
         var lifetime = request.DurationMinutes is { } minutes
             ? TimeSpan.FromMinutes(Math.Clamp(minutes, 1, StartImpersonationCommandValidator.MaxImpersonationMinutes))
             : (TimeSpan?)null;
@@ -128,10 +124,8 @@ public sealed class StartImpersonationCommandHandler
         var (accessToken, expiresAt) = await _tokenService.IssueAccessOnlyAsync(
             subject, impersonationClaims, lifetime, cancellationToken);
 
-        // Persist the grant AFTER the token issues — if issuance fails we don't
-        // leave an orphan grant row claiming to track a session that never was.
-        // Cache priming inside CreateAsync ensures the JWT validation hook sees
-        // status=Active on the very next request without a DB hit.
+        // Persist the grant AFTER issuance so a failed issue leaves no orphan grant. CreateAsync primes the
+        // cache so the JWT validation hook sees status=Active on the next request without a DB hit.
         await _grantService.CreateAsync(new CreateGrantInput(
             Jti: jti,
             ActorUserId: actorUserId,

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/RoleService.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/RoleService.cs
@@ -20,9 +20,8 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
     ICurrentUser currentUser,
     IUserPermissionService userPermissionService) : IRoleService
 {
-    // Invalidate every user whose effective permission set may have shifted as a
-    // result of a role-level mutation. "Direct" = AspNetUserRoles, "via groups"
-    // = members of groups that carry this role.
+    // Invalidate every user whose effective permissions may have shifted from a role mutation:
+    // direct holders (AspNetUserRoles) and group-derived holders (members of groups carrying this role).
     private async Task InvalidateAffectedUsersAsync(string roleId, CancellationToken cancellationToken)
     {
         var role = await roleManager.FindByIdAsync(roleId);
@@ -198,10 +197,8 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
             return;
         }
 
-        // Strip every permission flagged IsRoot in the registry. The previous check removed only names
-        // starting with "Permissions.Root." — but NO root permission uses that prefix (they are
-        // Permissions.Tenants.* / Permissions.Platform.*, flagged via IsRoot), so the filter was a
-        // no-op and a non-root tenant admin with Roles.Update could grant their role root permissions.
+        // Strip every permission flagged IsRoot in the registry. (A prior prefix check on "Permissions.Root."
+        // was a no-op — no root perm uses that prefix — letting a tenant admin grant themselves root perms.)
         var rootOnly = PermissionConstants.Root.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
         permissions.RemoveAll(rootOnly.Contains);
     }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserPermissions/GetUserPermissionsEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserPermissions/GetUserPermissionsEndpoint.cs
@@ -11,14 +11,8 @@ namespace FSH.Modules.Identity.Features.v1.Users.GetUserPermissions;
 
 public static class GetUserPermissionsEndpoint
 {
-    // No RequirePermission here on purpose: this endpoint returns the *caller's*
-    // own permissions, which the SPA needs to render permission-gated routes.
-    // Gating it behind Users.View locked out every role that doesn't manage
-    // users (e.g. a Billing-only tenant operator), which would have meant
-    // their client-side route guards never received any permissions and the
-    // admin would stall on "Resolving permissions" forever. The fallback
-    // policy still enforces RequireAuthenticatedUser, so anonymous callers
-    // get 401 as expected.
+    // No RequirePermission on purpose: returns the *caller's* own permissions (the SPA needs them to render
+    // gated routes); gating behind Users.View would lock out non-user-managing roles. Fallback policy → 401.
     internal static RouteHandlerBuilder MapGetCurrentUserPermissionsEndpoint(this IEndpointRouteBuilder endpoints)
     {
         return endpoints.MapGet("/permissions", async (ClaimsPrincipal user, IMediator mediator, CancellationToken cancellationToken) =>

--- a/src/Modules/Identity/Modules.Identity/IdentityModule.cs
+++ b/src/Modules/Identity/Modules.Identity/IdentityModule.cs
@@ -153,9 +153,8 @@ public class IdentityModule : IModule
             options.Password.RequireUppercase = true;
             options.User.RequireUniqueEmail = true;
 
-            // Account lockout: 5 consecutive failed logins → 15-minute lockout.
-            // Applies to newly created users by default. Login flow triggers
-            // AccessFailedAsync / IsLockedOutAsync in IdentityService.
+            // Account lockout: 5 consecutive failed logins → 15-minute lockout (applies to new users by default).
+            // IdentityService's login flow drives AccessFailedAsync / IsLockedOutAsync.
             options.Lockout.AllowedForNewUsers = true;
             options.Lockout.MaxFailedAccessAttempts = 5;
             options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
@@ -187,11 +186,8 @@ public class IdentityModule : IModule
         group.MapGenerateTokenEndpoint().AllowAnonymous().RequireRateLimiting("auth");
         group.MapRefreshTokenEndpoint().AllowAnonymous().RequireRateLimiting("auth");
 
-        // The outbox is dispatched by the framework's OutboxDispatcherHostedService
-        // (EventingOptions.UseHostedServiceDispatcher, on by default). A second
-        // dispatcher here would race the same rows (GetPendingBatchAsync has no
-        // row-level claim) — duplicate handler invocations and PK_InboxMessages
-        // collisions — so this module does NOT register its own recurring job.
+        // The outbox is dispatched by the framework's OutboxDispatcherHostedService (on by default). A second dispatcher
+        // here would race the same rows (no row-level claim) → duplicate handlers + PK_InboxMessages collisions, so this module registers none.
 
         // roles
         group.MapGetRolesEndpoint();

--- a/src/Modules/Identity/Modules.Identity/Services/IdentityService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/IdentityService.cs
@@ -103,11 +103,8 @@ public sealed class IdentityService : IIdentityService
 
     public async Task StoreRefreshTokenAsync(string subject, string refreshToken, DateTime expiresAtUtc, CancellationToken ct = default)
     {
-        // ExecuteUpdateAsync issues a single targeted UPDATE bypassing both
-        // entity tracking and Finbuckle's MultiTenant interceptors (which NRE
-        // on cross-tenant `IgnoreQueryFilters` use in MultiTenantIdentityDbContext).
-        // Safe because user IDs are globally unique GUIDs — there is exactly
-        // one row matching `Id == subject` regardless of tenant scope.
+        // Targeted UPDATE bypasses tracking + Finbuckle interceptors (which NRE on cross-tenant IgnoreQueryFilters).
+        // Safe: user IDs are globally unique GUIDs, so exactly one row matches Id == subject regardless of tenant.
         var hashedToken = HashToken(refreshToken);
         var updated = await _dbContext.Users
             .IgnoreQueryFilters()
@@ -310,12 +307,8 @@ public sealed class IdentityService : IIdentityService
         return
         [
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            // RFC 7519 standard short-form claims — emitted alongside the legacy
-            // ClaimTypes.* entries so JWT consumers (including the dashboard's
-            // claimsToUser) can read `sub` / `name` / `email` per the spec.
-            // JwtSecurityTokenHandler's default outbound map turns ClaimTypes.Name
-            // into `unique_name`, which is *not* the standard `name` claim, so
-            // we publish `name` explicitly here.
+            // RFC 7519 short-form sub/name/email emitted alongside legacy ClaimTypes.* so JWT consumers read them per spec.
+            // `name` is published explicitly because the default outbound map turns ClaimTypes.Name into `unique_name`, not `name`.
             new(JwtRegisteredClaimNames.Sub, user.Id),
             new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
             new(JwtRegisteredClaimNames.Name, fullName.Length > 0 ? fullName : (user.Email ?? string.Empty)),

--- a/src/Modules/Identity/Modules.Identity/Services/ImpersonationGrantService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/ImpersonationGrantService.cs
@@ -37,11 +37,8 @@ internal sealed class ImpersonationGrantService(
         db.ImpersonationGrants.Add(grant);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-        // Prime the revocation cache with status=Active so the JWT validation
-        // hook's GetOrCreate gets a hit on the very first request without a
-        // DB round-trip. TTL matches the token lifetime so the entry self-
-        // evicts after expiry — and the hook treats expired tokens as
-        // implicitly ended anyway, so a cache miss after expiry is harmless.
+        // Prime the cache with status=Active so the JWT hook hits on the first request without a DB round-trip.
+        // Entry self-evicts after the token lifetime; a miss after expiry is harmless since the hook treats expired tokens as ended.
         await SetCachedStatusAsync(grant, GrantState.Active, ct).ConfigureAwait(false);
 
         return ToDto(grant);
@@ -167,9 +164,8 @@ internal sealed class ImpersonationGrantService(
 
     private static readonly HybridCacheEntryOptions CacheEntryOptions = new()
     {
-        // 5-minute TTL is plenty — impersonation sessions are 60 min max, and
-        // the entry is re-primed on every revoke/end. After natural expiry the
-        // jti is meaningless anyway (JwtBearer rejects on lifetime).
+        // 5-min TTL suffices: sessions are 60 min max and the entry is re-primed on every revoke/end.
+        // After expiry the jti is meaningless anyway (JwtBearer rejects on lifetime).
         Expiration = TimeSpan.FromMinutes(5),
         LocalCacheExpiration = TimeSpan.FromMinutes(1),
         Flags = HybridCacheEntryFlags.DisableCompression,

--- a/src/Modules/Identity/Modules.Identity/Services/TokenService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/TokenService.cs
@@ -66,9 +66,8 @@ public sealed class TokenService : ITokenService
         var creds = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        // Caller-supplied lifetime wins over the configured default. The caller
-        // (e.g. StartImpersonationCommandHandler) is responsible for capping
-        // to a safe upper bound before passing it in.
+        // Caller-supplied lifetime wins over the configured default; the caller
+        // (e.g. StartImpersonationCommandHandler) must cap it to a safe upper bound.
         var accessTokenExpiry = lifetime is { } span
             ? now.Add(span)
             : now.AddMinutes(_options.AccessTokenMinutes);

--- a/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
@@ -29,9 +29,8 @@ internal sealed class UserPasswordService(
 
         var user = await userManager.FindByEmailAsync(email);
 
-        // Anti-enumeration: respond identically whether or not the address is registered, so an
-        // anonymous caller cannot distinguish real accounts from unknown ones. A real user gets
-        // the reset email; an unknown (or email-less) account silently no-ops with the same 200.
+        // Anti-enumeration: respond identically regardless of registration — a real user gets the
+        // reset email; an unknown or email-less account silently no-ops with the same 200.
         if (user is null || string.IsNullOrWhiteSpace(user.Email))
         {
             return;

--- a/src/Modules/Identity/Modules.Identity/Services/UserPermissionService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserPermissionService.cs
@@ -32,9 +32,8 @@ internal sealed class UserPermissionService(
     {
         var set = await GetOrLoadAsync(userId, cancellationToken).ConfigureAwait(false);
 
-        // Materialize a new List<string> on the way out to preserve the existing public contract.
-        // The copy is ~50 ns for a typical permission set — negligible vs the JSON deserialization
-        // we'd otherwise pay on every L1 hit without the [ImmutableObject] optimization.
+        // Copy to a new List<string> to preserve the public contract; ~50 ns is negligible vs the
+        // JSON deserialization we'd otherwise pay per L1 hit without the [ImmutableObject] optimization.
         return [.. set.Values];
     }
 

--- a/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
@@ -82,9 +82,8 @@ internal sealed class UserProfileService(
         _ = user ?? throw new NotFoundException("user not found");
 
         Uri imageUri = user.ImageUrl ?? null!;
-        // image is optional: a profile update without an avatar passes a null FileUploadRequest
-        // (the endpoint forwards command.Image, which is null for text-only edits). Guard the
-        // null before dereferencing Data, otherwise the common no-image update path NREs.
+        // image is optional: text-only edits forward a null FileUploadRequest, so guard before
+        // dereferencing Data or the common no-image update path NREs.
         if (image?.Data != null)
         {
             var imageString = await storageService.UploadAsync<FshUser>(image, FileType.Image, cancellationToken);

--- a/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
@@ -34,9 +34,8 @@ internal sealed class UserRoleService(
 
         await RaiseRolesAssignedEventAsync(user, assignedRoles, cancellationToken);
 
-        // Any role mutation invalidates the cached permission set for this user —
-        // both additions and removals, so flush unconditionally rather than
-        // gating on assignedRoles (which only tracks additions).
+        // Any role mutation (add or remove) invalidates the cached permission set; flush
+        // unconditionally rather than gating on assignedRoles, which only tracks additions.
         await userPermissionService.InvalidatePermissionCacheAsync(userId, cancellationToken).ConfigureAwait(false);
 
         return "User Roles Updated Successfully.";

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandHandler.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandHandler.cs
@@ -24,9 +24,8 @@ public sealed class CreateTenantCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Resolve the plan (falling back to the configured trial plan) and read its term so we can
-        // set the tenant's validity window up front. GetPlanTerm throws NotFound for a bad key,
-        // surfacing as a 400 before any tenant is created.
+        // Resolve the plan (falls back to trial) and read its term to set the tenant validity
+        // window. A bad plan key throws NotFound (400) before any tenant is created.
         var planKey = string.IsNullOrWhiteSpace(command.PlanKey)
             ? billingOptions.Value.DefaultPlanKey
             : command.PlanKey!;
@@ -45,9 +44,8 @@ public sealed class CreateTenantCommandHandler(
             periodEnd,
             cancellationToken).ConfigureAwait(false);
 
-        // Buffer the admin password so IdentityDbInitializer can consume it during
-        // the background provisioning seed step. Stored before StartAsync to avoid
-        // a race where the seed runs before the buffer is populated.
+        // Buffer the admin password for IdentityDbInitializer's background seed step,
+        // storing it before StartAsync so the seed never runs ahead of the buffer.
         passwordBuffer.Store(tenantId, command.AdminPassword);
 
         var provisioning = await provisioningService.StartAsync(tenantId, cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandValidator.cs
@@ -27,10 +27,8 @@ public sealed class CreateTenantCommandValidator : AbstractValidator<CreateTenan
             .NotEmpty()
             .EmailAddress();
 
-        // Admin password is now operator-supplied rather than a hardcoded default.
-        // The minimum 8-char rule matches the Identity password policy floor; the
-        // mixed-character requirements (digit / upper / non-alpha) are enforced
-        // later by ASP.NET Identity's PasswordValidators when the seed runs.
+        // Admin password is operator-supplied. The 8-char floor matches the Identity policy; mixed-character
+        // rules (digit/upper/non-alpha) are enforced later by Identity's PasswordValidators at seed time.
         RuleFor(t => t.AdminPassword).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .MinimumLength(8)

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -69,10 +69,8 @@ public sealed class MultitenancyModule : IModule
 
         builder.Services.AddHeroDbContext<TenantDbContext>();
 
-        // Override the no-op event tenant scope (registered by AddEventingCore) with a
-        // Finbuckle-backed one so background event dispatch (outbox / hosted services)
-        // establishes the tenant before tenant-filtered handler DbContexts are built.
-        // Replace (not Add) so it wins regardless of module registration order.
+        // Replace (not Add) the no-op event tenant scope with a Finbuckle-backed one so background
+        // event dispatch establishes the tenant before tenant-filtered handler DbContexts are built.
         builder.Services.Replace(
             ServiceDescriptor.Singleton<IEventTenantScope, FinbuckleEventTenantScope>());
 
@@ -94,16 +92,9 @@ public sealed class MultitenancyModule : IModule
                     await Task.CompletedTask;
                 };
             })
-            // ── Strategy chain — first hit wins ────────────────────────
-            // Finbuckle runs strategies in registration order, first non-null
-            // identifier wins. ClaimStrategy reads HttpContext.User.Claims, so
-            // it only works when auth has already populated User. In FSH the
-            // app pipeline runs UseMultiTenant() BEFORE UseAuthentication(),
-            // so at strategy-resolution time User is still anonymous and
-            // ClaimStrategy effectively no-ops. That's intentional: tenant
-            // resolution stays header-driven, and the root-operator header
-            // override is implemented as a post-auth middleware below
-            // (see ConfigureMiddleware) where User claims are available.
+            // ── Strategy chain — first non-null identifier wins (registration order) ──
+            // ClaimStrategy no-ops here: UseMultiTenant() runs BEFORE UseAuthentication(), so User is
+            // anonymous at resolution. Tenant stays header-driven; root override is post-auth middleware below.
             .WithClaimStrategy(ClaimConstants.Tenant)
             .WithHeaderStrategy(MultitenancyConstants.Identifier)
             .WithDelegateStrategy(async context =>
@@ -133,20 +124,8 @@ public sealed class MultitenancyModule : IModule
         ArgumentNullException.ThrowIfNull(app);
 
         // ── Root-operator header override ──────────────────────────────
-        // Lets a SuperAdmin (caller whose JWT tenant claim is "root") scope
-        // a single request to another tenant by sending the `tenant` header
-        // (e.g. admin app searching users in tenant X before impersonation).
-        //
-        // Implemented as a post-auth middleware (registered via
-        // UseModuleMiddlewares, which runs AFTER UseAuthentication) because
-        // Finbuckle's strategy chain runs BEFORE auth — User.Claims is empty
-        // at strategy-resolution time. By the time this middleware runs,
-        // Finbuckle has already resolved a tenant (root, from the matching
-        // header sent by the admin app) and JWT bearer has populated User.
-        // We re-resolve only when the override conditions are satisfied:
-        //   - caller's claim tenant == "root"  (gate: prevents cross-tenant escape)
-        //   - request `tenant` header is set and != "root"
-        //   - the requested tenant exists in the store
+        // A "root"-claim caller scopes one request to another tenant via the `tenant` header (post-auth, since
+        // Finbuckle's pre-auth chain has no User). Gated on claim==root + header set != root + target exists.
         app.Use(async (ctx, next) =>
         {
             var callerTenant = ctx.User?.FindFirstValue(ClaimConstants.Tenant);
@@ -169,16 +148,8 @@ public sealed class MultitenancyModule : IModule
         });
 
         // ── Deactivated-tenant guard ───────────────────────────────────
-        // Deactivation was previously a data-only flag with no enforcement:
-        // a deactivated tenant's users could still log in and call the API
-        // (the token handler never checked it, and Finbuckle resolves inactive
-        // tenants like any other). This post-auth guard — running before every
-        // endpoint, so it also covers the anonymous login/refresh requests —
-        // rejects any request whose resolved tenant is non-root and inactive.
-        //
-        // Operators (callers whose JWT tenant claim is "root") are exempt so
-        // they can still manage/reactivate or inspect a deactivated tenant
-        // cross-tenant (incl. via the root-operator override above).
+        // Finbuckle resolves inactive tenants normally, so this post-auth guard rejects any request (incl.
+        // anonymous login/refresh) with a non-root inactive tenant; root operators are exempt.
         app.Use(async (ctx, next) =>
         {
             var callerTenant = ctx.User?.FindFirstValue(ClaimConstants.Tenant);
@@ -188,9 +159,8 @@ public sealed class MultitenancyModule : IModule
                 var accessor = ctx.RequestServices.GetRequiredService<IMultiTenantContextAccessor<AppTenantInfo>>();
                 var tenant = accessor.MultiTenantContext?.TenantInfo;
 
-                // Finbuckle's claim strategy no-ops pre-auth, so an authenticated
-                // request carrying its tenant only in the JWT (no header) may have
-                // no resolved tenant here — fall back to the caller's claim.
+                // Claim strategy no-ops pre-auth, so a JWT-only (no header) request may have no resolved
+                // tenant here — fall back to the caller's claim.
                 if (tenant is null && !string.IsNullOrEmpty(callerTenant))
                 {
                     var store = ctx.RequestServices.GetRequiredService<IMultiTenantStore<AppTenantInfo>>();
@@ -216,9 +186,8 @@ public sealed class MultitenancyModule : IModule
                         throw new ForbiddenException("This tenant's subscription has expired. Please renew to continue.");
                     }
 
-                    // Inside the grace window (past ValidUpto, before grace ends): surface the days left
-                    // so clients can warn the tenant. Set via OnStarting so the header survives even when
-                    // an exception handler rewrites the response (e.g. a failed login still in grace).
+                    // Inside the grace window: surface days-left so clients can warn. Set via OnStarting so
+                    // the header survives even when an exception handler rewrites the response.
                     if (nowUtc > tenant.ValidUpto)
                     {
                         var daysLeft = (int)Math.Ceiling((graceEndsUtc - nowUtc).TotalDays);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
@@ -116,10 +116,8 @@ public sealed class TenantExpiryScanJob
         _db.TenantExpiryNotices.Add(TenantExpiryNotice.Record(tenant.Id, noticeType, validUpto, now));
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-        // Install the tenant's Finbuckle context before publishing: downstream handlers (e.g. the
-        // webhook fan-out) touch tenant-filtered DbContexts that capture the ambient tenant at
-        // construction. With no HTTP request in a background job, that context is otherwise empty and
-        // their query filters NRE. The ambient (AsyncLocal) value flows into the bus's handler scope.
+        // Install the Finbuckle context before publishing: downstream handlers (e.g. webhook fan-out) use
+        // tenant-filtered DbContexts that NRE without it, since a background job carries no HTTP request.
         _tenantContextSetter.MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
 
         await _eventBus.PublishAsync(BuildEvent(noticeType, tenant, validUpto, graceEnds, now), ct).ConfigureAwait(false);

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
@@ -82,9 +82,8 @@ public sealed class TenantService : ITenantService
         AppTenantInfo tenant = new(id, name, connectionString, adminEmail, issuer)
         {
             Plan = planKey,
-            // Set the initial validity directly to the plan term. SetValidity() guards against moving
-            // the date backward (correct for renewals), but the constructor seeds ValidUpto to now+1mo,
-            // so using it here would reject a term computed from an earlier 'now'.
+            // Set ValidUpto directly to the plan term: SetValidity() forbids moving the date backward, and
+            // the ctor seeds now+1mo, so it would reject a term computed from an earlier 'now'.
             ValidUpto = DateTime.SpecifyKind(validUpto, DateTimeKind.Utc),
         };
         await _tenantStore.AddAsync(tenant).ConfigureAwait(false);
@@ -250,12 +249,8 @@ public sealed class TenantService : ITenantService
         await _tenantStore.GetAsync(id).ConfigureAwait(false)
             ?? throw new NotFoundException($"{typeof(AppTenantInfo).Name} {id} Not Found.");
 
-    // Finbuckle resolves tenants through the distributed-cache store first
-    // (60-min TTL), and the injected store above only writes to the EF store —
-    // so an IsActive flip wouldn't take effect until the cache expired, and the
-    // deactivated-tenant guard would keep seeing the stale "active" copy. Push
-    // the new state straight into the cache store so the guard (and tenant
-    // resolution everywhere) sees it on the very next request.
+    // Finbuckle resolves via the distributed-cache store first (60-min TTL) while the injected store only
+    // writes EF, so push the new state into the cache store too — otherwise flips lag until cache expiry.
     private async Task RefreshTenantCacheAsync(AppTenantInfo tenant)
     {
         var cacheStore = _serviceProvider

--- a/src/Modules/Notifications/Modules.Notifications/Data/NotificationsDbContext.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Data/NotificationsDbContext.cs
@@ -26,9 +26,8 @@ public sealed class NotificationsDbContext : BaseDbContext
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.HasDefaultSchema(Schema);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(NotificationsDbContext).Assembly);
-        // base.OnModelCreating runs LAST so BaseDbContext's auto-apply
-        // (ApplyTenantIsolationByDefault) sees fully-configured entities,
-        // including child types reached via HasMany navigation.
+        // base.OnModelCreating runs LAST so BaseDbContext's auto-apply (ApplyTenantIsolationByDefault)
+        // sees fully-configured entities, including child types reached via HasMany navigation.
         base.OnModelCreating(modelBuilder);
     }
 }

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/MentionedInChannelIntegrationEventHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/MentionedInChannelIntegrationEventHandler.cs
@@ -31,12 +31,8 @@ public sealed class MentionedInChannelIntegrationEventHandler(
     {
         ArgumentNullException.ThrowIfNull(@event);
 
-        // Fail loud on a tenant-context mismatch instead of silently writing the notification to
-        // the wrong tenant. NotificationsDbContext captures its tenant at construction (BaseDbContext),
-        // so we cannot "restore" it here — but the publisher (Chat, in-memory synchronous dispatch)
-        // runs inside the originating request's tenant context, which flows into this scope. If a
-        // future background publisher omits that context, this guard turns a cross-tenant leak into a
-        // visible failure rather than corrupt data.
+        // Fail loud on a tenant mismatch rather than write to the wrong tenant: the DbContext captures its
+        // tenant at construction, so a future publisher omitting the context would leak cross-tenant silently.
         var ambientTenantId = tenantAccessor.MultiTenantContext.TenantInfo?.Id;
         if (!string.Equals(ambientTenantId, @event.TenantId, StringComparison.Ordinal))
         {

--- a/src/Modules/Tickets/Modules.Tickets/Data/Configurations/TicketCommentConfiguration.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Data/Configurations/TicketCommentConfiguration.cs
@@ -12,13 +12,8 @@ public sealed class TicketCommentConfiguration : IEntityTypeConfiguration<Ticket
         builder.ToTable("TicketComments");
         builder.HasKey(x => x.Id);
 
-        // TicketComment.Id is assigned in the domain factory via Guid.CreateVersion7().
-        // TicketComments are only ever attached through the Ticket aggregate's nav
-        // collection (ticket.AddComment(...)), never via dbContext.Set<TicketComment>().Add().
-        // Without ValueGeneratedNever(), EF's default ValueGeneratedOnAdd treats the
-        // already-populated Guid as "already persisted" during DetectChanges, tracks the
-        // new comment as Modified, and SaveChanges emits an UPDATE that affects 0 rows →
-        // DbUpdateConcurrencyException. ValueGeneratedNever() makes EF treat it as Added.
+        // Id is app-assigned (Guid.CreateVersion7) and comments attach only via the Ticket aggregate's nav
+        // collection. Without ValueGeneratedNever, EF tracks the populated Guid as Modified → UPDATE-0-rows.
         builder.Property(x => x.Id).ValueGeneratedNever();
 
         builder.Property(x => x.Body).IsRequired().HasMaxLength(8192);

--- a/src/Modules/Tickets/Modules.Tickets/Data/Configurations/TicketConfiguration.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Data/Configurations/TicketConfiguration.cs
@@ -13,8 +13,7 @@ public sealed class TicketConfiguration : IEntityTypeConfiguration<Ticket>
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.Number).IsRequired().HasMaxLength(32);
-        // Unique per tenant — Finbuckle adds a TenantId to the row, so the
-        // index ends up being effectively (TenantId, Number). Filter on
+        // Effectively unique per (TenantId, Number) since Finbuckle adds TenantId; filtered on
         // IsDeleted so soft-deleted ticket numbers don't conflict with new ones.
         builder.HasIndex(x => x.Number).IsUnique().HasFilter("\"IsDeleted\" = FALSE");
 

--- a/src/Modules/Tickets/Modules.Tickets/Domain/Ticket.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Domain/Ticket.cs
@@ -98,9 +98,8 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
         AssignedToUserId = assigneeUserId;
         UpdatedAtUtc = DateTime.UtcNow;
 
-        // Picking up a ticket implicitly starts it. Unassigning a ticket
-        // that's currently InProgress sends it back to Open — it has no
-        // owner pushing it forward.
+        // Picking up a ticket implicitly starts it (Open → InProgress); unassigning an InProgress
+        // ticket sends it back to Open since no owner is pushing it forward.
         if (assigneeUserId is not null && Status == TicketStatus.Open)
         {
             TransitionStatus(TicketStatus.InProgress);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AddTicketComment/AddTicketCommentCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AddTicketComment/AddTicketCommentCommandHandler.cs
@@ -26,10 +26,8 @@ public sealed class AddTicketCommentCommandHandler(
                 HttpStatusCode.Unauthorized);
         }
 
-        // Loading the Comments collection up front gives EF's change tracker
-        // a populated nav property to compare against, so adding a new
-        // TicketComment via the aggregate's encapsulated method is detected
-        // as an INSERT rather than slipping through change detection.
+        // Load the Comments collection up front so EF's change tracker detects the new TicketComment
+        // (added via the aggregate) as an INSERT rather than missing it during change detection.
         var ticket = await dbContext.Tickets
             .Include(t => t.Comments)
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CreateTicket/CreateTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CreateTicket/CreateTicketCommandHandler.cs
@@ -29,19 +29,8 @@ public sealed class CreateTicketCommandHandler(
                 HttpStatusCode.Unauthorized);
         }
 
-        // Sequential, tenant-scoped ticket numbers (TK-1, TK-2, …).
-        //
-        // We count ALL tenant rows including soft-deleted ones (via
-        // IgnoreQueryFilters) — otherwise a deleted TK-3 would let us
-        // re-issue TK-3 to a new ticket, which collides with the live
-        // unique index AND is a confusing audit footprint. Two writers
-        // racing here will both compute the same next-number; the
-        // filtered unique index on `Number` rejects the second insert
-        // and the API surface returns 409 — caller can retry.
-        //
-        // For higher write contention, the right upgrade is a dedicated
-        // counter table updated via `UPDATE … RETURNING` (or a Postgres
-        // sequence per tenant). The demo doesn't need it.
+        // Sequential, tenant-scoped ticket numbers (TK-1, …). Count ALL rows incl. soft-deleted so a
+        // deleted number isn't reused; racing writers collide on the unique index (→ 409, retryable).
         long count = await dbContext.Tickets
             .IgnoreQueryFilters([QueryFilters.SoftDelete])
             .LongCountAsync(cancellationToken)

--- a/src/Modules/Tickets/Modules.Tickets/TicketsModule.cs
+++ b/src/Modules/Tickets/Modules.Tickets/TicketsModule.cs
@@ -65,9 +65,8 @@ public sealed class TicketsModule : IModule
             .WithApiVersionSet(versionSet)
             .RequireAuthorization();
 
-        // Trash + comment routes registered before the catch-all
-        // `{ticketId:guid}` GET so the literal segments win. Minimal APIs
-        // match the first compatible pattern, so order matters.
+        // Trash + comment routes register before the catch-all `{ticketId:guid}` GET so literal
+        // segments win — minimal APIs match the first compatible pattern, so order matters.
         group.MapListTrashedTicketsEndpoint();
         group.MapAddTicketCommentEndpoint();
         group.MapListTicketCommentsEndpoint();

--- a/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDispatchJob.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDispatchJob.cs
@@ -59,9 +59,8 @@ public sealed class WebhookDispatchJob
         ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
         ArgumentException.ThrowIfNullOrWhiteSpace(payloadJson);
 
-        // Mirror SqlAuditSink's pattern: create a fresh scope, set tenant context first,
-        // then resolve the DbContext so its Finbuckle filter reads a real TenantInfo
-        // instead of a null one from the outer scope.
+        // Like SqlAuditSink: fresh scope, set tenant context first, then resolve the DbContext so its
+        // Finbuckle filter reads a real TenantInfo instead of a null one from the outer scope.
         using var scope = _scopeFactory.CreateScope();
         var store = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<AppTenantInfo>>();
         var tenant = await store.GetAsync(tenantId).ConfigureAwait(false);

--- a/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookFanoutHandler.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookFanoutHandler.cs
@@ -54,10 +54,8 @@ public sealed class WebhookFanoutHandler<TEvent> : IIntegrationEventHandler<TEve
             return;
         }
 
-        // Restore the tenant context for the subscription read — the WebhookDbContext
-        // Finbuckle query filter relies on multiTenantContextAccessor seeing the right
-        // tenant. The OutboxDispatcher / event bus background pumps don't carry HTTP
-        // context, so we need to install it explicitly here.
+        // Install the tenant context for the subscription read — the WebhookDbContext Finbuckle filter needs
+        // it, and the background event pumps (OutboxDispatcher / event bus) carry no HTTP context.
         var prev = _tenantContextAccessor.MultiTenantContext;
         try
         {
@@ -67,9 +65,8 @@ public sealed class WebhookFanoutHandler<TEvent> : IIntegrationEventHandler<TEve
 
             var eventType = typeof(TEvent).Name;
 
-            // Pull active subscriptions for this tenant; filter by event type in memory
-            // because EventsCsv stores a CSV blob, not a join table — there are typically
-            // 0–20 subscriptions per tenant so in-memory matching is fine.
+            // Pull active subscriptions, then match event type in memory: EventsCsv is a CSV blob (no join
+            // table), and there are typically 0–20 subscriptions per tenant so in-memory matching is fine.
             var subscriptions = await _db.Subscriptions
                 .AsNoTracking()
                 .Where(s => s.IsActive)
@@ -93,9 +90,8 @@ public sealed class WebhookFanoutHandler<TEvent> : IIntegrationEventHandler<TEve
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    // One bad subscription must not abort fan-out to others — the dispatcher
-                    // job itself has its own retry policy, this catch is for synchronous
-                    // enqueue-side failures (Hangfire transient errors etc).
+                    // One bad subscription must not abort fan-out to others; this catches synchronous
+                    // enqueue-side failures (Hangfire transient errors etc), not delivery (the job retries).
                     _logger.LogWarning(
                         ex,
                         "Failed to enqueue webhook delivery for subscription {SubscriptionId} (tenant {TenantId}, event {EventType})",

--- a/src/Modules/Webhooks/Modules.Webhooks/WebhooksModule.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/WebhooksModule.cs
@@ -39,9 +39,8 @@ public sealed class WebhooksModule : IModule
         builder.Services.AddScoped<IWebhookDispatcher, WebhookDispatcher>();
         builder.Services.AddScoped<WebhookDispatchJob>();
 
-        // Open-generic integration-event bridge — every IIntegrationEvent the bus
-        // publishes is fanned out to matching tenant webhook subscriptions. Closed
-        // handler types are materialized per event type by DI.
+        // Open-generic integration-event bridge — every published IIntegrationEvent fans out to
+        // matching tenant webhook subscriptions; DI materializes closed handler types per event.
         builder.Services.AddScoped(
             typeof(IIntegrationEventHandler<>),
             typeof(WebhookFanoutHandler<>));

--- a/src/Tests/Architecture.Tests/BuildingBlocksIndependenceTests.cs
+++ b/src/Tests/Architecture.Tests/BuildingBlocksIndependenceTests.cs
@@ -166,11 +166,8 @@ public class BuildingBlocksIndependenceTests
     [Fact]
     public void BuildingBlocks_Should_Follow_Layered_Dependencies()
     {
-        // Define the expected dependency order (lower layers should not depend on higher)
-        // Layer 0: Core (no dependencies)
-        // Layer 1: Shared, Caching, Mailing, Storage (depend on Core)
-        // Layer 2: Persistence, Jobs (depend on Core, Shared)
-        // Layer 3: Eventing, Web (can depend on lower layers)
+        // Expected layering (lower must not depend on higher): 0=Core; 1=Shared/Caching/Mailing/Storage;
+        // 2=Persistence/Jobs; 3=Eventing/Web.
 
         var layerViolations = new List<string>();
 
@@ -237,10 +234,8 @@ public class BuildingBlocksIndependenceTests
         }
     }
 
-    // ProjectReference Include paths are authored with Windows separators (e.g. ..\Core\Core.csproj).
-    // Path.GetFileNameWithoutExtension only treats '\' as a separator on Windows, so on Linux CI it
-    // returns the whole path minus the extension. Normalize to '/' first to get the bare project name
-    // on every platform.
+    // ProjectReference paths use Windows separators (..\Core\Core.csproj), but GetFileNameWithoutExtension only
+    // splits on '\' on Windows — normalize to '/' first so Linux CI also gets the bare project name.
     private static string GetReferencedProjectName(string includePath) =>
         Path.GetFileNameWithoutExtension(includePath.Replace('\\', '/'));
 }

--- a/src/Tests/Architecture.Tests/ContractsPurityTests.cs
+++ b/src/Tests/Architecture.Tests/ContractsPurityTests.cs
@@ -175,10 +175,8 @@ public class ContractsPurityTests
             }
         }
 
-        // This is informational - existing codebase may have non-sealed commands
-        // The pattern is recommended but not strictly enforced to allow gradual migration
-        // For now, just verify we can identify non-sealed types (the test infrastructure works)
-        // This serves as documentation of types that could be improved
+        // Informational only: sealed commands/queries are recommended but not enforced (gradual migration).
+        // Just verify the test infrastructure can identify non-sealed types.
         nonSealedTypes.ShouldNotBeNull();
     }
 }

--- a/src/Tests/Architecture.Tests/EndpointConventionTests.cs
+++ b/src/Tests/Architecture.Tests/EndpointConventionTests.cs
@@ -202,9 +202,8 @@ public class EndpointConventionTests
             }
         }
 
-        // This check is informational: some private static helpers in endpoints are acceptable.
-        // A hard failure would require case-by-case review. We assert the list was populated
-        // (i.e., the test ran) rather than that it is empty.
+        // Informational only — some private static helpers in endpoints are acceptable; we assert
+        // the check ran (list populated) rather than that it is empty.
         warnings.ShouldNotBeNull("Endpoint business logic check did not run");
         // Review any endpoints reported in 'warnings' and move business logic to handlers.
     }

--- a/src/Tests/Architecture.Tests/TenantIsolationTests.cs
+++ b/src/Tests/Architecture.Tests/TenantIsolationTests.cs
@@ -91,9 +91,8 @@ public sealed class TenantIsolationTests
         var optionsType = typeof(DbContextOptions<>).MakeGenericType(dbContextType);
         var builderType = typeof(DbContextOptionsBuilder<>).MakeGenericType(dbContextType);
         var builder = (DbContextOptionsBuilder)Activator.CreateInstance(builderType)!;
-        // Use Npgsql provider so OnConfiguring's per-tenant wiring is a no-op
-        // (we pass an empty ConnectionString below). Model is built lazily on
-        // first access of ctx.Model — no actual DB connection is opened.
+        // Npgsql provider keeps OnConfiguring's per-tenant wiring a no-op (empty ConnectionString);
+        // the model builds lazily on first ctx.Model access, so no DB connection is opened.
         builder.UseNpgsql("Host=arch;Database=arch;Username=arch;Password=arch");
         var options = builder.Options;
 

--- a/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
+++ b/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
@@ -19,9 +19,8 @@ public sealed class GlobalExceptionHandlerTests
         return context;
     }
 
-    // Regression for #1245: a missing required `tenant` header surfaces as a
-    // BadHttpRequestException during parameter binding. It must be rendered with
-    // the framework's own status (400), not the generic 500 fallback.
+    // Regression for #1245: a missing required `tenant` header surfaces as a BadHttpRequestException
+    // during binding and must render with its own status (400), not the generic 500 fallback.
     [Fact]
     public async Task TryHandleAsync_Should_Map_BadHttpRequestException_To_ItsStatusCode()
     {

--- a/src/Tests/Generic.Tests/Architecture/HandlerArchitectureTests.cs
+++ b/src/Tests/Generic.Tests/Architecture/HandlerArchitectureTests.cs
@@ -197,9 +197,8 @@ public sealed class HandlerArchitectureTests
 
     private static bool IsPartialClass(Type type)
     {
-        // Partial classes that use source generators (like GeneratedRegex) will have
-        // compiler-generated nested types or methods. We check for the presence of
-        // GeneratedRegex attribute on any method as an indicator.
+        // Source-generator partials (e.g. GeneratedRegex) emit compiler-generated members; detect
+        // them via a GeneratedRegexAttribute on any method.
         return type.GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
             .Any(m => m.GetCustomAttributes()
                 .Any(a => a.GetType().Name == "GeneratedRegexAttribute"));

--- a/src/Tests/Integration.Middleware.Tests/Infrastructure/MiddlewareWebApplicationFactory.cs
+++ b/src/Tests/Integration.Middleware.Tests/Infrastructure/MiddlewareWebApplicationFactory.cs
@@ -64,16 +64,8 @@ public sealed class MiddlewareWebApplicationFactory : WebApplicationFactory<Prog
 
     public MiddlewareWebApplicationFactory()
     {
-        // ── Rate-limit config must be visible to the EAGER read in AddHeroRateLimiting ──
-        // AddHeroRateLimiting calls configuration.GetSection(...).Get<RateLimitingOptions>()
-        // at SERVICE-REGISTRATION time — which, for WebApplicationFactory, runs while Program.cs's
-        // top-level statements execute (before ConfigureWebHost's in-memory overlay is merged).
-        // appsettings.json ships RateLimitingOptions:Enabled=false, so the eager read would
-        // register NO limiter/policy and nothing would ever 429 (the later ConfigureAppConfiguration
-        // overlay only fixes IOptions, not the already-built limiter). Environment variables ARE in
-        // the default config that WebApplication.CreateBuilder reads up front, so setting them in the
-        // ctor (before `_ = Server` triggers host build) makes the eager read see Enabled=true and
-        // the tiny auth window. Same eager-config gotcha as AddHeroStorage.
+        // AddHeroRateLimiting reads config EAGERLY at registration (before ConfigureWebHost's overlay merges)
+        // and appsettings ships Enabled=false; set env vars here (in the up-front config) to flip it. Cf. AddHeroStorage.
         Environment.SetEnvironmentVariable("RateLimitingOptions__Enabled", "true");
         Environment.SetEnvironmentVariable("RateLimitingOptions__Auth__PermitLimit", "3");
         Environment.SetEnvironmentVariable("RateLimitingOptions__Auth__WindowSeconds", "300");
@@ -92,9 +84,8 @@ public sealed class MiddlewareWebApplicationFactory : WebApplicationFactory<Prog
         // Force host creation via the Server property (no leaked HttpClient)
         _ = Server;
 
-        // Run migrations and seed data for the root tenant.
-        // We use a semaphore to prevent multiple test classes (which might share the same DB)
-        // from attempting to migrate simultaneously.
+        // Migrate + seed the root tenant; the semaphore stops test classes sharing a DB from
+        // migrating simultaneously.
         await _migrationLock.WaitAsync();
         try
         {
@@ -176,10 +167,8 @@ public sealed class MiddlewareWebApplicationFactory : WebApplicationFactory<Prog
                 ["Seed:DemoPassword"] = "Password123!",
                 ["Seed:DefaultAdminPassword"] = TestConstants.DefaultPassword,
 
-                // --- Middleware-test-specific overrides (the whole point of this assembly) ---
-                // Rate limiting ON. Only the per-request "auth" policy should trip; the global
-                // tenant/user/ip chained limiters are set effectively unlimited so they never
-                // interfere with the burst test against /token/issue.
+                // Middleware-test overrides: rate limiting ON, but only the "auth" policy should trip —
+                // the global tenant/user/ip limiters are set unlimited so they don't interfere.
                 ["RateLimitingOptions:Enabled"] = "true",
                 ["RateLimitingOptions:Auth:PermitLimit"] = "3",
                 ["RateLimitingOptions:Auth:WindowSeconds"] = "300",
@@ -204,10 +193,8 @@ public sealed class MiddlewareWebApplicationFactory : WebApplicationFactory<Prog
 
         builder.ConfigureServices(services =>
         {
-            // Remove hosted services that depend on infrastructure not available in tests or cause race conditions:
-            // - RolePermissionSyncHostedService (queries identity schema before migrations run)
-            // - Hangfire server + stale lock cleanup (we register our own InMemory server below)
-            // - OutboxDispatcherHostedService (queries OutboxMessages table before migrations run)
+            // Remove hosted services that need unavailable infra or race migrations: RolePermissionSync,
+            // OutboxDispatcher (query tables pre-migration), and Hangfire server/cleanup (InMemory below).
             var hostedServicesToRemove = services
                 .Where(d => d.ServiceType == typeof(IHostedService) &&
                     (d.ImplementationType?.Name == "RolePermissionSyncHostedService" ||
@@ -237,27 +224,11 @@ public sealed class MiddlewareWebApplicationFactory : WebApplicationFactory<Prog
             services.RemoveAll<IMailService>();
             services.AddSingleton<IMailService, NoOpMailService>();
 
-            // NOTE: Unlike Integration.Tests' FshWebApplicationFactory we DELIBERATELY do NOT
-            // swap IExceptionHandler. The production GlobalExceptionHandler stays in place so the
-            // /__test/throw endpoint produces real RFC 9457 ProblemDetails output.
-            //
-            // We also do NOT rewire storage to S3: none of the middleware tests touch a storage
-            // endpoint, so the production registration (which resolves to LocalStorageService) is
-            // fine. Rewiring would require referencing the internal S3StorageService type, which is
-            // only InternalsVisibleTo "Integration.Tests" — and we must not modify BuildingBlocks.
-            // The MinIO container + Storage:S3 config keys are kept so the host configuration binds
-            // cleanly and provisioning/seeding succeed unchanged.
+            // DELIBERATELY keep the production GlobalExceptionHandler (no swap) so /__test/throw yields real
+            // RFC 9457 output; storage stays unrewired (no test hits it; MinIO + S3 keys kept so host binds).
 
-            // Append a throwing endpoint to the live route builder so the production
-            // GlobalExceptionHandler can be exercised end-to-end.
-            //
-            // NOTE on technique: a plain DI-registered EndpointDataSource is NOT routed by minimal
-            // hosting — WebApplication only maps the data sources attached to the route builder it
-            // owns. So we register an IStartupFilter, run `next(app)` FIRST (which executes Program.cs's
-            // pipeline incl. UseRouting → this stamps the WebApplication's own IEndpointRouteBuilder
-            // into app.Properties["__EndpointRouteBuilder"]), and only THEN reach into that builder and
-            // MapGet. Endpoints added to the route builder's DataSources are resolved lazily on the
-            // first request, so appending after the pipeline is built still gets the endpoint matched.
+            // Append a throwing endpoint via IStartupFilter: run next(app) first (UseRouting stamps the real
+            // IEndpointRouteBuilder into app.Properties), then MapGet onto it — lazy data sources still match.
             services.AddSingleton<IStartupFilter, ThrowEndpointStartupFilter>();
         });
     }

--- a/src/Tests/Integration.Tests/Infrastructure/FshWebApplicationFactory.cs
+++ b/src/Tests/Integration.Tests/Infrastructure/FshWebApplicationFactory.cs
@@ -56,9 +56,8 @@ public sealed class FshWebApplicationFactory : WebApplicationFactory<Program>, I
         // Force host creation via the Server property (no leaked HttpClient)
         _ = Server;
 
-        // Run migrations and seed data for the root tenant.
-        // We use a semaphore to prevent multiple test classes (which might share the same DB)
-        // from attempting to migrate simultaneously.
+        // Migrate + seed the root tenant. The semaphore stops test classes sharing the DB
+        // from migrating simultaneously.
         await _migrationLock.WaitAsync();
         try
         {
@@ -154,10 +153,8 @@ public sealed class FshWebApplicationFactory : WebApplicationFactory<Program>, I
 
         builder.ConfigureServices(services =>
         {
-            // Remove hosted services that depend on infrastructure not available in tests or cause race conditions:
-            // - RolePermissionSyncHostedService (queries identity schema before migrations run)
-            // - Hangfire server + stale lock cleanup (we register our own InMemory server below)
-            // - OutboxDispatcherHostedService (queries OutboxMessages table before migrations run)
+            // Remove hosted services that need unavailable infra or race migrations (RolePermissionSync,
+            // Hangfire server + stale-lock cleanup, OutboxDispatcher); we register our own InMemory server below.
             var hostedServicesToRemove = services
                 .Where(d => d.ServiceType == typeof(IHostedService) &&
                     (d.ImplementationType?.Name == "RolePermissionSyncHostedService" ||
@@ -193,10 +190,8 @@ public sealed class FshWebApplicationFactory : WebApplicationFactory<Program>, I
             foreach (var h in existingHandlers) services.Remove(h);
             services.AddExceptionHandler<DetailedTestExceptionHandler>();
 
-            // AddHeroStorage reads `Storage:Provider` eagerly at registration time, before the test
-            // factory's in-memory configuration overlay is applied — so the production registration
-            // wires up LocalStorageService. Replace it with the S3 stack pointed at the MinIO
-            // testcontainer here, after all module registrations have run.
+            // AddHeroStorage reads `Storage:Provider` eagerly (before the test config overlay applies), so it
+            // wires LocalStorageService. Replace it here with the S3 stack pointed at the MinIO testcontainer.
             RewireStorageForS3(services);
         });
     }

--- a/src/Tests/Integration.Tests/Tests/Auditing/AuditExceptionAndFilterTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Auditing/AuditExceptionAndFilterTests.cs
@@ -300,9 +300,8 @@ public sealed class AuditExceptionAndFilterTests
     [Fact]
     public async Task GetAudits_Should_ClampWindow_When_OnlyFromSuppliedAndOld()
     {
-        // Arrange — supplying only fromUtc (well beyond MaxWindow) bypasses the
-        // validator's both-endpoints rule and exercises the handler's clamp to
-        // the 90-day MaxWindow. A both-endpoints range >90d would 400 instead.
+        // Only fromUtc (well beyond MaxWindow) bypasses the validator's both-endpoints rule and exercises
+        // the handler's clamp to the 90-day MaxWindow. A both-endpoints range >90d would 400 instead.
         using var client = await _auth.CreateRootAdminClientAsync();
         await AuditTestHelper.GenerateActivityAuditAsync(client);
         string from = DateTime.UtcNow.AddDays(-400).ToString("o");
@@ -407,11 +406,8 @@ public sealed class AuditExceptionAndFilterTests
 
     private static async Task TriggerApiExceptionAsync(HttpClient client)
     {
-        // GET /audits/{guid} for a non-existent record throws KeyNotFoundException
-        // inside the audited request, producing an Api-area Exception audit event.
-        // The AuditHttpMiddleware writes the exception audit before the exception
-        // propagates to the exception handler, so the audit is recorded regardless
-        // of the final HTTP status the handler renders.
+        // GET /audits/{guid} for a missing record throws KeyNotFoundException inside the audited request, producing an Api-area Exception audit.
+        // AuditHttpMiddleware writes it before the exception reaches the handler, so it's recorded regardless of the final HTTP status.
         var response = await client.GetAsync($"{TestConstants.AuditsBasePath}/{Guid.NewGuid()}");
         (await AuditTestHelper.IsNotFoundAsync(response)).ShouldBeTrue();
     }

--- a/src/Tests/Integration.Tests/Tests/Auditing/AuditPayloadFilterTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Auditing/AuditPayloadFilterTests.cs
@@ -151,9 +151,8 @@ public sealed class AuditPayloadFilterTests
     [Fact]
     public async Task GetAudits_Should_DriveSearchOverRealAsyncWrittenAudit_When_LoggingIn()
     {
-        // Arrange — exercises the full async write path: a login produces a Security audit
-        // written by the background channel worker, then GetAudits?search= filters over the
-        // jsonb payload of that real row. Proves the fix end-to-end (no 500, correct match).
+        // Arrange — full async write path: a login produces a Security audit via the background
+        // channel worker, then GetAudits?search= filters its jsonb payload (end-to-end fix proof).
         await _auth.GetRootAdminTokenAsync();
         using var client = await _auth.CreateRootAdminClientAsync();
 

--- a/src/Tests/Integration.Tests/Tests/Authentication/AccountLockoutTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Authentication/AccountLockoutTests.cs
@@ -83,10 +83,8 @@ public sealed class AccountLockoutTests
             });
         registerResponse.StatusCode.ShouldBe(HttpStatusCode.Created);
 
-        // Admin-registered users aren't auto-confirmed; force-confirm via UserManager
-        // so the login flow reaches the password + lockout check instead of the
-        // EmailConfirmed guard. Need to set tenant context before UserManager queries
-        // so Finbuckle's multi-tenant filter has a real TenantInfo.
+        // Admin-registered users aren't auto-confirmed; force-confirm via UserManager so login reaches the
+        // password/lockout check. Set tenant context first so Finbuckle's filter has a real TenantInfo.
         using var scope = _factory.Services.CreateScope();
         var tenant = await scope.ServiceProvider
             .GetRequiredService<IMultiTenantStore<AppTenantInfo>>()

--- a/src/Tests/Integration.Tests/Tests/Authentication/PasswordResetTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Authentication/PasswordResetTests.cs
@@ -108,10 +108,8 @@ public sealed class PasswordResetTests
 
     #region Helpers
 
-    // NOTE: the tenant context is set INLINE here, not via an awaited helper. The
-    // Finbuckle IMultiTenantContextSetter writes to an AsyncLocal; a value set inside
-    // a separate awaited method is lost on return to the caller, so the tenant query
-    // filter would NRE during CreateAsync. Keep the setter in the same method body.
+    // Set the tenant context INLINE, not via an awaited helper: the Finbuckle setter writes an AsyncLocal
+    // that's lost on return from a separate method, NREing the tenant query filter during CreateAsync.
     private async Task CreateActiveUserAsync(string email, string password)
     {
         using var scope = _factory.Services.CreateScope();

--- a/src/Tests/Integration.Tests/Tests/Billing/BillingDomainEdgeTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/BillingDomainEdgeTests.cs
@@ -181,12 +181,8 @@ public sealed class BillingDomainEdgeTests
     [Fact]
     public async Task AddLineItem_Overage_Should_Round_Amount_AwayFromZero_And_Recompute_Subtotal()
     {
-        // Build the invoice graph fresh (BaseFee + Overage) then Add it — this mirrors how
-        // BillingService.GenerateInvoiceForPeriodAsync composes an invoice and is the production add
-        // pattern for line items. The overage line's Quantity*UnitPrice is exactly a .x25 midpoint:
-        // 2.5 * 0.01 = 0.025, which rounds AwayFromZero to 0.03 (banker's rounding would give 0.02),
-        // pinning the MidpointRounding.AwayFromZero behaviour in InvoiceLineItem.Create. Subtotal must
-        // recompute across both lines.
+        // Build the invoice fresh (BaseFee + Overage). Overage 2.5*0.01=0.025 must round AwayFromZero to
+        // 0.03 (not banker's 0.02), and the subtotal must recompute across both lines.
         // Arrange / Act
         var (year, month) = NextPeriod();
         Guid invoiceId = Guid.Empty;
@@ -257,10 +253,8 @@ public sealed class BillingDomainEdgeTests
 
     private async Task<Guid> SeedActiveSubscriptionAsync()
     {
-        // Use a throwaway tenant id, NOT root: there is a partial unique index
-        // (ux_subscriptions_tenantid_active) allowing at most one Active subscription per tenant, and
-        // root already has one from sibling tests in this collection. The billing DbContext is not
-        // tenant-filtered, so seeding an arbitrary tenant id is fine for status-transition coverage.
+        // Throwaway tenant id, NOT root: a partial unique index allows one Active subscription per tenant
+        // and root already has one. Billing's DbContext isn't tenant-filtered, so any tenant id works here.
         var tenantId = $"sub-edge-{Guid.NewGuid().ToString("N")[..8]}";
         Guid id = Guid.Empty;
         await SeedDirectAsync(async db =>

--- a/src/Tests/Integration.Tests/Tests/Billing/BillingEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/BillingEndpointTests.cs
@@ -31,9 +31,8 @@ public sealed class BillingEndpointTests
         Converters = { new JsonStringEnumConverter() }
     };
 
-    // Tests in this class need unique billing periods to avoid colliding on the
-    // (TenantId, PeriodYear, PeriodMonth) unique index. The shared factory is reused across the
-    // collection, so a process-wide counter keeps every test's period distinct.
+    // Tests need unique billing periods to avoid colliding on the (TenantId, PeriodYear, PeriodMonth)
+    // unique index; the factory is collection-shared, so a process-wide counter keeps periods distinct.
     private static int s_periodCounter;
 
     private readonly FshWebApplicationFactory _factory;
@@ -381,9 +380,8 @@ public sealed class BillingEndpointTests
     [Fact]
     public async Task IssueInvoice_Should_Reject_NonDraft_Invoice()
     {
-        // The Invoice aggregate's RequireStatus(Draft) guard surfaces as InvalidOperationException
-        // which the global handler converts to 5xx. We don't pin the exact status — just that the
-        // call did not succeed AND the invoice state is unchanged.
+        // The aggregate's RequireStatus(Draft) guard surfaces as InvalidOperationException (5xx);
+        // we don't pin the status — just that the call failed AND the invoice state is unchanged.
         var (year, month) = NextPeriod();
         var invoiceId = await SeedDraftInvoiceAsync(TestConstants.RootTenantId, year, month);
         await SeedDirectAsync(async db =>
@@ -551,9 +549,8 @@ public sealed class BillingEndpointTests
         inv.SubtotalAmount.ShouldBe(0m,
             "usage invoices bill metered overage only — the base fee moved to the subscription invoice, and root has no overage");
 
-        // Second call must be idempotent for root — it must not create a second invoice for the
-        // same (tenant, period). (Asserting the global Generated count is 0 is unreliable because
-        // other tests leave additional subscribed tenants in the shared host.)
+        // Second call must be idempotent for root (no duplicate invoice for the same tenant+period);
+        // asserting a global Generated count of 0 is unreliable since other tests leave subscribed tenants.
         using var secondResp = await client.PostAsJsonAsync(
             $"{BillingBasePath}/invoices/generate", new { periodYear = year, periodMonth = month });
         secondResp.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/src/Tests/Integration.Tests/Tests/Billing/BillingTenantIsolationTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/BillingTenantIsolationTests.cs
@@ -142,9 +142,8 @@ public sealed class BillingTenantIsolationTests
 
     #region Cross-tenant mutation isolation (P0 security regressions)
 
-    // A non-root tenant must never be able to MUTATE another tenant's billing resources by id —
-    // the read-side isolation above is necessary but not sufficient. Each test below encodes the
-    // exact attack: tenant B (fresh, non-root) targets root's resource. Pre-fix these succeeded.
+    // A non-root tenant must never MUTATE another tenant's billing resources by id (read isolation
+    // alone is insufficient). Each test below has tenant B target root's resource; pre-fix these succeeded.
 
     [Fact]
     public async Task VoidInvoice_Should_Return404_When_OwnedByDifferentTenant()
@@ -274,10 +273,8 @@ public sealed class BillingTenantIsolationTests
     [Fact]
     public async Task GenerateInvoiceForPeriod_Should_CreateUsageInvoice_EvenWhen_SubscriptionInvoiceSharesThePeriod()
     {
-        // Reproduces the revenue bug: the idempotency check used to match ANY invoice for the period
-        // (no Purpose), so when a Subscription invoice already existed for the month the Usage/overage
-        // invoice was silently skipped. Seed an active subscription + a Subscription invoice, then
-        // generate — a Usage invoice must still be produced.
+        // Reproduces the revenue bug: the idempotency check matched ANY invoice for the period (ignoring
+        // Purpose), silently skipping the Usage invoice when a Subscription invoice already existed.
         var (year, month) = NextPeriod();
         using var rootClient = await _auth.CreateRootAdminClientAsync();
         var key = UniqueKey("usgskip");
@@ -295,9 +292,8 @@ public sealed class BillingTenantIsolationTests
             await db.SaveChangesAsync();
         });
 
-        // Invoke the generator directly for this exact period (tenant context = root). Pre-fix the
-        // idempotency check matched the seeded SUBSCRIPTION invoice and returned it (Purpose=Subscription),
-        // skipping usage billing. Post-fix it must produce a USAGE invoice.
+        // Invoke the generator directly for this period (tenant context = root). Pre-fix it returned the
+        // seeded Subscription invoice and skipped usage billing; post-fix it must produce a Usage invoice.
         var generated = await InvokeGenerateInvoiceForPeriodAsync(TestConstants.RootTenantId, year, month);
 
         generated.ShouldNotBeNull("the generator must produce an invoice when an active subscription exists");
@@ -390,9 +386,8 @@ public sealed class BillingTenantIsolationTests
         return id;
     }
 
-    // The Finbuckle tenant context is an AsyncLocal; it MUST be set inline in the same method body
-    // that resolves and uses the DbContext, otherwise it is lost across the await boundary and the
-    // tenant query filter throws a NullReferenceException.
+    // The Finbuckle tenant context is an AsyncLocal: set it inline in the same method that resolves the
+    // DbContext, else it's lost across the await boundary and the tenant query filter NREs.
     private async Task SeedDirectAsync(string tenantId, Func<BillingDbContext, Task> action)
     {
         using var scope = _factory.Services.CreateScope();

--- a/src/Tests/Integration.Tests/Tests/Billing/UsageSnapshotQueryTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/UsageSnapshotQueryTests.cs
@@ -31,9 +31,8 @@ public sealed class UsageSnapshotQueryTests
         Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
     };
 
-    // Snapshots are unique-indexed on (TenantId, PeriodYear, PeriodMonth, Resource). The factory is
-    // shared across the whole collection, so a process-wide counter hands every test a private period
-    // window well away from the 2030/2031/2080+ ranges other Billing tests use.
+    // Snapshots are unique-indexed on (TenantId, PeriodYear, PeriodMonth, Resource); a process-wide
+    // counter hands each test a private period window away from other Billing tests' ranges.
     private static int s_periodCounter;
 
     private readonly FshWebApplicationFactory _factory;
@@ -180,9 +179,8 @@ public sealed class UsageSnapshotQueryTests
     [Fact]
     public async Task GetUsageSnapshots_Should_Return200_For_NonAdmin_User_With_Basic_View_Permission()
     {
-        // The View Billing permission is IsBasic, so a freshly-registered user (granted RoleConstants.Basic)
-        // can read the usage list. This proves the .RequirePermission(Billing.View) gate admits an
-        // authenticated non-admin caller rather than only the seeded root admin.
+        // Billing.View is a Basic permission, so a freshly-registered (Basic-role) user can read the usage
+        // list — proving the gate admits an authenticated non-admin, not just the seeded root admin.
         // Arrange
         using var adminClient = await _auth.CreateRootAdminClientAsync();
         var (email, password) = await RegisterBasicUserAsync(adminClient, "snap-basic");
@@ -203,11 +201,8 @@ public sealed class UsageSnapshotQueryTests
     [Fact]
     public async Task GetUsageSnapshots_Is_PlatformWide_And_Surfaces_OtherTenant_Rows_To_Admin()
     {
-        // GetUsageSnapshots mirrors GetInvoices: it is an administrative, platform-wide list that is
-        // NOT auto-scoped to the caller's tenant — the only narrowing is the optional tenantId filter.
-        // This test pins that documented behavior: a second tenant's snapshot is visible in the
-        // unfiltered admin result, and the tenantId filter is what isolates a single tenant. (Asserting
-        // hard isolation here would contradict the handler; see findings note on the Basic-View posture.)
+        // GetUsageSnapshots mirrors GetInvoices: a platform-wide admin list NOT auto-scoped to the caller's
+        // tenant. Pins that another tenant's snapshot shows unfiltered and the tenantId filter isolates one.
         // Arrange
         var (year, month) = NextPeriod();
         var otherTenant = $"snap-cross-{Guid.NewGuid().ToString("N")[..8]}";

--- a/src/Tests/Integration.Tests/Tests/Caching/HybridCacheRedisTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Caching/HybridCacheRedisTests.cs
@@ -88,9 +88,8 @@ public sealed class HybridCacheRedisTests : IAsyncLifetime
     [Fact]
     public async Task RemoveByTagAsync_Should_Invalidate_Within_Same_Instance()
     {
-        // Note: HybridCache tag invalidation is per-instance (no L1 backplane). This test
-        // verifies the in-instance behavior; cross-node invalidation requires a custom
-        // pub/sub backplane and is documented as a known limitation in docs/caching.mdx.
+        // HybridCache tag invalidation is per-instance (no L1 backplane); cross-node invalidation
+        // needs a custom pub/sub backplane — a known limitation documented in docs/caching.mdx.
         var (cache, _, provider) = CreateCache();
         await using (provider)
         {
@@ -118,9 +117,8 @@ public sealed class HybridCacheRedisTests : IAsyncLifetime
     [Fact]
     public void Redis_Backend_Should_Implement_IBufferDistributedCache()
     {
-        // Microsoft.Extensions.Caching.StackExchangeRedis 9.0+ implements IBufferDistributedCache
-        // for zero-copy reads via HybridCache. If this regresses, every L2 read pays an extra
-        // byte[] allocation. Lock it in.
+        // StackExchangeRedis 9.0+ implements IBufferDistributedCache for HybridCache zero-copy reads;
+        // a regression would cost an extra byte[] allocation per L2 read, so lock it in.
         var (_, distributedCache, provider) = CreateCache();
         using (provider)
         {

--- a/src/Tests/Integration.Tests/Tests/Catalog/BrandsEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Catalog/BrandsEndpointTests.cs
@@ -148,9 +148,8 @@ public sealed class BrandsEndpointTests
     [Fact]
     public async Task CreateBrand_Should_Succeed_When_NameMatchesSoftDeletedBrand()
     {
-        // The filtered unique index on Slug excludes soft-deleted rows so the
-        // same name can be reused after a delete — admins shouldn't get a 409
-        // unless there's a *live* brand with the conflicting slug.
+        // Filtered unique index on Slug excludes soft-deleted rows, so a name can be reused after
+        // a delete — a 409 should only fire when a *live* brand holds the conflicting slug.
         using var client = await _auth.CreateRootAdminClientAsync();
         var name = UniqueName("Reusable");
         var firstId = await CreateAsync(client, name);
@@ -259,9 +258,8 @@ public sealed class BrandsEndpointTests
     [Fact]
     public async Task CreateBrand_Should_NotMarkReplayed_When_NoIdempotencyKey()
     {
-        // Same-key replay is verified globally in IdempotencyFilterTests — same filter,
-        // same wiring. Here we just verify Brands' POST without a key behaves normally
-        // (no spurious replay header), which catches accidental opt-in regressions.
+        // Same-key replay is verified globally in IdempotencyFilterTests; here we just confirm
+        // Brands' POST without a key behaves normally, catching accidental opt-in regressions.
         const string ReplayedHeader = "Idempotency-Replayed";
 
         using var client = await _auth.CreateRootAdminClientAsync();

--- a/src/Tests/Integration.Tests/Tests/Catalog/CategoriesEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Catalog/CategoriesEndpointTests.cs
@@ -257,9 +257,8 @@ public sealed class CategoriesEndpointTests
     [Fact]
     public async Task CreateCategory_Should_Succeed_When_NameMatchesSoftDeletedCategory()
     {
-        // Filtered unique index on Slug excludes soft-deleted rows, so the same name can be
-        // reused after a delete — admins shouldn't get a 409 unless there's a *live* category
-        // with the conflicting slug.
+        // Filtered unique index on Slug excludes soft-deleted rows, so a name can be reused after
+        // a delete — a 409 should only fire when a *live* category holds the conflicting slug.
         using var client = await _auth.CreateRootAdminClientAsync();
         var name = UniqueName("Reusable");
         var firstId = await CreateAsync(client, name);

--- a/src/Tests/Integration.Tests/Tests/Catalog/ProductImagesTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Catalog/ProductImagesTests.cs
@@ -125,12 +125,8 @@ public sealed class ProductImagesTests
     [Fact]
     public async Task SetProductThumbnail_Should_Survive_Repeated_Flips_Across_Three_Images()
     {
-        // Regression: a partial UNIQUE index on (ProductId) WHERE IsThumbnail=TRUE was firing
-        // whenever EF emitted promote-before-demote, leaving the constraint with two TRUE rows
-        // mid-statement. The aggregate enforces the single-thumbnail invariant on its own; the
-        // DB-level constraint was belt-and-suspenders that broke for half the EF orderings.
-        // Walking the thumbnail through every image, both forward and backward, is the
-        // ordering-agnostic way to lock that bug down.
+        // Regression: a partial UNIQUE on (ProductId) WHERE IsThumbnail fired mid-statement on promote-before-
+        // demote. The aggregate enforces single-thumbnail; walking the cover forward+back locks the bug down.
         using var client = await _auth.CreateRootAdminClientAsync();
         var (brandId, categoryId) = await PickExistingBrandAndCategoryAsync(client);
         var productId = await CreateProductAsync(client, brandId, categoryId);

--- a/src/Tests/Integration.Tests/Tests/Catalog/ProductsEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Catalog/ProductsEndpointTests.cs
@@ -474,9 +474,8 @@ public sealed class ProductsEndpointTests
     [Fact]
     public async Task CreateProduct_Should_NotMarkReplayed_When_NoIdempotencyKey()
     {
-        // Mirror of the BrandsEndpointTests check. Products' POST opts in to the
-        // Idempotency filter — without a key, the response must never carry the
-        // Idempotency-Replayed: true header.
+        // Products' POST opts in to the Idempotency filter — without a key the response
+        // must never carry the Idempotency-Replayed: true header (mirrors BrandsEndpointTests).
         const string ReplayedHeader = "Idempotency-Replayed";
 
         using var client = await _auth.CreateRootAdminClientAsync();

--- a/src/Tests/Integration.Tests/Tests/Chat/ChatSendMessageTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Chat/ChatSendMessageTests.cs
@@ -37,11 +37,8 @@ public sealed class ChatSendMessageTests
     [Fact]
     public async Task SendMessage_Should_Succeed_When_Mirroring_Dashboard_Payload()
     {
-        // The dashboard composer always sends:
-        //   - POST /api/v1/chat/channels/{id}/messages
-        //   - Idempotency-Key header (fresh UUID per call)
-        //   - body: { body, parentMessageId: null, attachments: [] }
-        // This test reproduces that exact shape so any drift between client and contract is caught here.
+        // Reproduces the dashboard composer's exact wire shape (POST messages + fresh Idempotency-Key header +
+        // body { body, parentMessageId: null, attachments: [] }) so any client/contract drift is caught here.
         using var client = await _auth.CreateRootAdminClientAsync();
         var channelId = await CreateChannelAsync(client, UniqueName("Dash"));
 
@@ -204,9 +201,8 @@ public sealed class ChatSendMessageTests
     [Fact]
     public async Task SendMessage_Should_Succeed_When_Parent_Is_Top_Level_Message_In_Same_Channel()
     {
-        // Threads are 1-deep. A reply with a top-level parent in the *same* channel should land 200
-        // and bump the parent's ReplyCount (covered in ChatMessagesTests). This test just locks the
-        // happy thread shape so we can confidently assert the negative case that follows.
+        // Threads are 1-deep: a reply to a top-level parent in the *same* channel lands 200 and bumps ReplyCount (covered elsewhere).
+        // This locks the happy thread shape so the negative case that follows is meaningful.
         using var client = await _auth.CreateRootAdminClientAsync();
         var channelId = await CreateChannelAsync(client, UniqueName("OkThread"));
         var parentId = await SendMessageAsync(client, channelId, "parent");

--- a/src/Tests/Integration.Tests/Tests/Health/TenantMigrationsHealthCheckTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Health/TenantMigrationsHealthCheckTests.cs
@@ -42,8 +42,7 @@ public sealed class TenantMigrationsHealthCheckTests : IAsyncLifetime
         };
 
         // ── Before migrations ────────────────────────────────────────────
-        // Every migration in the assembly is pending. The check must surface
-        // that as Unhealthy so /health/ready returns 503.
+        // Every migration is pending → check must be Unhealthy so /health/ready returns 503.
         var beforeResult = await check.CheckHealthAsync(context, CancellationToken.None);
         beforeResult.Status.ShouldBe(HealthStatus.Unhealthy);
         beforeResult.Description.ShouldNotBeNull();

--- a/src/Tests/Integration.Tests/Tests/Idempotency/IdempotencyFilterTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Idempotency/IdempotencyFilterTests.cs
@@ -16,11 +16,8 @@ public sealed class IdempotencyFilterTests
         _auth = new AuthHelper(factory);
     }
 
-    // NOTE: full replay-with-matching-body coverage is not yet possible — the filter
-    // currently captures the raw IResult instead of the serialized response body
-    // (tracked via dotnet/aspnetcore#57191 and backlog item 2.4b). The two tests below
-    // verify only the wiring (presence vs absence of the Idempotency-Replayed header
-    // and that a distinct key forces a fresh execution).
+    // Full replay-with-matching-body coverage isn't possible yet (filter captures the raw IResult, not the body — dotnet/aspnetcore#57191, backlog 2.4b).
+    // These tests verify only the wiring: Idempotency-Replayed header presence/absence and that a distinct key forces fresh execution.
 
     [Fact]
     public async Task CreateBillingPlan_Should_ExecuteNormally_When_NoIdempotencyKey()

--- a/src/Tests/Integration.Tests/Tests/Impersonation/ImpersonationTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Impersonation/ImpersonationTests.cs
@@ -60,9 +60,8 @@ public sealed class ImpersonationTests : IAsyncLifetime
         await CreateTenantAsync(rootClient, _tenantId, _tenantAdminEmail);
         await WaitForProvisioningAsync(rootClient, _tenantId);
 
-        // Sign in as the freshly seeded tenant admin to capture their userId from
-        // the JWT — using the search endpoint would couple these tests to the
-        // (currently buggy) cross-tenant search header override.
+        // Sign in as the seeded tenant admin to capture their userId from the JWT — the search
+        // endpoint would couple these tests to the (currently buggy) cross-tenant search override.
         var tenantToken = await GetTokenWithRetryAsync(_tenantAdminEmail, TestConstants.DefaultPassword, _tenantId);
         _tenantAdminUserId = ReadSubject(tenantToken.AccessToken);
 
@@ -233,10 +232,8 @@ public sealed class ImpersonationTests : IAsyncLifetime
     [Fact]
     public async Task Start_Should_Return404_When_TargetUserDoesNotExistInTenant()
     {
-        // Arrange — root admin's userId is NOT in the test tenant, so passing it
-        // with targetTenantId=<test tenant> must 404. This is the same shape as
-        // the bug we hit in the admin app (search returned the wrong tenant's
-        // user, then start-impersonation rejected it).
+        // Arrange — root admin's userId is NOT in the test tenant, so passing it with
+        // targetTenantId=<test tenant> must 404 (same shape as the admin-app wrong-tenant-user bug).
         using var rootClient = await _auth.CreateRootAdminClientAsync();
 
         // Act
@@ -289,9 +286,7 @@ public sealed class ImpersonationTests : IAsyncLifetime
         var response = await endClient.PostAsync($"{ImpersonationBasePath}/end", content: null);
 
         // Assert — returns a fresh access+refresh pair for the original actor.
-        // On failure dump the problem-detail body so the underlying server
-        // exception (DetailedTestExceptionHandler emits it) is visible in the
-        // test output instead of a bare status code mismatch.
+        // On failure the problem-detail body surfaces the underlying server exception in the test output.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<TokenResult>(Json);
         body.ShouldNotBeNull();
@@ -300,8 +295,7 @@ public sealed class ImpersonationTests : IAsyncLifetime
 
         var jwt = new JwtSecurityTokenHandler().ReadJwtToken(body.AccessToken);
         jwt.Subject.ShouldBe(_rootAdminUserId);
-        // Restored actor token must NOT carry act_sub anymore — otherwise the
-        // user would still appear impersonated to permission checks.
+        // Restored actor token must NOT carry act_sub, else the user still appears impersonated to perms.
         jwt.Claims.ShouldNotContain(c => c.Type == "act_sub");
     }
 
@@ -628,9 +622,8 @@ public sealed class ImpersonationTests : IAsyncLifetime
         var grants = await rootClient.GetFromJsonAsync<List<ImpersonationGrantPayload>>(
             $"{ImpersonationBasePath}/grants?Status=Active", Json);
 
-        // Assert — exactly one grant should match this jti, proving the token's
-        // jti is the same value persisted in the grant row (the revocation
-        // hook keys off this).
+        // Assert — exactly one grant matches this jti, proving the token's jti equals the value
+        // persisted in the grant row (the revocation hook keys off this).
         grants.ShouldNotBeNull();
         grants.Count(g => g.Jti == jtiClaim).ShouldBe(1);
     }

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/ChangeTenantActivationValidationTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/ChangeTenantActivationValidationTests.cs
@@ -115,11 +115,8 @@ public sealed class ChangeTenantActivationValidationTests
     [Fact]
     public async Task ChangeActivation_Should_Reactivate_When_ProvisioningCompleted()
     {
-        // Arrange — provision fully so EnsureCanActivate passes, then deactivate.
-        // Reactivation re-checks the latest provisioning record is Completed; the
-        // background job can briefly report a non-terminal latest record even after
-        // the status endpoint first showed Completed (provisioning is async), so we
-        // wait for the status to be *stably* Completed before toggling.
+        // Provision fully (so EnsureCanActivate passes) then deactivate. Reactivation re-checks the latest provisioning
+        // record is Completed, which can transiently flip non-terminal after first showing Completed — so wait for *stable* Completed.
         using var rootClient = await _auth.CreateRootAdminClientAsync();
         var unique = Guid.NewGuid().ToString("N")[..8];
         var tenantId = $"act-reactivate-{unique}";

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/MissingTenantTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/MissingTenantTests.cs
@@ -2,10 +2,8 @@ using Integration.Tests.Infrastructure;
 
 namespace Integration.Tests.Tests.Multitenancy;
 
-// Regression for #1245: anonymous, tenant-scoped endpoints bind a required
-// `tenant` header. When it's missing, ASP.NET Core throws BadHttpRequestException
-// (StatusCode 400) during parameter binding. GlobalExceptionHandler used to let
-// that fall through to a generic 500; it must now surface the framework's 400.
+// Regression for #1245: a missing required `tenant` header on anonymous tenant-scoped endpoints throws
+// BadHttpRequestException (400) during binding — must surface as 400, not fall through to a generic 500.
 [Collection(FshCollectionDefinition.Name)]
 public sealed class MissingTenantTests
 {

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
@@ -133,9 +133,8 @@ public sealed class RenewTenantTests
     [Fact]
     public async Task RenewTenant_Should_Advance_SubscriptionEndUtc_On_SamePlanRenewal()
     {
-        // Regression for billing/tenant drift: a SAME-PLAN renewal advanced tenant.ValidUpto (which
-        // enforcement uses) but left Subscription.EndUtc (which the dashboard term reads) untouched —
-        // so the two diverged after every renewal. Both must move together.
+        // Regression for billing/tenant drift: a same-plan renewal advanced tenant.ValidUpto but left
+        // Subscription.EndUtc untouched, so the two diverged each renewal. Both must move together.
         using var rootClient = await _auth.CreateRootAdminClientAsync();
         var unique = Guid.NewGuid().ToString("N")[..8];
         var tenantId = $"renew-drift-{unique}";

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantActivationTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantActivationTests.cs
@@ -98,16 +98,13 @@ public sealed class TenantActivationTests
             new { tenantId, isActive = false });
         deactivate.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        // Once deactivated, the tenant guard rejects the request before the
-        // token handler runs → 403. Regression guard for "a deactivated tenant
-        // can still log in via the dashboard".
+        // Once deactivated, the tenant guard rejects before the token handler runs → 403.
+        // Regression guard for "a deactivated tenant can still log in via the dashboard".
         (await TryIssueTokenAsync(tenantId)).ShouldBe(HttpStatusCode.Forbidden);
     }
 
-    // Anonymous token request scoped to a tenant via the `tenant` header, with
-    // deliberately invalid credentials. We assert on the status the pipeline
-    // returns (401 when the handler runs, 403 when the tenant guard blocks it),
-    // so the test never depends on the tenant's admin being provisioned yet.
+    // Anonymous tenant-scoped token request with invalid credentials. Asserts the pipeline status
+    // (401 when the handler runs, 403 when the tenant guard blocks), so it never needs a provisioned admin.
     private async Task<HttpStatusCode> TryIssueTokenAsync(string tenantId)
     {
         using var client = _factory.CreateClient();

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryEnforcementTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryEnforcementTests.cs
@@ -123,9 +123,8 @@ public sealed class TenantExpiryEnforcementTests
         return status;
     }
 
-    // Probes the post-auth guard with an anonymous token-issue request scoped to the tenant header,
-    // returning the response status plus the X-Subscription-Grace header (null when absent). The guard
-    // runs before the token handler, so the grace header is set regardless of the credential outcome.
+    // Probes the post-auth guard via anonymous token-issue scoped to the tenant header, returning status
+    // plus X-Subscription-Grace (null when absent); the guard runs before the handler, so grace is set regardless of creds.
     private async Task<(HttpStatusCode Status, string? Grace)> ProbeAsync(string tenantId)
     {
         using var client = _factory.CreateClient();

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantHeaderOverrideTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantHeaderOverrideTests.cs
@@ -53,13 +53,8 @@ public sealed class TenantHeaderOverrideTests : IAsyncLifetime
         await WaitForProvisioningAsync(rootClient, _tenantA);
         await WaitForProvisioningAsync(rootClient, _tenantB);
 
-        // WaitForProvisioning returns when the provisioning record reports
-        // "Completed", but identity seeding writes the admin user inside that
-        // same job and the UserManager view can lag the status by a tick. A
-        // successful token issuance is the strongest cross-check that the
-        // tenant admin user exists *and* is queryable by the identity store
-        // — without this, the very first test occasionally races and gets an
-        // empty user list.
+        // Provisioning can report "Completed" a tick before the seeded admin user is queryable; a
+        // successful token issuance cross-checks the user exists, avoiding a first-test race on empty lists.
         _ = await GetTokenWithRetryAsync(_tenantAAdminEmail, TestConstants.DefaultPassword, _tenantA);
         _ = await GetTokenWithRetryAsync(_tenantBAdminEmail, TestConstants.DefaultPassword, _tenantB);
     }
@@ -94,9 +89,8 @@ public sealed class TenantHeaderOverrideTests : IAsyncLifetime
     [Fact]
     public async Task RootOperator_Should_UseOwnTenant_When_NoHeaderSent()
     {
-        // Arrange — bare CreateRootAdminClient sends `tenant: root`. The claim
-        // matches the header, so the override is a no-op and we fall through
-        // to ClaimStrategy. The result must scope to root tenant.
+        // Arrange — bare CreateRootAdminClient sends `tenant: root`; claim matches header, so the
+        // override no-ops and resolution scopes to the root tenant.
         using var rootClient = await _auth.CreateRootAdminClientAsync();
 
         // Act
@@ -113,9 +107,8 @@ public sealed class TenantHeaderOverrideTests : IAsyncLifetime
     [Fact]
     public async Task TenantAdmin_HeaderOverride_Should_BeIgnored()
     {
-        // Arrange — tenant A's admin tries to scope to tenant B by sending the
-        // header. The override is gated by `claim == root`, so this must fail
-        // closed: query stays in tenant A.
+        // Arrange — tenant A's admin sends a `tenant: B` header; the override is gated by claim==root,
+        // so it must fail closed and the query stays in tenant A.
         var tenantAToken = await GetTokenWithRetryAsync(_tenantAAdminEmail, TestConstants.DefaultPassword, _tenantA);
         using var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new("Bearer", tenantAToken.AccessToken);
@@ -124,9 +117,8 @@ public sealed class TenantHeaderOverrideTests : IAsyncLifetime
         // Act
         var response = await client.GetAsync($"{TestConstants.IdentityBasePath}/users/search?PageNumber=1&PageSize=50");
 
-        // Assert — request still resolves to tenant A (the claim wins), so
-        // tenant A's admin is in results and tenant B's admin is not. If the
-        // override leaked to non-root callers this assertion would flip.
+        // Assert — still resolves to tenant A (claim wins): A's admin present, B's absent. This flips
+        // if the override ever leaked to non-root callers.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var page = await response.Content.ReadFromJsonAsync<PagedResult<SearchUserDto>>(Json);
         page.ShouldNotBeNull();

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantProvisioningFailureTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantProvisioningFailureTests.cs
@@ -115,9 +115,8 @@ public sealed class TenantProvisioningFailureTests
         var status = await PollUntilTerminalAsync(rootClient, tenantId);
         status.Status.ShouldBe("Failed");
 
-        // Act + Assert — drive the production activation guard directly. The Finbuckle tenant
-        // context for TenantDbContext access is set inline in this method (AsyncLocal — must not
-        // cross an awaited helper) to satisfy the named tenant query filter.
+        // Act + Assert — drive the production activation guard directly. Tenant context is set
+        // inline here (AsyncLocal must not cross an awaited helper) for the tenant query filter.
         using var scope = _factory.Services.CreateScope();
         var provisioningService = scope.ServiceProvider.GetRequiredService<ITenantProvisioningService>();
 

--- a/src/Tests/Integration.Tests/Tests/Notifications/NotificationsEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Notifications/NotificationsEndpointTests.cs
@@ -412,9 +412,8 @@ public sealed class NotificationsEndpointTests
         string type = "test.poke",
         int spaceCreationByMs = 0)
     {
-        // userId comes from /register as the raw Guid string Identity assigned; the handler reads
-        // currentUser.GetUserId().ToString() against the same column, so the canonical Guid format
-        // is what we need to match. Normalize through Guid.Parse to be sure.
+        // The handler reads currentUser.GetUserId().ToString() against the same column, so normalize
+        // the registered userId through Guid.Parse to the canonical Guid format to match.
         var canonical = Guid.Parse(userId).ToString();
         var ids = new List<Guid>(count);
 

--- a/src/Tests/Integration.Tests/Tests/Roles/PermissionCacheInvalidationTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Roles/PermissionCacheInvalidationTests.cs
@@ -21,9 +21,8 @@ namespace Integration.Tests.Tests.Roles;
 [Collection(FshCollectionDefinition.Name)]
 public sealed class PermissionCacheInvalidationTests
 {
-    // Non-basic permission: a freshly-created user with only a custom role (no Basic role)
-    // will NOT have this unless the custom role grants it — so its presence/absence in the
-    // user's effective set is an unambiguous signal of what the cache returned.
+    // Non-basic permission: a user with only a custom role won't have this unless the role grants it,
+    // so its presence/absence is an unambiguous signal of what the cache returned.
     private const string ProbePermission = IdentityPermissions.Groups.Create;
     private const string SecondaryPermission = IdentityPermissions.Groups.Delete;
 
@@ -58,14 +57,12 @@ public sealed class PermissionCacheInvalidationTests
         warmed.ShouldContain(ProbePermission,
             "Pre-condition: the user must hold the probe permission via the custom role before the mutation.");
 
-        // Act — remove the probe permission from the role through the live admin API.
-        // RoleService.UpdatePermissionsAsync must call InvalidatePermissionCacheAsync for
-        // every user reachable through this role.
+        // Act — remove the probe permission via the live admin API. UpdatePermissionsAsync
+        // must call InvalidatePermissionCacheAsync for every user reachable through this role.
         await SetRolePermissionsAsync(adminClient, role.Id /* no permissions */);
 
-        // Assert — the very next read must reflect the new (empty) state. If the cache
-        // entry were not evicted, the warmed entry (still inside its 1h expiration) would
-        // be returned and this would still contain ProbePermission.
+        // Assert — the next read must reflect the empty state. If not evicted, the warmed entry
+        // (still within its 1h expiration) would be served and still contain ProbePermission.
         var afterRevoke = await GetOwnPermissionsAsync(userClient);
         afterRevoke.ShouldNotContain(ProbePermission,
             "Cache was NOT invalidated: a removed role permission is still being served from the stale cache entry.");

--- a/src/Tests/Integration.Tests/Tests/Roles/PermissionCatalogTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Roles/PermissionCatalogTests.cs
@@ -44,9 +44,8 @@ public sealed class PermissionCatalogTests
 
         catalog.ShouldNotBeNull();
 
-        // Root tenant sees the full Admin set plus the platform Root set. This is the
-        // same union RolePermissionSyncer applies, so if the two diverge the editor and
-        // the syncer would disagree on what's grantable.
+        // Root tenant sees Admin ∪ Root — the same union RolePermissionSyncer applies,
+        // so any divergence means editor and syncer disagree on what's grantable.
         var expected = PermissionConstants.Admin
             .Concat(PermissionConstants.Root)
             .DistinctBy(p => p.Name)
@@ -55,9 +54,8 @@ public sealed class PermissionCatalogTests
         var actual = catalog.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
         actual.ShouldBe(expected, ignoreOrder: true);
 
-        // The drift bug we're guarding against: prior to the endpoint, the SPA had only
-        // ~25 Identity permissions while the server held 70+. A canary count check catches
-        // a regression that quietly returns just one module's slice.
+        // Drift bug guard: the SPA once saw ~25 Identity permissions while the server held 70+.
+        // This canary count catches a regression that returns just one module's slice.
         catalog.Count.ShouldBeGreaterThan(25);
     }
 

--- a/src/Tests/Integration.Tests/Tests/Tickets/TicketCommentsEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Tickets/TicketCommentsEndpointTests.cs
@@ -104,9 +104,8 @@ public sealed class TicketCommentsEndpointTests
     [Fact]
     public async Task AddComment_Should_BeAccepted_When_TicketIsResolved()
     {
-        // AddComment only rejects Closed tickets — a Resolved ticket still
-        // accepts comments (e.g. follow-up notes). There is no API path to
-        // reach Closed, so this covers the non-throwing branch explicitly.
+        // AddComment only rejects Closed tickets; Resolved still accepts comments.
+        // No API path reaches Closed, so this covers the non-throwing branch.
         #region Arrange
         using var client = await _auth.CreateRootAdminClientAsync();
         var ticketId = await CreateTicketAsync(client, UniqueTitle("ResolvedComment"));

--- a/src/Tests/Integration.Tests/Tests/Tickets/TicketsEndpointTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Tickets/TicketsEndpointTests.cs
@@ -40,9 +40,8 @@ public sealed class TicketsEndpointTests
     [Fact]
     public async Task CreateTicket_Should_StartInProgress_When_AssignedAtCreation()
     {
-        // Tickets created with an assignee skip the Open state — there's no point
-        // flicking through it for a single tick when an owner is already pushing
-        // it forward. The aggregate's Create() encodes this rule.
+        // Tickets created with an assignee skip the Open state (an owner is already driving it).
+        // The aggregate's Create() encodes this rule.
         using var client = await _auth.CreateRootAdminClientAsync();
         var assigneeId = Guid.NewGuid();
 
@@ -144,9 +143,8 @@ public sealed class TicketsEndpointTests
         reopenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         var fetched = await GetAsync(client, ticketId);
-        // Reopened tickets fall back to whichever assignment state they had.
-        // This one was still assigned, so back to InProgress; the resolution
-        // metadata is wiped so a future resolve gets its own audit window.
+        // Reopened tickets fall back to their assignment state (still assigned here, so InProgress);
+        // resolution metadata is wiped so a future resolve gets its own audit window.
         fetched.Status.ShouldBe("InProgress");
         fetched.ResolutionNote.ShouldBeNull();
         fetched.ResolvedAtUtc.ShouldBeNull();
@@ -157,11 +155,8 @@ public sealed class TicketsEndpointTests
     [Fact]
     public async Task AddComment_Should_Persist_And_BumpCommentCount()
     {
-        // Previously skipped: adding a TicketComment via the aggregate's nav
-        // collection failed with DbUpdateConcurrencyException because
-        // TicketComment.Id lacked ValueGeneratedNever() in its EF config, so EF
-        // tracked the new child as Modified (UPDATE 0 rows) instead of Added.
-        // Fixed in TicketCommentConfiguration; this test now passes.
+        // Previously failed: TicketComment.Id lacked ValueGeneratedNever(), so EF tracked the nav-collection child
+        // as Modified (UPDATE 0 rows) not Added → DbUpdateConcurrencyException. Fixed in TicketCommentConfiguration.
         using var client = await _auth.CreateRootAdminClientAsync();
         var ticketId = await CreateAsync(client, UniqueTitle("Commentable"));
 
@@ -185,10 +180,8 @@ public sealed class TicketsEndpointTests
     [Fact]
     public async Task DeleteTicket_Should_HideFromSearch_But_Show_In_Trash()
     {
-        // Tickets has no DELETE endpoint exposed yet — but EF's interceptor
-        // still soft-deletes when we call Remove. Without a DELETE endpoint
-        // to drive this, we drop into the DbContext via the test factory's
-        // service scope. (This test stays valid once a DELETE endpoint ships.)
+        // No DELETE endpoint exists yet, but EF's interceptor soft-deletes on Remove, so we drive it
+        // via the DbContext through the test factory's service scope. (Stays valid once a DELETE endpoint ships.)
         using var client = await _auth.CreateRootAdminClientAsync();
         var ticketId = await CreateAsync(client, UniqueTitle("Soft"));
 

--- a/src/Tests/Integration.Tests/Tests/Webhooks/WebhookDispatchOutcomeTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Webhooks/WebhookDispatchOutcomeTests.cs
@@ -165,10 +165,8 @@ public sealed class WebhookDispatchOutcomeTests
         using var scope = capturingFactory.Services.CreateScope();
         var sp = scope.ServiceProvider;
 
-        // Set the Finbuckle tenant context INLINE: the AsyncLocal mutation must happen in this
-        // method body (not a separate awaited helper, or the change doesn't flow back to the
-        // caller's execution context) and BEFORE the DbContext is resolved, so its tenant query
-        // filter reads a real TenantInfo instead of throwing an NRE on a null one.
+        // Set Finbuckle tenant context INLINE and BEFORE resolving the DbContext: the AsyncLocal mutation
+        // must happen in this method body (not an awaited helper) or its tenant query filter NREs on a null.
         var tenant = await sp.GetRequiredService<IMultiTenantStore<AppTenantInfo>>()
             .GetAsync(TestConstants.RootTenantId).ConfigureAwait(false);
         sp.GetRequiredService<IMultiTenantContextSetter>()

--- a/src/Tests/Integration.Tests/Tests/Webhooks/WebhookSignatureTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Webhooks/WebhookSignatureTests.cs
@@ -179,10 +179,8 @@ public sealed class WebhookSignatureTests
         using var scope = capturingFactory.Services.CreateScope();
         var sp = scope.ServiceProvider;
 
-        // Set the Finbuckle tenant context INLINE in this scope (AsyncLocal — must not cross an awaited
-        // helper boundary or the DbContext tenant filter sees a null TenantInfo). The dispatch job sets
-        // its own context internally too, but it resolves a fresh inner scope, so this is for safety on
-        // the calling scope.
+        // Set Finbuckle tenant context INLINE (AsyncLocal must not cross an awaited helper, else the
+        // DbContext filter sees a null TenantInfo). The job sets its own context too; this guards this scope.
         var tenant = await sp.GetRequiredService<IMultiTenantStore<AppTenantInfo>>()
             .GetAsync(TestConstants.RootTenantId);
         sp.GetRequiredService<IMultiTenantContextSetter>()

--- a/src/Tests/Webhooks.Tests/Services/WebhookFanoutHandlerTests.cs
+++ b/src/Tests/Webhooks.Tests/Services/WebhookFanoutHandlerTests.cs
@@ -181,9 +181,8 @@ public sealed class WebhookFanoutHandlerTests
 
     private async Task<Guid> SeedSubscriptionAsync(WebhookDbContext db, string[] events, bool isActive)
     {
-        // Install the tenant context so Finbuckle stamps the seeded row with the
-        // target tenant (BaseDbContext saves in Overwrite mode) and the handler's
-        // tenant-filtered read can see it.
+        // Install tenant context so Finbuckle stamps the seeded row (Overwrite mode)
+        // and the handler's tenant-filtered read can see it.
         SetTenant(TenantId);
 
         WebhookSubscription sub = WebhookSubscription.Create("https://example.com/hook", events, "hash");

--- a/src/Tools/CLI/Commands/NewCommand.cs
+++ b/src/Tools/CLI/Commands/NewCommand.cs
@@ -263,9 +263,8 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
             {
                 await ProcessRunner.RunAsync("git", "init", output, showOutput: false, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
-                // Default the initial branch to `main` regardless of the user's git
-                // `init.defaultBranch` (older git defaults to `master`). symbolic-ref on
-                // the unborn HEAD works on every git version, unlike `git init -b`.
+                // Force the initial branch to main on every git version via symbolic-ref on the
+                // unborn HEAD, regardless of the user's configured default-branch setting.
                 await ProcessRunner.RunAsync("git", "symbolic-ref HEAD refs/heads/main", output, showOutput: false, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
                 await ProcessRunner.RunAsync("git", "add -A", output, showOutput: false, cancellationToken: cancellationToken)
@@ -326,9 +325,8 @@ public sealed class NewCommand : AsyncCommand<NewCommand.Settings>
         File.WriteAllText(appsettingsDev, content.Replace(placeholder, key, StringComparison.Ordinal));
     }
 
-    // Generate deploy/docker/.env from .env.example with strong random secrets so
-    // `cd deploy/docker && docker compose up` works without hand-filling 8 secrets.
-    // .env is git-ignored, so the initial commit never captures these values.
+    // Generate deploy/docker/.env from .env.example with strong random secrets so compose
+    // works without hand-filling 8 secrets; .env is git-ignored so the initial commit skips them.
     private static bool GenerateDockerEnv(string output)
     {
         string dockerDir = Path.Combine(output, "deploy", "docker");

--- a/src/Tools/CLI/Infrastructure/NuGetClient.cs
+++ b/src/Tools/CLI/Infrastructure/NuGetClient.cs
@@ -65,10 +65,8 @@ internal static class NuGetClient
     internal static async Task<string?> GetInstalledTemplateVersionAsync(
         CancellationToken cancellationToken = default)
     {
-        // `dotnet new list` has no version column, so we read `dotnet new uninstall`
-        // (no args), which lists installed template packages with their versions:
-        //    FullStackHero.NET.StarterKit
-        //       Version: 10.0.0
+        // `dotnet new list` has no version column; `dotnet new uninstall` (no args) lists installed
+        // template packages with their versions (package id line, then an indented "Version: x.y.z").
         (bool ok, string output) = await ProcessRunner.CaptureAsync(
             "dotnet", "new uninstall", cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary

Fixes a chain of AWS deploy blockers found while deploying `dev` to `us-east-1`, switches the container images off chiseled, and includes a repo-wide comment-condensing pass.

### Deploy fixes (`deploy/terraform/apps/starter`)
- **`deploy.ps1`** — pin `AWS_REGION`/`AWS_DEFAULT_REGION` to the `-Region` param so every `aws` CLI call hits the right endpoint. Previously it fell back to `~/.aws/config` (e.g. `ap-south-1`), producing `InvalidParameterException: Invalid Region in ARN` against `us-east-1` ARNs. Also guard the `run-task` null-deref so a future `aws` failure reports the real error instead of *"You cannot call a method on a null-valued expression."*
- **`app_stack/main.tf`** — the migrator is a generic-host console app (`Host.CreateApplicationBuilder`), which selects its environment from **`DOTNET_ENVIRONMENT`**, not `ASPNETCORE_ENVIRONMENT` (web-host only). With the wrong var it defaulted to Production, skipped `appsettings.Development.json`, and never loaded the `Seed:*` block → *"No initial admin password available for tenant 'root'."* Now sets `DOTNET_ENVIRONMENT`.
- **dev `terraform.tfvars`** — correct the stale seed-config comment.

### Container images
- `FSH.Starter.Api` + `FSH.Starter.DbMigrator` csproj: `ContainerFamily` `noble-chiseled` → `noble` (non-chiseled). Takes effect on the next `-BuildApi` rebuild.

### Repo-wide
- Condense verbose comments across modules, `BuildingBlocks`, and tests. **Comment-only — no logic changes** (verified: every added line is a comment/doc-comment/using/blank).

## Test plan
- `terraform validate` passes on `app_stack`.
- Migrator ran green in `us-east-1` (migrate + seed) after the env fix; API healthy (serves `401 ProblemDetails`, DB queries succeed post-migration).
- Comment pass is whitespace/comment-only; backend build (`TreatWarningsAsErrors`) should remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)