### PR TITLE
fix(sse): flush stream headers eagerly so clients connect instantly

### DIFF
--- a/src/BuildingBlocks/Web/Sse/SseEndpoints.cs
+++ b/src/BuildingBlocks/Web/Sse/SseEndpoints.cs
@@ -61,6 +61,16 @@ public static class SseEndpoints
             context.Response.Headers["X-Accel-Buffering"] = "no"; // disable nginx buffering
 
             var (connectionId, reader) = connectionManager.Connect(principal.UserId, principal.TenantId);
+
+            // Flush the response headers + an initial comment immediately. Kestrel buffers
+            // response headers until the first body write, and our first write would otherwise
+            // be the heartbeat up to HeartbeatInterval (15s) away — so the client's fetch()
+            // promise (which resolves on response headers) would sit pending and the UI would
+            // show "connecting" for up to 15s on every connect/reconnect. Writing a no-op SSE
+            // comment now sends the headers and lets the client flip to "connected" at once.
+            await context.Response.WriteAsync(":connected\n\n", cancellationToken).ConfigureAwait(false);
+            await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+
             using var heartbeat = new PeriodicTimer(HeartbeatInterval);
 
             try


### PR DESCRIPTION
## What

On the dashboard, the Overview "System status" card sat on **Connecting** ("Waiting for the stream to come online") for up to 15 seconds after every connect/reconnect on an idle stream.

## Why

The client flips to **Connected** only when its `fetch()` to `/api/v1/sse/stream` resolves — and `fetch()` on a streaming response resolves when the **response headers** arrive. The server handler (`SseEndpoints.cs`) set the headers and then entered the read loop without writing anything, so Kestrel buffered the headers until the first body write — which was the heartbeat, up to `HeartbeatInterval` (15s) away. With no traffic and `Events this session: 0`, the browser sat pending the whole interval.

## How

Write a no-op `:connected` SSE comment and flush immediately after `Connect()`, so the headers go out at once and the client connects instantly. Two lines.

## Notes

- Touches `src/BuildingBlocks/Web/Sse` (protected) — change is minimal and self-contained.
- No test asserts the SSE stream bytes, so the extra leading comment is safe; the `Web` project builds clean (0 warnings).
- Changelog entry added in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)