### PR TITLE
fix(notifications): stop logging recipient email (CodeQL #27)

### DIFF
--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailSender.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailSender.cs
@@ -26,7 +26,9 @@ internal static class BillingEmailSender
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to send {Context} email to {Email}", context, email);
+            // Do not log the recipient address — it is PII and the log is an external sink
+            // (CodeQL cs/exposure-of-sensitive-information). The context identifies the operation.
+            logger.LogWarning(ex, "Failed to send {Context} email", context);
         }
     }
 }


### PR DESCRIPTION
## What

Resolves CodeQL **cs/exposure-of-sensitive-information** ([alert #27](https://github.com/fullstackhero/dotnet-starter-kit/security/code-scanning/27), CWE-359, medium).

`BillingEmailSender.SendAsync` logged the raw recipient address on a delivery failure (`"Failed to send {Context} email to {Email}"`), writing PII to an external sink (the log). The `{Email}` placeholder is dropped; `{Context}` already identifies the operation for debugging.

## Why this is safe

The email is still used to actually send the message — only the log statement changed. No behavior change beyond log content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)