### PR TITLE
refactor(webhooks): rename misleading SecretHash to ProtectedSecret

### DIFF
--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Webhooks/20260624152035_RenameWebhookSecretHashToProtectedSecret.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Webhooks/20260624152035_RenameWebhookSecretHashToProtectedSecret.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Webhooks.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Webhooks
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624152035_RenameWebhookSecretHashToProtectedSecret")]
+    partial class RenameWebhookSecretHashToProtectedSecret
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Webhooks/20260624152035_RenameWebhookSecretHashToProtectedSecret.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Webhooks/20260624152035_RenameWebhookSecretHashToProtectedSecret.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Webhooks
+{
+    /// <inheritdoc />
+    public partial class RenameWebhookSecretHashToProtectedSecret : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "SecretHash",
+                schema: "webhooks",
+                table: "Subscriptions",
+                newName: "ProtectedSecret");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ProtectedSecret",
+                schema: "webhooks",
+                table: "Subscriptions",
+                newName: "SecretHash");
+        }
+    }
+}

--- a/src/Modules/Webhooks/Modules.Webhooks/Data/WebhookSubscriptionConfiguration.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Data/WebhookSubscriptionConfiguration.cs
@@ -15,7 +15,7 @@ public sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguration<
         builder.HasKey(x => x.Id);
         builder.Property(x => x.Url).IsRequired().HasMaxLength(2048);
         builder.Property(x => x.EventsCsv).IsRequired().HasMaxLength(4096);
-        builder.Property(x => x.SecretHash).HasMaxLength(512);
+        builder.Property(x => x.ProtectedSecret).HasMaxLength(512);
         builder.HasIndex(x => x.IsActive);
         builder.Ignore(x => x.DomainEvents);
     }

--- a/src/Modules/Webhooks/Modules.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Domain/WebhookSubscription.cs
@@ -6,13 +6,13 @@ public sealed class WebhookSubscription : BaseEntity<Guid>
 {
     public string Url { get; private set; } = default!;
     public string EventsCsv { get; private set; } = default!;
-    public string? SecretHash { get; private set; }
+    public string? ProtectedSecret { get; private set; }
     public bool IsActive { get; private set; } = true;
     public DateTime CreatedAtUtc { get; private set; }
 
     private WebhookSubscription() { }
 
-    public static WebhookSubscription Create(string url, string[] events, string? secretHash)
+    public static WebhookSubscription Create(string url, string[] events, string? protectedSecret)
     {
         ArgumentNullException.ThrowIfNull(url);
         ArgumentNullException.ThrowIfNull(events);
@@ -22,7 +22,7 @@ public sealed class WebhookSubscription : BaseEntity<Guid>
             Id = Guid.CreateVersion7(),
             Url = url,
             EventsCsv = string.Join(',', events),
-            SecretHash = secretHash,
+            ProtectedSecret = protectedSecret,
             IsActive = true,
             CreatedAtUtc = TimeProvider.System.GetUtcNow().UtcDateTime
         };

--- a/src/Modules/Webhooks/Modules.Webhooks/Features/v1/TestWebhookSubscription/TestWebhookSubscriptionCommandHandler.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Features/v1/TestWebhookSubscription/TestWebhookSubscriptionCommandHandler.cs
@@ -33,7 +33,7 @@ public sealed class TestWebhookSubscriptionCommandHandler(
         await deliveryService.DeliverAsync(
             subscription.Id,
             subscription.Url,
-            secretProtector.Unprotect(subscription.SecretHash),
+            secretProtector.Unprotect(subscription.ProtectedSecret),
             "webhook.test",
             testPayload,
             cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Webhooks/Modules.Webhooks/Services/IWebhookDeliveryService.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Services/IWebhookDeliveryService.cs
@@ -2,5 +2,5 @@ namespace FSH.Modules.Webhooks.Services;
 
 public interface IWebhookDeliveryService
 {
-    Task DeliverAsync(Guid subscriptionId, string url, string? secretHash, string eventType, string payloadJson, CancellationToken ct = default);
+    Task DeliverAsync(Guid subscriptionId, string url, string? signingSecret, string eventType, string payloadJson, CancellationToken ct = default);
 }

--- a/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDeliveryService.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDeliveryService.cs
@@ -14,7 +14,7 @@ public sealed class WebhookDeliveryService(
     public async Task DeliverAsync(
         Guid subscriptionId,
         string url,
-        string? secretHash,
+        string? signingSecret,
         string eventType,
         string payloadJson,
         CancellationToken ct = default)
@@ -26,9 +26,9 @@ public sealed class WebhookDeliveryService(
         {
             using var content = new StringContent(payloadJson, Encoding.UTF8, new MediaTypeHeaderValue("application/json"));
 
-            if (!string.IsNullOrEmpty(secretHash))
+            if (!string.IsNullOrEmpty(signingSecret))
             {
-                var signature = WebhookPayloadSigner.Sign(payloadJson, secretHash);
+                var signature = WebhookPayloadSigner.Sign(payloadJson, signingSecret);
                 content.Headers.Add("X-Webhook-Signature", signature);
             }
 

--- a/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDispatchJob.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Services/WebhookDispatchJob.cs
@@ -103,7 +103,7 @@ public sealed class WebhookDispatchJob
         try
         {
             using var content = new StringContent(payloadJson, Encoding.UTF8, new MediaTypeHeaderValue("application/json"));
-            var signingSecret = _secretProtector.Unprotect(subscription.SecretHash);
+            var signingSecret = _secretProtector.Unprotect(subscription.ProtectedSecret);
             if (!string.IsNullOrEmpty(signingSecret))
             {
                 content.Headers.Add("X-Webhook-Signature", WebhookPayloadSigner.Sign(payloadJson, signingSecret));

--- a/src/Tests/Integration.Tests/Tests/Webhooks/WebhookDeliveryTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Webhooks/WebhookDeliveryTests.cs
@@ -257,7 +257,7 @@ public sealed class WebhookDeliveryTests
         await service.DeliverAsync(
             subscriptionId,
             "https://no-secret.invalid/hook",
-            secretHash: null,
+            signingSecret: null,
             eventType: "manual.event",
             payloadJson: "{\"manual\":true}",
             ct: CancellationToken.None);

--- a/src/Tests/Integration.Tests/Tests/Webhooks/WebhookSubscriptionDomainTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Webhooks/WebhookSubscriptionDomainTests.cs
@@ -29,7 +29,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "user.created", "user.updated" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act & Assert
         subscription.MatchesEvent("user.updated").ShouldBeTrue();
@@ -42,7 +42,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "a.one", "b.two", "c.three" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act
         var events = subscription.GetEvents();
@@ -62,7 +62,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "User.Created" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act & Assert — exact-name matching ignores case.
         subscription.MatchesEvent("user.created").ShouldBeTrue();
@@ -76,7 +76,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "*" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act & Assert
         subscription.MatchesEvent("any.unconfigured.event").ShouldBeTrue();
@@ -90,7 +90,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "user.created" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act & Assert
         subscription.MatchesEvent("user.deleted").ShouldBeFalse();
@@ -104,7 +104,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "  spaced.event  ", "", "  ", "tight.event" },
-            secretHash: null);
+            protectedSecret: null);
 
         // Act
         var events = subscription.GetEvents();
@@ -123,7 +123,7 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "user.created" },
-            secretHash: null);
+            protectedSecret: null);
         subscription.IsActive.ShouldBeTrue();
 
         // Act
@@ -140,12 +140,12 @@ public sealed class WebhookSubscriptionDomainTests
         var subscription = WebhookSubscription.Create(
             "https://example.com/hook",
             new[] { "user.created" },
-            secretHash: "hashed-secret");
+            protectedSecret: "protected-secret");
 
         // Assert
         subscription.Id.ShouldNotBe(Guid.Empty);
         subscription.Url.ShouldBe("https://example.com/hook");
-        subscription.SecretHash.ShouldBe("hashed-secret");
+        subscription.ProtectedSecret.ShouldBe("protected-secret");
         subscription.IsActive.ShouldBeTrue();
         subscription.CreatedAtUtc.ShouldNotBe(default);
     }

--- a/src/Tests/Webhooks.Tests/Domain/WebhookSubscriptionTests.cs
+++ b/src/Tests/Webhooks.Tests/Domain/WebhookSubscriptionTests.cs
@@ -12,22 +12,22 @@ public sealed class WebhookSubscriptionTests
         var sub = WebhookSubscription.Create(
             "https://example.com/hook",
             ["user.created", "user.deleted"],
-            "hashed-secret");
+            "protected-secret");
 
         sub.Url.ShouldBe("https://example.com/hook");
         sub.EventsCsv.ShouldBe("user.created,user.deleted");
-        sub.SecretHash.ShouldBe("hashed-secret");
+        sub.ProtectedSecret.ShouldBe("protected-secret");
         sub.IsActive.ShouldBeTrue();
         sub.Id.ShouldNotBe(Guid.Empty);
         sub.CreatedAtUtc.ShouldNotBe(default);
     }
 
     [Fact]
-    public void Create_Should_Allow_Null_SecretHash()
+    public void Create_Should_Allow_Null_ProtectedSecret()
     {
-        var sub = WebhookSubscription.Create("https://example.com", ["a"], secretHash: null);
+        var sub = WebhookSubscription.Create("https://example.com", ["a"], protectedSecret: null);
 
-        sub.SecretHash.ShouldBeNull();
+        sub.ProtectedSecret.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## What

`WebhookSubscription.SecretHash` stores the per-subscription signing secret **encrypted at rest** via ASP.NET Data Protection (`IWebhookSecretProtector.Protect`), then recovers it with `Unprotect` to compute the outbound HMAC signature. The name `SecretHash` wrongly implies a one-way, irreversible hash, which misrepresents the value's security properties and invites mishandling (treating it as safe-at-rest, or comparing it instead of unprotecting it).

This renames the value to describe what it actually is.

## Changes

- `WebhookSubscription.SecretHash` → `ProtectedSecret` (property + `Create` parameter), matching the existing `protectedSecret` local in `CreateWebhookSubscriptionCommandHandler`.
- EF `RenameColumn` migration (`webhooks.Subscriptions.SecretHash` → `ProtectedSecret`) — reversible, preserves existing rows.
- `IWebhookDeliveryService.DeliverAsync` parameter `secretHash` → `signingSecret`: there the value is the **already-unprotected plaintext** used for signing, matching the `signingSecret` local in `WebhookDispatchJob`.
- Updated unit + integration test references.

## Notes

- No public contract change — the secret is write-only via the create command and is never returned.
- Webhooks unit tests pass (54/54); build is clean (`TreatWarningsAsErrors`).
