### PR TITLE
fix(admin): correct identity register & change-password routes (405)

### DIFF
--- a/clients/admin/src/api/users.ts
+++ b/clients/admin/src/api/users.ts
@@ -81,7 +81,7 @@ export async function changePassword(input: {
   newPassword: string;
   confirmNewPassword: string;
 }): Promise<string> {
-  return apiFetch<string>(`${BASE}/change-password`, {
+  return apiFetch<string>(`${IDENTITY}/change-password`, {
     method: "POST",
     body: JSON.stringify(input),
   });
@@ -110,7 +110,7 @@ export async function getUserRoles(id: string): Promise<UserRoleDto[]> {
 }
 
 export async function registerUser(input: RegisterUserInput): Promise<RegisterUserResponse> {
-  return apiFetch<RegisterUserResponse>(`${BASE}/register`, {
+  return apiFetch<RegisterUserResponse>(`${IDENTITY}/register`, {
     method: "POST",
     body: JSON.stringify(input),
   });

--- a/clients/admin/tests/settings/security.spec.ts
+++ b/clients/admin/tests/settings/security.spec.ts
@@ -5,7 +5,7 @@ import { installAdminShellMocks, ADMIN_PERMS } from "../helpers/shell-mocks";
 
 // SecuritySettings = password change + 2FA. The 2FA branch is driven by the
 // profile's twoFactorEnabled flag (GET /api/v1/identity/profile). Password
-// change POSTs to /api/v1/identity/users/change-password with
+// change POSTs to /api/v1/identity/change-password with
 // { password, newPassword, confirmNewPassword }.
 
 const PROFILE_2FA_OFF = {
@@ -55,7 +55,7 @@ test.describe("settings · security", () => {
     await mockJsonResponse(page, "**/api/v1/identity/profile", PROFILE_2FA_OFF);
     await mockJsonResponse(
       page,
-      "**/api/v1/identity/users/change-password",
+      "**/api/v1/identity/change-password",
       '"Password changed."',
       { method: "POST" },
     );
@@ -75,7 +75,7 @@ test.describe("settings · security", () => {
 
     const reqPromise = page.waitForRequest(
       (r) =>
-        r.url().includes("/api/v1/identity/users/change-password") && r.method() === "POST",
+        r.url().includes("/api/v1/identity/change-password") && r.method() === "POST",
       { timeout: 5_000 },
     );
     await dialog.getByRole("button", { name: /update password/i }).click();
@@ -135,7 +135,7 @@ test.describe("settings · security", () => {
     await mockJsonResponse(page, "**/api/v1/identity/profile", PROFILE_2FA_OFF);
     await mockProblemDetails(
       page,
-      "**/api/v1/identity/users/change-password",
+      "**/api/v1/identity/change-password",
       400,
       { title: "Bad Request", detail: "Current password is incorrect." },
     );

--- a/clients/admin/tests/users/users.spec.ts
+++ b/clients/admin/tests/users/users.spec.ts
@@ -138,8 +138,8 @@ test.describe("users create form", () => {
     ).toBeVisible();
   });
 
-  test("filling the form and submitting POSTs to /users/register", async ({ page }) => {
-    await page.route("**/api/v1/identity/users/register", async (route) => {
+  test("filling the form and submitting POSTs to /register", async ({ page }) => {
+    await page.route("**/api/v1/identity/register", async (route) => {
       if (route.request().method() !== "POST") {
         await route.fallback();
         return;
@@ -179,7 +179,7 @@ test.describe("users create form", () => {
     await dialog.getByLabel(/^Confirm password/).fill("Sup3rSecret!");
 
     const reqPromise = page.waitForRequest(
-      (r) => r.url().endsWith("/api/v1/identity/users/register") && r.method() === "POST",
+      (r) => r.url().endsWith("/api/v1/identity/register") && r.method() === "POST",
       { timeout: 5_000 },
     );
     await dialog.getByRole("button", { name: "Create account", exact: true }).click();
@@ -198,7 +198,7 @@ test.describe("users create form", () => {
 
   test("client-side validation blocks submit on an invalid username", async ({ page }) => {
     let posted = false;
-    await page.route("**/api/v1/identity/users/register", async (route) => {
+    await page.route("**/api/v1/identity/register", async (route) => {
       if (route.request().method() === "POST") posted = true;
       await route.fulfill({
         status: 200,


### PR DESCRIPTION
## Problem

Adding a user from the **admin** app failed with **405 Method Not Allowed** on `POST /api/v1/identity/users/register` (issue #1309).

The admin client posted to:
- `/api/v1/identity/users/register`
- `/api/v1/identity/users/change-password`

…but the API serves these as **bare** routes:
- `/api/v1/identity/register`
- `/api/v1/identity/change-password`

The `/users` prefix is only for user-collection sub-resources (`/users`, `/users/{id}`, `/users/{id}/roles`, …). `register` and `change-password` live directly under the identity group.

## Why only admin was affected

- The **dashboard** app already calls the correct bare routes (`clients/dashboard/src/api/identity.ts`).
- The **identity integration tests** exercise `/identity/register` and `/identity/change-password`.
- Only `clients/admin/src/api/users.ts` was wrong — and internally inconsistent: it already used the `IDENTITY` base (no `/users`) for `forgot-password`, `reset-password`, `profile`, and `permissions`, but used the `/users` `BASE` for these two calls.

## Fix

Point `registerUser` and `changePassword` at the `IDENTITY` base, and update the route-mocked Playwright specs to match the real routes.

## Verification

- `tsc -b` clean.
- All 13 admin user/security Playwright specs pass against a clean dev server (register POST, change-password POST, validation, error paths).

Fixes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)