### PR TITLE
fix(deps): pin transitive MessagePack to 2.5.301 (NU1903 breaks all CI)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -120,4 +120,11 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
+  <ItemGroup Label="Transitive security pins">
+    <!-- Pulled transitively by Microsoft.AspNetCore.SignalR.StackExchangeRedis; versions
+         below 2.5.301 fail NuGet audit (NU1903, GHSA-hv8m-jj95-wg3x: LZ4 decompression
+         AccessViolation). Transitive pinning is enabled, so this entry alone bumps it.
+         Remove once the SignalR backplane package depends on a patched version itself. -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

GitHub advisory [GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (high severity — LZ4 decompression `AccessViolationException`) was published against **MessagePack < 2.5.301**. `Microsoft.AspNetCore.SignalR.StackExchangeRedis` 10.0.8 pulls MessagePack **2.5.187** transitively, and NuGet audit runs with warnings-as-errors — so **every `dotnet restore` in CI now fails with NU1903**, breaking all PR checks repo-wide (this is what turned #1298 and every other open PR red).

## What

One `PackageVersion` entry in `Directory.Packages.props` under a new "Transitive security pins" group. `CentralPackageTransitivePinningEnabled` is already on, so this single entry bumps the transitive across the whole solution (and the `dotnet new fsh` template, which packs from this same source).

Remove the pin once the SignalR backplane package depends on a patched MessagePack itself.

## Testing

- `dotnet restore --force-evaluate` — exit 0, no NU1903/NU1109.
- `dotnet build src/FSH.Starter.slnx` — 0 warnings, 0 errors (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)