### PR TITLE
fix(identity): correct password-reset email link (trailing slash, tenant, URL-encoding)

### DIFF
--- a/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
@@ -39,7 +39,18 @@ internal sealed class UserPasswordService(
         var token = await userManager.GeneratePasswordResetTokenAsync(user);
         token = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
 
-        var resetPasswordUri = $"{origin}/reset-password?token={token}&email={email}";
+        // Build the SPA reset link with QueryHelpers (matches GetEmailVerificationUriAsync): trim any trailing
+        // slash from the configured origin (Uri.ToString adds one for a host-only URL → "//reset-password"
+        // misses the client route) and include the tenant the reset page requires. QueryHelpers URL-encodes
+        // each value, so reserved chars in the email (e.g. '+') survive.
+        var resetPasswordUri = QueryHelpers.AddQueryString(
+            $"{origin.TrimEnd('/')}/reset-password",
+            new Dictionary<string, string?>
+            {
+                ["token"] = token,
+                ["email"] = email,
+                ["tenant"] = multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id,
+            });
         var mailRequest = new MailRequest(
             new Collection<string> { user.Email },
             "Reset Password",

--- a/src/Tests/Identity.Tests/Services/UserPasswordServiceTests.cs
+++ b/src/Tests/Identity.Tests/Services/UserPasswordServiceTests.cs
@@ -1,0 +1,99 @@
+using System.Linq.Expressions;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Jobs.Services;
+using FSH.Framework.Mailing;
+using FSH.Framework.Mailing.Services;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Services;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+
+namespace Identity.Tests.Services;
+
+/// <summary>
+/// Tests for UserPasswordService.ForgotPasswordAsync — focuses on the reset-link format
+/// (regression cover for the double-slash, missing-tenant and unencoded-email defects).
+/// </summary>
+public sealed class UserPasswordServiceTests
+{
+    private const string TenantId = "codefi";
+
+    private readonly UserManager<FshUser> _userManager;
+    private readonly IJobService _jobService;
+    private readonly IMailService _mailService;
+    private readonly IMultiTenantContextAccessor<AppTenantInfo> _tenantAccessor;
+
+    public UserPasswordServiceTests()
+    {
+        _userManager = Substitute.For<UserManager<FshUser>>(
+            Substitute.For<IUserStore<FshUser>>(), null, null, null, null, null, null, null, null);
+        _jobService = Substitute.For<IJobService>();
+        _mailService = Substitute.For<IMailService>();
+        _tenantAccessor = Substitute.For<IMultiTenantContextAccessor<AppTenantInfo>>();
+
+        var mtContext = Substitute.For<IMultiTenantContext<AppTenantInfo>>();
+        mtContext.TenantInfo.Returns(new AppTenantInfo(TenantId, TenantId, "Codefi"));
+        _tenantAccessor.MultiTenantContext.Returns(mtContext);
+
+        // The mail job is enqueued as an expression; compile + invoke it so the captured MailRequest
+        // reaches the (mocked) mail service exactly as production would build it.
+        _jobService.Enqueue(Arg.Any<Expression<Func<Task>>>())
+            .Returns(ci =>
+            {
+                ci.Arg<Expression<Func<Task>>>().Compile().Invoke();
+                return "job-1";
+            });
+        _mailService.SendAsync(Arg.Any<MailRequest>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+    }
+
+    private UserPasswordService CreateSut() =>
+        new(_userManager, null!, _jobService, _mailService, _tenantAccessor, null!, null!);
+
+    private MailRequest CaptureSentMail()
+    {
+        var call = _mailService.ReceivedCalls().Single();
+        return (MailRequest)call.GetArguments()[0]!;
+    }
+
+    [Fact]
+    public async Task ForgotPasswordAsync_Should_BuildResetLink_WithSingleSlash_Tenant_AndEncodedEmail()
+    {
+        // Arrange — trailing slash on the origin (as Uri.ToString() produces for a host-only URL) and an
+        // email with reserved characters ('+', '@') to exercise all three defects at once.
+        const string email = "marcelo+reset@codefi.com.br";
+        var user = new FshUser { Email = email, UserName = email };
+        _userManager.FindByEmailAsync(email).Returns(user);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("raw-token");
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ForgotPasswordAsync(email, "https://appbase.codefi.com.br/", CancellationToken.None);
+
+        // Assert
+        var body = CaptureSentMail().Body!;
+        body.ShouldContain("https://appbase.codefi.com.br/reset-password?");
+        body.ShouldNotContain("//reset-password");                       // defect 3: no double slash
+        body.ShouldContain($"&tenant={TenantId}");                       // defect 4: tenant present
+        // defect 5: reserved chars are encoded — '+' must become %2B (an unencoded '+' would decode to a
+        // space). '@' is left as-is, which is valid in a query component per RFC 3986 (QueryHelpers encodes
+        // only what is required, matching GetEmailVerificationUriAsync).
+        body.ShouldContain("email=marcelo%2Breset");
+        body.ShouldNotContain("email=marcelo+reset");                    // raw '+' must not leak
+    }
+
+    [Fact]
+    public async Task ForgotPasswordAsync_Should_NotEnqueueMail_When_UserIsUnknown()
+    {
+        // Arrange — anti-enumeration: unknown user silently no-ops (no mail), still a 200 upstream.
+        _userManager.FindByEmailAsync(Arg.Any<string>()).Returns((FshUser?)null);
+        var sut = CreateSut();
+
+        // Act
+        await sut.ForgotPasswordAsync("ghost@codefi.com.br", "https://appbase.codefi.com.br/", CancellationToken.None);
+
+        // Assert
+        _jobService.DidNotReceive().Enqueue(Arg.Any<Expression<Func<Task>>>());
+    }
+}


### PR DESCRIPTION
### Summary
The password-reset email builds a link the dashboard SPA cannot open. With `OriginOptions.OriginUrl`
set to a host-only URL, the emitted link is malformed in three independent ways, so the reset page
rejects it as a broken link. This fixes the link builder in `UserPasswordService.ForgotPasswordAsync`.

### Environment
- .NET SDK: 10.0.301
- DB provider: PostgreSQL (Npgsql)
- Branch: `main` @ 8c216ada

### Reproduction
1. Default `appsettings.Production.json` (`OriginOptions.OriginUrl` empty):
   `POST /api/v1/identity/forgot-password` returns 500 ("Origin URL is not configured.").
2. Set `OriginOptions__OriginUrl=https://app.example.com` and request a reset for a real user.
3. Emitted link: `https://app.example.com//reset-password?token=...&email=user+x@example.com`
   (double slash, no `tenant`, unencoded email) — the reset page shows "this link is incomplete".

### Defects fixed
1. **Double slash.** `OriginOptions.OriginUrl` is a `Uri`; `ForgotPasswordCommandHandler.cs:24` uses
   `OriginUrl.ToString()`, which appends a trailing slash for a host-only URL. Combined with
   `UserPasswordService.cs:42` (`$"{origin}/reset-password..."`) this yields `//reset-password`. The SPA
   route is `/reset-password` (`clients/dashboard/src/routes.tsx`), so it 404s in the client-side router.
2. **Missing `tenant`.** The reset page requires `token` + `email` + `tenant` and shows a "malformed link"
   state when any is absent (`clients/dashboard/src/pages/auth/reset-password.tsx`). The backend built
   only `?token=...&email=...`.
3. **Email not URL-encoded.** The email went raw into the query string, so addresses with `+`
   (sub-addressing) or other reserved characters were corrupted.

### Change
Build the link with `QueryHelpers.AddQueryString`, matching the sibling email-link builder
`UserRegistrationService.GetEmailVerificationUriAsync`. This trims the trailing slash, URL-encodes each
value, and adds the `tenant` the reset page requires.

```diff
- var resetPasswordUri = $"{origin}/reset-password?token={token}&email={email}";
+ var resetPasswordUri = QueryHelpers.AddQueryString(
+     $"{origin.TrimEnd('/')}/reset-password",
+     new Dictionary<string, string?>
+     {
+         ["token"] = token,
+         ["email"] = email,
+         ["tenant"] = multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id,
+     });
```

`tenantId` is already guaranteed non-empty by `EnsureValidTenant()` earlier in the method; `token` is
already Base64Url-encoded. No public signature changes. No `src/BuildingBlocks/` changes.

### Tests
Adds `UserPasswordServiceTests`:
- reset link built with a trailing-slash origin and an email containing `+`/`@`, asserting single slash,
  `tenant` present and the `+` encoded (an unencoded `+` would decode to a space);
- anti-enumeration: an unknown user enqueues no mail.

`dotnet test src/Tests/Identity.Tests` → 312 passing. Build clean under `TreatWarningsAsErrors`.

### Out of scope
There is a broader structural issue (single global origin; `register`/`confirm` derive the origin from
the API host), which affects any deployment with a front-end separate from the API. That part is
non-trivial, so per CONTRIBUTING I will raise it as a Discussion rather than fold it into this fix.
