### PR TITLE
feat(deploy): API CloudFront HTTPS + ap-south-1 dev env; realtime & identity seed fixes

### DIFF
--- a/clients/dashboard/src/realtime/realtime-context.tsx
+++ b/clients/dashboard/src/realtime/realtime-context.tsx
@@ -155,6 +155,9 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
       }
       setStatus("connecting");
       const conn = await buildConnection();
+      // Torn down while SignalR's chunk / the connection was still building —
+      // abort before any start() so we never open a socket we have to stop.
+      if (stoppedRef.current) return;
       connectionRef.current = conn;
       wireListeners(conn);
 
@@ -176,6 +179,15 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
 
       try {
         await conn.start();
+        // Cleanup ran while start() was negotiating: it deliberately left this
+        // still-"Connecting" socket alone (calling stop() mid-start makes SignalR
+        // reject with "Failed to start the HttpConnection before stop() was
+        // called", logged at Error level). Now that start() has resolved, stop
+        // it cleanly — no race, no error log.
+        if (stoppedRef.current) {
+          void conn.stop();
+          return;
+        }
         consecutiveFailures = 0;
         setStatus("connected");
       } catch {
@@ -196,8 +208,17 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
       // string enum ("Disconnected"|"Connecting"|"Connected"|"Disconnecting"|
       // "Reconnecting") in SignalR 10 — comparing against the literal
       // avoids referencing the lazy-loaded module here.
-      if (conn && (conn.state as string) !== "Disconnected") {
-        void conn.stop();
+      //
+      // Only stop a settled connection. A still-"Connecting" socket is mid
+      // initial start(): stopping it here makes SignalR reject start() with
+      // "Failed to start the HttpConnection before stop() was called" (Error
+      // level). We've set stoppedRef, so connect()'s post-start guard stops it
+      // cleanly once start() resolves — start() holds its own `conn` reference.
+      if (conn) {
+        const state = conn.state as string;
+        if (state === "Connected" || state === "Reconnecting") {
+          void conn.stop();
+        }
       }
       setStatus("idle");
     };

--- a/deploy/terraform/apps/starter/app_stack/main.tf
+++ b/deploy/terraform/apps/starter/app_stack/main.tf
@@ -19,8 +19,14 @@ locals {
   migrator_container_image = "${var.container_registry}/${var.migrator_image_name}:${var.container_image_tag}"
 
   # Public origin of the API (no /api suffix) — used for the app OriginUrl and
-  # as the apiBase the React SPAs read from their runtime config.json.
-  api_origin = var.enable_https && var.domain_name != null ? "https://${var.domain_name}" : "http://${module.alb.dns_name}"
+  # as the apiBase the React SPAs read from their runtime config.json. HTTPS via
+  # a custom domain when set, else via the API CloudFront distribution (free
+  # *.cloudfront.net cert), else plain HTTP on the ALB.
+  api_origin = (
+    var.enable_https && var.domain_name != null ? "https://${var.domain_name}" :
+    var.enable_api_cloudfront ? "https://${one(aws_cloudfront_distribution.api[*].domain_name)}" :
+    "http://${module.alb.dns_name}"
+  )
 }
 
 ################################################################################
@@ -169,10 +175,14 @@ module "app_s3" {
   enable_intelligent_tiering = var.app_s3_enable_intelligent_tiering
   lifecycle_rules            = var.app_s3_lifecycle_rules
 
-  cors_rules = var.enable_https && var.domain_name != null ? [
+  # Browser presigned uploads (My Files, chat attachments) PUT directly from the
+  # SPA origins to S3, so the bucket must allow those origins — not just a custom
+  # domain. Reuse the API's allow-list (SPA CloudFront/alias origins + custom
+  # domain + extras), so it works on the default CloudFront domains too.
+  cors_rules = local.has_cors_origins ? [
     {
       allowed_methods = ["GET", "PUT", "POST"]
-      allowed_origins = ["https://${var.domain_name}"]
+      allowed_origins = local.cors_allowed_origins
       allowed_headers = ["*"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3600
@@ -240,6 +250,63 @@ module "admin_site" {
   tags = local.common_tags
 }
 
+################################################################################
+# API CloudFront — HTTPS in front of the (HTTP-only) ALB without a custom
+# domain. Viewer↔CloudFront is HTTPS on the free *.cloudfront.net cert; the
+# CloudFront↔ALB hop stays HTTP inside AWS. Dynamic API: no caching, forward
+# everything (incl. Authorization) via the managed AllViewerExceptHostHeader.
+################################################################################
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  count = var.enable_api_cloudfront ? 1 : 0
+  name  = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host" {
+  count = var.enable_api_cloudfront ? 1 : 0
+  name  = "Managed-AllViewerExceptHostHeader"
+}
+
+resource "aws_cloudfront_distribution" "api" {
+  count       = var.enable_api_cloudfront ? 1 : 0
+  enabled     = true
+  comment     = "${local.name_prefix} API (ALB origin)"
+  price_class = var.frontend_cloudfront_price_class
+
+  origin {
+    domain_name = module.alb.dns_name
+    origin_id   = "alb"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id         = "alb"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled[0].id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host[0].id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = local.common_tags
+}
+
 locals {
   # Resolved SPA origins (custom alias when set, else the CloudFront domain).
   # Fall back to an override for SPAs hosted outside this stack.
@@ -253,6 +320,20 @@ locals {
     var.enable_https && var.domain_name != null ? ["https://${var.domain_name}"] : [],
     var.api_extra_cors_origins,
   ))
+
+  # Whether to emit the app bucket's CORS rule. Must be a PLAN-KNOWN boolean: the
+  # resolved origins above are CloudFront domains that don't exist until apply, so
+  # length(cors_allowed_origins) is unknown on first apply — feeding that into the
+  # s3_bucket module's `count` fails with "Invalid count argument". Gate on the
+  # known inputs that produce those origins instead.
+  has_cors_origins = (
+    var.enable_admin_site
+    || var.enable_dashboard_site
+    || var.admin_url != null
+    || var.dashboard_url != null
+    || (var.enable_https && var.domain_name != null)
+    || length(var.api_extra_cors_origins) > 0
+  )
 
   cors_environment_variables = {
     for idx, origin in local.cors_allowed_origins :

--- a/deploy/terraform/apps/starter/app_stack/outputs.tf
+++ b/deploy/terraform/apps/starter/app_stack/outputs.tf
@@ -47,7 +47,16 @@ output "alb_zone_id" {
 
 output "api_url" {
   description = "API URL."
-  value       = var.enable_https && var.domain_name != null ? "https://${var.domain_name}/api" : "http://${module.alb.dns_name}/api"
+  value = (
+    var.enable_https && var.domain_name != null ? "https://${var.domain_name}/api" :
+    var.enable_api_cloudfront ? "https://${one(aws_cloudfront_distribution.api[*].domain_name)}/api" :
+    "http://${module.alb.dns_name}/api"
+  )
+}
+
+output "api_cloudfront_domain" {
+  description = "CloudFront domain fronting the API (null unless enable_api_cloudfront)."
+  value       = one(aws_cloudfront_distribution.api[*].domain_name)
 }
 
 ################################################################################

--- a/deploy/terraform/apps/starter/app_stack/variables.tf
+++ b/deploy/terraform/apps/starter/app_stack/variables.tf
@@ -138,6 +138,12 @@ variable "acm_certificate_arn" {
   default     = null
 }
 
+variable "enable_api_cloudfront" {
+  type        = bool
+  description = "Front the API ALB with a CloudFront distribution for HTTPS without a custom domain (free *.cloudfront.net cert). Ignored when enable_https + domain_name are set."
+  default     = false
+}
+
 variable "ssl_policy" {
   type        = string
   description = "SSL policy for the HTTPS listener."

--- a/deploy/terraform/apps/starter/destroy.ps1
+++ b/deploy/terraform/apps/starter/destroy.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+  Destroy the FullStackHero Starter Kit AWS stack for one environment.
+
+.EXAMPLE
+  ./destroy.ps1 -Environment dev
+  ./destroy.ps1 -Environment dev -AutoApprove
+
+.DESCRIPTION
+  Runs terraform init (re-pointing the backend) + terraform destroy for the
+  given env/region. Tears down the app_stack (VPC, ALB+WAF, ECS, RDS, Redis,
+  S3 + CloudFront SPAs, secrets, IAM). Does NOT remove the Terraform state
+  bucket/lock (separate bootstrap stack) or the GHCR container images.
+
+  dev S3 buckets are force_destroy and RDS skips the final snapshot, so dev
+  tears down cleanly. staging/prod enable RDS + ALB deletion protection, so
+  destroy will fail until those are disabled — by design.
+
+  Requires: terraform >= 1.15.4, aws cli (configured).
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][ValidateSet('dev', 'staging', 'prod')][string]$Environment,
+  [string]$Region = 'us-east-1',
+  [switch]$SkipInit,
+  [switch]$AutoApprove
+)
+
+$ErrorActionPreference = 'Stop'
+$MinTfVersion = [version]'1.15.4'
+
+$ScriptDir = $PSScriptRoot
+$AppStackDir = Join-Path $ScriptDir 'app_stack'
+$EnvDir = Join-Path $ScriptDir "envs/$Environment/$Region"
+
+function Die($msg) { Write-Error $msg; exit 1 }
+
+if (-not (Test-Path "$EnvDir/backend.hcl")) { Die "no backend.hcl for $Environment/$Region at $EnvDir" }
+if (-not (Test-Path "$EnvDir/terraform.tfvars")) { Die "no terraform.tfvars for $Environment/$Region at $EnvDir" }
+
+foreach ($tool in 'terraform', 'aws') {
+  if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) { Die "$tool is required but not installed" }
+}
+
+# Pin the region for every `aws` CLI call (else it falls back to ~/.aws/config).
+$env:AWS_REGION = $Region
+$env:AWS_DEFAULT_REGION = $Region
+
+$tfVersion = [version](terraform version -json | ConvertFrom-Json).terraform_version
+if ($tfVersion -lt $MinTfVersion) {
+  Die "Terraform >= $MinTfVersion required (found $tfVersion)."
+}
+
+# Typed confirmation guard — irreversible, and mandatory for non-dev.
+if (-not $AutoApprove) {
+  Write-Host "==> About to DESTROY the '$Environment' stack in $Region. This is irreversible." -ForegroundColor Yellow
+  $answer = Read-Host "    Type the environment name ('$Environment') to confirm"
+  if ($answer -ne $Environment) { Die 'aborted (confirmation did not match)' }
+}
+
+# Native exes don't trip $ErrorActionPreference, so check $LASTEXITCODE explicitly.
+if (-not $SkipInit) {
+  Write-Host '==> terraform init'
+  terraform -chdir="$AppStackDir" init -reconfigure -input=false -backend-config="$EnvDir/backend.hcl"
+  if ($LASTEXITCODE -ne 0) { Die "terraform init failed (exit $LASTEXITCODE)" }
+}
+
+$destroyArgs = @("-var-file=$EnvDir/terraform.tfvars", '-input=false')
+if ($AutoApprove) { $destroyArgs += '-auto-approve' }
+
+Write-Host "==> terraform destroy '$Environment' ($Region) — CloudFront deletions can take ~15-20 min"
+terraform -chdir="$AppStackDir" destroy @destroyArgs
+if ($LASTEXITCODE -ne 0) { Die "terraform destroy failed (exit $LASTEXITCODE)" }
+
+Write-Host "`n==> Destroyed '$Environment' in $Region. State bucket/lock and GHCR images are untouched."

--- a/deploy/terraform/apps/starter/envs/dev/ap-south-1/backend.hcl
+++ b/deploy/terraform/apps/starter/envs/dev/ap-south-1/backend.hcl
@@ -1,0 +1,5 @@
+bucket       = "fsh-tfstate"
+key          = "dev/ap-south-1/terraform.tfstate"
+region       = "us-east-1"
+encrypt      = true
+use_lockfile = true

--- a/deploy/terraform/apps/starter/envs/dev/ap-south-1/terraform.tfvars
+++ b/deploy/terraform/apps/starter/envs/dev/ap-south-1/terraform.tfvars
@@ -1,24 +1,27 @@
 ################################################################################
-# Dev Environment — US East 1
+# Dev Environment — Asia Pacific (Mumbai) ap-south-1
 ################################################################################
 
 environment = "dev"
-region      = "us-east-1"
+region      = "ap-south-1"
 
 ################################################################################
 # Network
+#
+# Distinct CIDR from us-east-1 (10.10.0.0/16) so the two dev stacks can ever be
+# peered without overlap.
 ################################################################################
 
-vpc_cidr_block = "10.10.0.0/16"
+vpc_cidr_block = "10.20.0.0/16"
 
 public_subnets = {
-  a = { cidr_block = "10.10.0.0/24", az = "us-east-1a" }
-  b = { cidr_block = "10.10.1.0/24", az = "us-east-1b" }
+  a = { cidr_block = "10.20.0.0/24", az = "ap-south-1a" }
+  b = { cidr_block = "10.20.1.0/24", az = "ap-south-1b" }
 }
 
 private_subnets = {
-  a = { cidr_block = "10.10.10.0/24", az = "us-east-1a" }
-  b = { cidr_block = "10.10.11.0/24", az = "us-east-1b" }
+  a = { cidr_block = "10.20.10.0/24", az = "ap-south-1a" }
+  b = { cidr_block = "10.20.11.0/24", az = "ap-south-1b" }
 }
 
 single_nat_gateway = true
@@ -28,10 +31,12 @@ enable_ecr_endpoints = true
 enable_logs_endpoint = true
 
 ################################################################################
-# S3
+# S3 — bucket names must be globally unique, so they carry an -aps1 suffix to
+# coexist with the us-east-1 dev stack (S3 names are global; a bucket lives in
+# exactly one region).
 ################################################################################
 
-app_s3_bucket_name        = "dev-fsh-app-bucket"
+app_s3_bucket_name        = "dev-fsh-app-bucket-aps1"
 app_s3_enable_public_read = false
 app_s3_enable_cloudfront  = true
 
@@ -39,8 +44,8 @@ app_s3_enable_cloudfront  = true
 # Frontend SPAs (S3 + CloudFront) — bucket names must be globally unique
 ################################################################################
 
-dashboard_s3_bucket_name = "dev-fsh-dashboard"
-admin_s3_bucket_name     = "dev-fsh-admin"
+dashboard_s3_bucket_name = "dev-fsh-dashboard-aps1"
+admin_s3_bucket_name     = "dev-fsh-admin-aps1"
 dashboard_demo_mode      = true
 
 # HTTPS for the API without a custom domain: front the ALB with CloudFront

--- a/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
+++ b/src/Modules/Identity/Modules.Identity/Data/IdentityDbInitializer.cs
@@ -2,13 +2,11 @@ using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Persistence;
 using FSH.Framework.Shared.Constants;
 using FSH.Framework.Shared.Multitenancy;
-using FSH.Framework.Web.Origin;
 using FSH.Modules.Identity.Domain;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace FSH.Modules.Identity.Data;
 
@@ -19,7 +17,6 @@ internal sealed class IdentityDbInitializer(
     UserManager<FshUser> userManager,
     TimeProvider timeProvider,
     IMultiTenantContextAccessor<AppTenantInfo> multiTenantContextAccessor,
-    IOptions<OriginOptions> originSettings,
     ITenantInitialPasswordBuffer passwordBuffer,
     IConfiguration configuration) : IDbInitializer
 {
@@ -199,7 +196,10 @@ internal sealed class IdentityDbInitializer(
                 PhoneNumberConfirmed = true,
                 NormalizedEmail = multiTenantContextAccessor.MultiTenantContext.TenantInfo?.AdminEmail!.ToUpperInvariant(),
                 NormalizedUserName = adminUserName.ToUpperInvariant(),
-                ImageUrl = new Uri(originSettings.Value.OriginUrl! + MultitenancyConstants.Root.DefaultProfilePicture),
+                // No default avatar: the asset was never shipped, and baking an absolute
+                // {OriginUrl}/… URL at seed time pinned it to the seeder's localhost origin
+                // (migrator has no OriginOptions). Leave null → the SPA renders initials.
+                ImageUrl = null,
                 IsActive = true
             };
 


### PR DESCRIPTION
## Summary

Follow-up to #1284. Three independent changes:

### Deploy / Terraform
- **API CloudFront for HTTPS without a custom domain** — new `enable_api_cloudfront` fronts the (HTTP-only) ALB with a CloudFront distribution on the free `*.cloudfront.net` cert, so the HTTPS SPAs can call the API with no mixed-content. `api_origin`/`api_url` and a new `api_cloudfront_domain` output resolve to it; enabled in the us-east-1 dev tfvars.
- **Fix `Invalid count argument` on a first apply into an empty region** — the app S3 bucket's CORS rule was gated on `length()` of the compacted CloudFront origins, whose length is unknown until apply. Now gated on a plan-known boolean (`has_cors_origins`); the `allowed_origins` still resolve dynamically and reuse the API CORS allow-list (so presigned uploads work on default `*.cloudfront.net` origins).
- **New `envs/dev/ap-south-1` (Mumbai)** — own backend state key, `10.20.0.0/16` VPC, `-aps1`-suffixed globally-unique bucket names so it coexists with the us-east-1 dev stack. (`deploy.ps1 -Region ap-south-1` already wired everything else.)
- **New `destroy.ps1`** — `terraform destroy` per env/region with a typed-confirmation guard; leaves the state bucket/lock and GHCR images untouched.

### Realtime (dashboard)
- Avoid a SignalR start/stop race on teardown: stopping a still-`Connecting` socket made SignalR reject `start()` with `Failed to start the HttpConnection before stop() was called` (Error-level). Cleanup now only stops settled connections; a mid-start socket is stopped cleanly by the post-start guard.

### Identity
- Stop seeding a default admin avatar URL — the asset was never shipped and the absolute `{OriginUrl}/…` URL pinned it to the seeder's localhost origin (the migrator has no `OriginOptions`). Seed `ImageUrl = null`; the SPA renders initials.

## Test plan
- `terraform validate` passes; `terraform fmt` clean.
- ap-south-1 dev applies cleanly (the CORS `count` error is resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)