### PR TITLE
chore(deploy): require explicit AWS region + recover Redis final-snapshot fix

### DIFF
--- a/deploy/terraform/apps/starter/README.md
+++ b/deploy/terraform/apps/starter/README.md
@@ -29,18 +29,21 @@ each SPA's `config.json` so the API/dashboard URLs are wired without rebuilding.
 Provisions infra **and** publishes the API image + both SPAs in a single step
 (`deploy.sh` for bash/CI/macOS/Linux, `deploy.ps1` for Windows):
 
+The region is **required** — these scripts never assume one. Pass it as the
+2nd positional arg (bash) or `-Region` (PowerShell); omit it and they prompt.
+
 ```bash
 # bash
-./deploy.sh dev                      # use the image tag from tfvars; dev auto-seeds (apply --seed)
-./deploy.sh dev --seed-demo           # also seed acme/globex demo tenants
-./deploy.sh prod --build-api --auto-approve   # also build+push the API + migrator images at the current git SHA
+./deploy.sh dev us-east-1                       # use the image tag from tfvars; dev auto-seeds (apply --seed)
+./deploy.sh dev ap-south-1 --seed-demo           # also seed acme/globex demo tenants
+./deploy.sh prod us-east-1 --build-api --auto-approve   # also build+push the API + migrator images at the current git SHA
 ```
 
 ```powershell
 # PowerShell
-./deploy.ps1 -Environment dev
-./deploy.ps1 -Environment dev -SeedDemo
-./deploy.ps1 -Environment prod -BuildApi -AutoApprove
+./deploy.ps1 -Environment dev -Region us-east-1
+./deploy.ps1 -Environment dev -Region ap-south-1 -SeedDemo
+./deploy.ps1 -Environment prod -Region us-east-1 -BuildApi -AutoApprove
 ```
 
 The script: `terraform init` + `apply` → (optional) build & push the API +

--- a/deploy/terraform/apps/starter/app_stack/main.tf
+++ b/deploy/terraform/apps/starter/app_stack/main.tf
@@ -551,6 +551,11 @@ module "redis" {
   automatic_failover_enabled = var.redis_automatic_failover_enabled
   transit_encryption_enabled = var.redis_transit_encryption_enabled
 
+  # dev tears down without a final snapshot (matches RDS above); otherwise a
+  # repeated destroy collides with the prior attempt's snapshot name
+  # (SnapshotAlreadyExistsFault). staging/prod keep the final snapshot.
+  skip_final_snapshot = var.environment == "dev" ? true : false
+
   tags = local.common_tags
 }
 

--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -3,8 +3,8 @@
   One-command deploy of the FullStackHero Starter Kit to AWS.
 
 .EXAMPLE
-  ./deploy.ps1 -Environment dev
-  ./deploy.ps1 -Environment prod -Region us-east-1 -BuildApi -AutoApprove
+  ./deploy.ps1 -Environment dev -Region us-east-1
+  ./deploy.ps1 -Environment prod -Region ap-south-1 -BuildApi -AutoApprove
 
 .DESCRIPTION
   Runs, in order:
@@ -19,7 +19,9 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)][ValidateSet('dev', 'staging', 'prod')][string]$Environment,
-  [string]$Region = 'us-east-1',
+  # Region is mandatory — never assume one. PowerShell prompts when it is omitted;
+  # CI/automation passes -Region explicitly.
+  [Parameter(Mandatory, HelpMessage = 'AWS region, e.g. us-east-1 or ap-south-1')][string]$Region,
   [switch]$BuildApi,
   [string]$ImageTag,
   [string]$Registry = 'ghcr.io/fullstackhero',

--- a/deploy/terraform/apps/starter/deploy.sh
+++ b/deploy/terraform/apps/starter/deploy.sh
@@ -2,7 +2,10 @@
 #
 # One-command deploy of the FullStackHero Starter Kit to AWS.
 #
-#   ./deploy.sh <dev|staging|prod> [region]
+#   ./deploy.sh <dev|staging|prod> <region>
+#
+# Region is required — the script never assumes one. Pass it as the 2nd arg
+# (e.g. `./deploy.sh dev ap-south-1`) or it will prompt interactively.
 #
 # It will, in order:
 #   1. terraform init + apply (infra: VPC, ALB+WAF, ECS API, RDS, Redis, S3, the two SPA CloudFront sites)
@@ -34,7 +37,7 @@ APP_STACK_DIR="$SCRIPT_DIR/app_stack"
 
 # ---- args -------------------------------------------------------------------
 ENVIRONMENT="${1:-}"
-REGION="us-east-1"
+REGION=""
 BUILD_API=false
 SKIP_FRONTEND=false
 SKIP_MIGRATE=false
@@ -61,7 +64,17 @@ done
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-[[ "$ENVIRONMENT" =~ ^(dev|staging|prod)$ ]] || die "usage: ./deploy.sh <dev|staging|prod> [region] [flags]"
+[[ "$ENVIRONMENT" =~ ^(dev|staging|prod)$ ]] || die "usage: ./deploy.sh <dev|staging|prod> <region> [flags]"
+
+# Region is required — never assume one. Prompt when interactive, else fail.
+if [[ -z "$REGION" ]]; then
+  if [[ -t 0 ]]; then
+    read -rp "AWS region (e.g. us-east-1, ap-south-1): " REGION
+  else
+    die "no region given — pass it as the 2nd arg (e.g. ./deploy.sh $ENVIRONMENT us-east-1); refusing to assume a default"
+  fi
+fi
+[[ "$REGION" =~ ^[a-z]{2}-[a-z]+-[0-9]$ ]] || die "invalid AWS region: '$REGION'"
 
 ENV_DIR="$SCRIPT_DIR/envs/$ENVIRONMENT/$REGION"
 [[ -f "$ENV_DIR/backend.hcl" ]] || die "no backend.hcl for $ENVIRONMENT/$REGION at $ENV_DIR"

--- a/deploy/terraform/apps/starter/destroy.ps1
+++ b/deploy/terraform/apps/starter/destroy.ps1
@@ -3,8 +3,8 @@
   Destroy the FullStackHero Starter Kit AWS stack for one environment.
 
 .EXAMPLE
-  ./destroy.ps1 -Environment dev
-  ./destroy.ps1 -Environment dev -AutoApprove
+  ./destroy.ps1 -Environment dev -Region us-east-1
+  ./destroy.ps1 -Environment dev -Region us-east-1 -AutoApprove
 
 .DESCRIPTION
   Runs terraform init (re-pointing the backend) + terraform destroy for the
@@ -21,7 +21,8 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)][ValidateSet('dev', 'staging', 'prod')][string]$Environment,
-  [string]$Region = 'us-east-1',
+  # Region is mandatory — never assume one. PowerShell prompts when it is omitted.
+  [Parameter(Mandatory, HelpMessage = 'AWS region, e.g. us-east-1 or ap-south-1')][string]$Region,
   [switch]$SkipInit,
   [switch]$AutoApprove
 )


### PR DESCRIPTION
## Summary

Two deploy-script changes. One of these (the Redis fix) was **stranded** when #1285 was merged at the "Merge main" tip just before its push landed — this PR recovers it.

### 1. Require an explicit AWS region (never assume `us-east-1`)
The deploy/destroy scripts defaulted `Region` to `us-east-1`, so forgetting it silently targeted the wrong place. Region is now required:
- **PowerShell** (`deploy.ps1`, `destroy.ps1`): `-Region` is `[Parameter(Mandatory)]` — prompts when omitted, still accepts an explicit value for CI/automation.
- **bash** (`deploy.sh`): no default; prompts interactively when a TTY is present, otherwise fails rather than assume one. Region format is validated.
- README examples updated to pass the region.

### 2. Skip the Redis final snapshot in dev (recovered from #1285)
The `elasticache_redis` module defaults `skip_final_snapshot=false` and the stack never overrode it, so `terraform destroy` in dev tried to take a final snapshot; a repeated destroy then failed with `SnapshotAlreadyExistsFault`. Mirrors the RDS module (dev skips, staging/prod keep the snapshot), matching `destroy.ps1`'s documented behavior.

## Test plan
- `terraform validate` passes; `bash -n deploy.sh` clean.
- `./destroy.ps1 -Environment dev -Region us-east-1` now tears down Redis without a snapshot collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)