### PR TITLE
fix(deps): pin Microsoft.OpenApi to patched 2.9.0 (NU1903)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -99,6 +99,11 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="UAParser" Version="3.1.47" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <!-- Pin the transitive Microsoft.OpenApi explicitly. Microsoft.AspNetCore.OpenApi 10.0.8 only requires
+         >= 2.0.0, but 2.0.0 carries a HIGH-severity advisory (GHSA-v5pm-xwqc-g5wc, patched in 2.7.5) that
+         trips NuGetAudit under TreatWarningsAsErrors. Stay on the 2.x line — 3.x has breaking API changes that
+         fail the framework's OpenAPI transformers. Bump in lockstep with Microsoft.AspNetCore.OpenApi. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
Fixes #1318.

## Problem
`Microsoft.OpenApi` 2.0.0 flows in transitively via `Microsoft.AspNetCore.OpenApi` 10.0.8 (which only requires `>= 2.0.0`) and carries HIGH-severity advisory **GHSA-v5pm-xwqc-g5wc**. With `NuGetAuditMode=all` (default on recent SDKs) + `TreatWarningsAsErrors=true`, this fails the build:

```
error NU1903: Package 'Microsoft.OpenApi' 2.0.0 has a known high severity vulnerability
```

Reproduce on clean `main`:
```
dotnet build src/FSH.Starter.slnx -p:NuGetAuditMode=all
```

## Fix
Pin `Microsoft.OpenApi` to `2.9.0` in `src/Directory.Packages.props` (`CentralPackageTransitivePinningEnabled` is already on, so one entry pins the whole graph).

- Advisory is first patched in **2.7.5**; 2.9.0 is the latest patched 2.x.
- Deliberately staying on **2.x**: 3.x has breaking API changes (`IOpenApiMediaType.Example` becomes read-only) that fail the framework's OpenAPI transformers and AspNetCore.OpenApi's source generator.

## Verification
- `dotnet build src/FSH.Starter.slnx -p:NuGetAuditMode=all` → **Build succeeded** (was NU1903 before).
- Resolved `Microsoft.OpenApi` is now `2.9.0` (no advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)