### PR TITLE
chore(nuget): publish-readiness fixes for CLI + template packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -503,6 +503,8 @@ spec-os/
 /.claude/worktrees/
 /.claude/scheduled_tasks.lock
 /.claude/last30days.env
+# Local AI-tool state should never be tracked, at any depth.
+**/.claude/settings.local.json
 tmpclaude**
 
 # Auto Claude data directory

--- a/src/.claude/settings.local.json
+++ b/src/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__cwm-roslyn-navigator__get_project_graph",
-      "Bash(python3 -c \"import sys,json; print\\(json.dumps\\(json.load\\(sys.stdin\\).get\\(''mcpServers'',{}\\), indent=2\\)\\)\")",
-      "Bash(cat:*)"
-    ]
-  }
-}

--- a/src/Host/FSH.Starter.AppHost/Properties/launchSettings.json
+++ b/src/Host/FSH.Starter.AppHost/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:17273;http://localhost:15036",
+      "applicationUrl": "https://localhost:15888;http://localhost:15036",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",

--- a/templates/FullStackHero.NET.StarterKit.csproj
+++ b/templates/FullStackHero.NET.StarterKit.csproj
@@ -28,6 +28,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
+    <!-- Render the project README on the nuget.org gallery page (same README the CLI ships). -->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <TargetFramework>net10.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -46,6 +48,8 @@
     <Compile Remove="**\*" />
     <!-- Gallery icon at package root (separate from the .template.config content copy). -->
     <None Include="..\.template.config\icon.png" Pack="true" PackagePath="\" Visible="false" />
+    <!-- Gallery README at package root (separate from the content/README.md scaffold copy). -->
+    <None Include="..\README.md" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Pre-publish validation of the `FullStackHero.CLI` and `FullStackHero.NET.StarterKit` packages. Ran the full pipeline end-to-end and fixed three issues found along the way.

## Validation performed
- **Pack** — both packages pack clean (CLI 0.90 MB, template 2.82 MB / 2064 files, no junk leak: no `node_modules`/`bin`/`obj`/`.terraform`/`.tfstate`/`.claude`).
- **Install + scaffold** — template + `fsh` CLI install; scaffolded **full**, **--no-aspire**, and **--no-frontend** variants. Renames correct (`Acme.Store.AppHost`, `Projects.Acme_Store_Api`, OpenAPI title "Acme Store API"), conditional excludes correct.
- **Build** — all 3 backend variants build 0 warn / 0 err (incl. Aspire); both React apps `npm install` + production build clean.
- **Run** — scaffolded Aspire stack came up (Postgres/Valkey/MinIO/pgAdmin/migrator/demo-seeder/API/admin/dashboard); `/health/live` + `/health/ready` 200; Scalar 200; both frontends serve 200; root-admin JWT issued and `GET /api/v1/tenants` returned seeded data.
- **Tests** — full suite green: 14 projects pass (~1,790 tests). One SignalR realtime test flaked under load and passes on isolated rerun (untouched by this PR).

## Fixes
1. **Stop shipping a local AI-tool settings file** — `src/.claude/settings.local.json` was tracked and leaked into both the template package and scaffolded output (root `.gitignore` only anchored `/.claude/`). Untracked + ignore `**/.claude/settings.local.json` at any depth.
2. **Template package README** — the template pack lives outside `src/` so it never inherited `src/Directory.Build.props`'s `PackageReadmeFile`; added `PackageReadmeFile` + root README so the nuget.org gallery page renders (clears the "missing a readme" pack warning). The logo (`icon.png`) is already embedded at the root of both packages.
3. **Aspire dashboard port** — `launchSettings.json` used an auto-generated `17273` while the README, README-template, `fsh` CLI "Next Steps" (`FshConstants.AspireDashboardPort`), and `fsh doctor` all advertise `15888`. Pinned to `15888` so docs/CLI/doctor match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)