### PR TITLE
Hardening audit: identity N+1, PII log scrubbing, dead IsMuted column, dashboard refresh timeout

### DIFF
--- a/clients/admin/package-lock.json
+++ b/clients/admin/package-lock.json
@@ -41,7 +41,6 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.18",
         "globals": "^15.14.0",
-        "openapi-typescript": "^7.6.1",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.23.0",
@@ -1811,82 +1810,6 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
-    "node_modules/@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@redocly/config": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@redocly/openapi-core": {
-      "version": "1.34.12",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.12.tgz",
-      "integrity": "sha512-b32XWsz6enN6K4bx8xWsqUaXTJR/DnYT3lL1CzDYzIYKw243NNlz6fexmr71q/U4HrEcMoJGBvwAfcxOb8ymQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.22.0",
-        "colorette": "1.4.0",
-        "https-proxy-agent": "7.0.6",
-        "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
-        "minimatch": "5.1.9",
-        "pluralize": "8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=18.17.0",
-        "npm": ">=9.5.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2990,16 +2913,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3015,16 +2928,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -3442,13 +3345,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -3497,13 +3393,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -4634,20 +4523,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4683,19 +4558,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/index-to-position": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/internal-slot": {
@@ -5110,16 +4972,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -5727,40 +5579,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/openapi-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/openapi-core": "^1.34.6",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.2.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.x"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5851,24 +5669,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-json": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5953,16 +5753,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pngjs": {
@@ -6276,16 +6066,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6850,19 +6630,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -7053,13 +6820,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/uri-js-replace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -7374,13 +7134,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -7401,16 +7154,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/find-up": {

--- a/clients/admin/package.json
+++ b/clients/admin/package.json
@@ -45,7 +45,6 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
-    "openapi-typescript": "^7.6.1",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.23.0",

--- a/clients/dashboard/src/api/chat.ts
+++ b/clients/dashboard/src/api/chat.ts
@@ -22,7 +22,6 @@ export type ChannelMemberDto = {
   role: ChannelMemberRoleValue;
   joinedAtUtc: string;
   lastReadMessageId?: string | null;
-  isMuted: boolean;
 };
 
 export type ChannelDto = {

--- a/clients/dashboard/src/lib/api-client.ts
+++ b/clients/dashboard/src/lib/api-client.ts
@@ -119,6 +119,9 @@ export async function refreshAccessToken() {
       ...(tenant ? { tenant } : {}),
     },
     body: JSON.stringify({ token: accessToken, refreshToken }),
+    // A stalled refresh would otherwise hang forever and block every queued
+    // 401-retry awaiting the shared refreshPromise.
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/clients/dashboard/src/pages/chat/message.tsx
+++ b/clients/dashboard/src/pages/chat/message.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cn";
+import { describe } from "@/lib/list-helpers";
 import { useUserByUsername, useUserDisplay } from "@/lib/use-user-display";
 import { usePresence } from "@/realtime/use-presence";
 import { groupReactions, shortTime } from "@/pages/chat/chat-utils";
@@ -568,7 +569,7 @@ function MentionPill({ username }: { username: string }) {
       setOpen(false);
       navigate(`/chat/${channelId}`);
     },
-    onError: () => toast.error("Couldn't open DM"),
+    onError: (err) => toast.error("Couldn't open DM", { description: describe(err) }),
   });
 
   const displayName =
@@ -719,7 +720,7 @@ function MessageActions({
       setConfirmingDelete(false);
       toast.success("Message deleted");
     },
-    onError: () => toast.error("Couldn't delete the message"),
+    onError: (err) => toast.error("Couldn't delete the message", { description: describe(err) }),
   });
 
   const pinMutation = useMutation({
@@ -733,7 +734,7 @@ function MessageActions({
       void queryClient.invalidateQueries({ queryKey: ["chat", "pinned", message.channelId] });
       toast.success(message.isPinned ? "Unpinned" : "Pinned");
     },
-    onError: () => toast.error("Couldn't update the pin."),
+    onError: (err) => toast.error("Couldn't update the pin", { description: describe(err) }),
   });
 
   if (isDeleted) return null;

--- a/clients/dashboard/src/pages/tickets/ticket-detail.tsx
+++ b/clients/dashboard/src/pages/tickets/ticket-detail.tsx
@@ -372,7 +372,8 @@ function CommentsSection({
   const [body, setBody] = useState("");
 
   const mutation = useMutation({
-    mutationFn: () => addTicketComment(ticketId, body.trim()),
+    // Per-call data flows through mutate(arg), never closed-over state (golden rule #9).
+    mutationFn: (text: string) => addTicketComment(ticketId, text),
     onSuccess: () => {
       setBody("");
       toast.success("Comment posted");
@@ -416,7 +417,7 @@ function CommentsSection({
         onSubmit={(e) => {
           e.preventDefault();
           if (!body.trim() || disabled) return;
-          mutation.mutate();
+          mutation.mutate(body.trim());
         }}
         className={cn(
           "mt-5 rounded-xl border bg-[var(--color-card)]",
@@ -427,6 +428,7 @@ function CommentsSection({
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
+          aria-label="Add a comment"
           placeholder={
             disabled
               ? "Reopen the ticket to add a new comment."

--- a/clients/dashboard/tests/chat/chat.spec.ts
+++ b/clients/dashboard/tests/chat/chat.spec.ts
@@ -51,7 +51,6 @@ const CHANNEL_ENGINEERING = {
       role: "Admin",
       joinedAtUtc: "2026-05-01T10:00:00Z",
       lastReadMessageId: null,
-      isMuted: false,
     },
   ],
 };

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Chat/20260612201021_DropChannelMemberIsMuted.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Chat/20260612201021_DropChannelMemberIsMuted.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Chat.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Chat
 {
     [DbContext(typeof(ChatDbContext))]
-    partial class ChatDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260612201021_DropChannelMemberIsMuted")]
+    partial class DropChannelMemberIsMuted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Chat/20260612201021_DropChannelMemberIsMuted.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Chat/20260612201021_DropChannelMemberIsMuted.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Chat
+{
+    /// <inheritdoc />
+    public partial class DropChannelMemberIsMuted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsMuted",
+                schema: "chat",
+                table: "ChannelMembers");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsMuted",
+                schema: "chat",
+                table: "ChannelMembers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/Modules/Chat/Modules.Chat.Contracts/v1/DTOs/ChannelMemberDto.cs
+++ b/src/Modules/Chat/Modules.Chat.Contracts/v1/DTOs/ChannelMemberDto.cs
@@ -5,5 +5,4 @@ public sealed record ChannelMemberDto(
     string UserId,
     ChannelMemberRole Role,
     DateTime JoinedAtUtc,
-    Guid? LastReadMessageId,
-    bool IsMuted);
+    Guid? LastReadMessageId);

--- a/src/Modules/Chat/Modules.Chat/Data/Configurations/ChannelMemberConfiguration.cs
+++ b/src/Modules/Chat/Modules.Chat/Data/Configurations/ChannelMemberConfiguration.cs
@@ -20,7 +20,6 @@ public sealed class ChannelMemberConfiguration : IEntityTypeConfiguration<Channe
         builder.Property(x => x.Role).IsRequired().HasConversion<int>();
         builder.Property(x => x.JoinedAtUtc).IsRequired();
         builder.Property(x => x.LastReadMessageId);
-        builder.Property(x => x.IsMuted).IsRequired();
 
         builder.HasIndex(x => new { x.UserId, x.ChannelId }).IsUnique();
         builder.HasIndex(x => x.UserId);

--- a/src/Modules/Chat/Modules.Chat/Domain/ChannelMember.cs
+++ b/src/Modules/Chat/Modules.Chat/Domain/ChannelMember.cs
@@ -10,7 +10,6 @@ public sealed class ChannelMember : BaseEntity<Guid>
     public ChannelMemberRole Role { get; private set; }
     public DateTime JoinedAtUtc { get; private set; }
     public Guid? LastReadMessageId { get; private set; }
-    public bool IsMuted { get; }
 
     private ChannelMember() { }
 

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChatMappers.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChatMappers.cs
@@ -6,7 +6,7 @@ namespace FSH.Modules.Chat.Features.v1.Internal;
 internal static class ChatMappers
 {
     public static ChannelMemberDto ToDto(this ChannelMember m) =>
-        new(m.Id, m.UserId, m.Role, m.JoinedAtUtc, m.LastReadMessageId, m.IsMuted);
+        new(m.Id, m.UserId, m.Role, m.JoinedAtUtc, m.LastReadMessageId);
 
     public static ChannelDto ToDto(this ChatChannel c, int unreadCount = 0) =>
         new(

--- a/src/Modules/Identity/Modules.Identity/Events/TokenGeneratedLogHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Events/TokenGeneratedLogHandler.cs
@@ -24,10 +24,10 @@ public sealed class TokenGeneratedLogHandler
 
         if (_logger.IsEnabled(LogLevel.Information))
         {
+            // PII minimization: log the pseudonymous UserId only, not the email address.
             _logger.LogInformation(
-                "Token generated for user {UserId} ({Email}) with client {ClientId}, IP {IpAddress}, UserAgent {UserAgent}, expires at {ExpiresAtUtc} (fingerprint: {Fingerprint})",
+                "Token generated for user {UserId} with client {ClientId}, IP {IpAddress}, UserAgent {UserAgent}, expires at {ExpiresAtUtc} (fingerprint: {Fingerprint})",
                 @event.UserId,
-                @event.Email,
                 @event.ClientId,
                 @event.IpAddress,
                 @event.UserAgent,

--- a/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEmailHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEmailHandler.cs
@@ -45,7 +45,8 @@ public sealed class UserRegisteredEmailHandler
         {
             // Email failures must not break user registration.
             // The email can be retried via the outbox/dead-letter mechanism.
-            _logger.LogWarning(ex, "Failed to send welcome email to {Email}", @event.Email);
+            // PII minimization: identify the recipient by UserId, not email address.
+            _logger.LogWarning(ex, "Failed to send welcome email to user {UserId}", @event.UserId);
         }
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEventHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEventHandler.cs
@@ -21,10 +21,10 @@ public sealed class UserRegisteredHandler(
 
         if (logger.IsEnabled(LogLevel.Information))
         {
+            // PII minimization: log the pseudonymous UserId only, not the email address.
             logger.LogInformation(
-                "User registered: {UserId} ({Email})",
-                notification.UserId,
-                notification.Email);
+                "User registered: {UserId}",
+                notification.UserId);
         }
 
         var integrationEvent = new UserRegisteredIntegrationEvent(

--- a/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
@@ -49,6 +49,10 @@ internal sealed class UserRoleService(
         var roles = await roleManager.Roles.AsNoTracking().ToListAsync(cancellationToken)
             ?? throw new NotFoundException("roles not found");
 
+        // Single membership query instead of one IsInRoleAsync round-trip per role.
+        var memberships = await userManager.GetRolesAsync(user);
+        var membershipSet = new HashSet<string>(memberships, StringComparer.OrdinalIgnoreCase);
+
         var userRoles = new List<UserRoleDto>();
         foreach (var role in roles)
         {
@@ -57,7 +61,7 @@ internal sealed class UserRoleService(
                 RoleId = role.Id,
                 RoleName = role.Name,
                 Description = role.Description,
-                Enabled = await userManager.IsInRoleAsync(user, role.Name!)
+                Enabled = membershipSet.Contains(role.Name!)
             });
         }
 


### PR DESCRIPTION
## What

Output of a full-stack hardening audit (authz/tenant-isolation > performance > clean code > frontend > IaC). Five parallel audit sweeps, every finding re-verified against code before fixing. Headline: **no authorization or tenant-isolation issues exist** — all historical security fixes re-verified PASS, and a fresh sweep of all 168 endpoints found no gaps.

## Fixes

- **perf(identity):** `GetUserRolesAsync` issued one `IsInRoleAsync` DB round-trip per role (N+1). Now a single `GetRolesAsync` feeds a case-insensitive set lookup.
- **fix(identity):** emails (PII) removed from 3 log message templates (registration, token generation, welcome-email failure) — UserId only.
- **refactor(chat):** dead `ChannelMember.IsMuted` removed end-to-end (domain, EF config, `ChannelMemberDto`, dashboard client type) + migration `DropChannelMemberIsMuted`.
  - ⚠️ **Deliberate contract change:** `ChannelMemberDto` loses `IsMuted`. The property was get-only, never set, always serialized `false`; no consumer read it (verified across both apps and all tests).
  - ⚠️ **Schema change:** existing DBs need `DbMigrator apply` (drops `chat.ChannelMembers.IsMuted`).
- **fix(dashboard):** `refreshAccessToken` now aborts after 30s — a stalled refresh previously hung the shared refresh promise and every queued 401-retry behind it (admin already had this guard). Ticket comment composer passes its body through `mutate(arg)` (golden rule #9) and gains an `aria-label`. Chat DM/delete/pin failure toasts now include the ProblemDetails description.
- **chore(admin):** unused `openapi-typescript` devDependency removed.

## Verified

- Backend build 0 warnings (TreatWarningsAsErrors), full suite green: 713/714 integration (1 pre-existing skip) + 964 unit/arch tests, 0 failures
- Both apps: tsc + vite build + eslint clean; dashboard chat+tickets Playwright 15/15
- `terraform fmt -check` + `terraform validate` clean on `app_stack`

## Deferred (documented, unchanged)

- Billing/Files direct `IEventBus` publish (outbox needs BuildingBlocks/Eventing keyed-store redesign — same deferral as #1273)
- AppHost hardcoded dev credentials (throwaway/dev-only, out-of-box DX)
- Changelog entry in the docs repo for the `ChannelMemberDto` change — follow-up (docs repo has uncommitted WIP on its overhaul branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)