### PR TITLE
refactor(billing): adopt Money value object across Wallet, Invoice and BillingPlan

### DIFF
--- a/src/BuildingBlocks/Core/Domain/Money.cs
+++ b/src/BuildingBlocks/Core/Domain/Money.cs
@@ -13,4 +13,50 @@ public sealed record Money
     }
 
     public static Money Zero(string currency = "USD") => new(0m, currency);
+
+    public Money Add(Money other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        EnsureSameCurrency(other);
+        return this with { Amount = Amount + other.Amount };
+    }
+
+    public Money Subtract(Money other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        EnsureSameCurrency(other);
+        return this with { Amount = Amount - other.Amount };
+    }
+
+    public Money Multiply(decimal factor) => this with { Amount = Amount * factor };
+
+    public Money Round(int decimals) =>
+        this with { Amount = Math.Round(Amount, decimals, MidpointRounding.AwayFromZero) };
+
+    public static Money operator +(Money left, Money right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Add(right);
+    }
+
+    public static Money operator -(Money left, Money right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Subtract(right);
+    }
+
+    public static Money operator *(Money left, decimal right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Multiply(right);
+    }
+
+    private void EnsureSameCurrency(Money other)
+    {
+        if (!string.Equals(Currency, other.Currency, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Cannot operate on Money with different currencies: {Currency} and {other.Currency}.");
+        }
+    }
 }

--- a/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
+++ b/src/Host/FSH.Starter.DbMigrator/DemoSeed/DemoSeeder.cs
@@ -233,7 +233,7 @@ internal sealed class DemoSeeder
 
         // Paid plans get an issued term invoice (like real CreateTenant), written directly so no InvoiceIssuedIntegrationEvent fires
         // (no outbox dispatcher; seeding mustn't email). Idempotent on invoice number; free plans (term price 0) get none, as in production.
-        if (plan.TermPrice > 0m)
+        if (plan.TermPrice.Amount > 0m)
         {
             var invoiceNumber = string.Create(
                 CultureInfo.InvariantCulture, $"SUB-{startUtc:yyyyMM}-{demo.Id.ToUpperInvariant()}");
@@ -251,7 +251,7 @@ internal sealed class DemoSeeder
                         CultureInfo.InvariantCulture,
                         $"{plan.Name} — {plan.Interval} subscription ({startUtc:yyyy-MM-dd} to {endUtc:yyyy-MM-dd})"),
                     1m,
-                    plan.TermPrice);
+                    plan.TermPrice.Amount);
                 invoice.Issue();
                 billingDb.Invoices.Add(invoice);
                 if (_logger.IsEnabled(LogLevel.Information))

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Billing/20260701063312_BillingMoneyValueObjectAdoption.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Billing/20260701063312_BillingMoneyValueObjectAdoption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Billing.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Billing
 {
     [DbContext(typeof(BillingDbContext))]
-    partial class BillingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701063312_BillingMoneyValueObjectAdoption")]
+    partial class BillingMoneyValueObjectAdoption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Billing/20260701063312_BillingMoneyValueObjectAdoption.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Billing/20260701063312_BillingMoneyValueObjectAdoption.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Billing
+{
+    /// <inheritdoc />
+    public partial class BillingMoneyValueObjectAdoption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // WalletTransaction.Amount and InvoiceLineItem.Amount became Money owned value objects, and
+            // BillingPlan.AnnualPrice became an optional Money. The amount columns are preserved; only the
+            // per-row currency columns are new. Currency is denormalized from the owning aggregate, so
+            // existing rows are backfilled from the parent's currency before the NOT NULL columns are enforced.
+            // (Wallet.Balance/Invoice.SubtotalAmount/BillingPlan.MonthlyBasePrice reuse their existing
+            // "Currency" columns via OwnsOne, so those adoptions are pure no-ops with no schema change here.)
+
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                schema: "billing",
+                table: "WalletTransactions",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AmountCurrency",
+                schema: "billing",
+                table: "InvoiceLineItems",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AnnualPriceCurrency",
+                schema: "billing",
+                table: "Plans",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE billing."WalletTransactions" t
+                SET "Currency" = w."Currency"
+                FROM billing."Wallets" w
+                WHERE t."WalletId" = w."Id";
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE billing."InvoiceLineItems" li
+                SET "AmountCurrency" = i."Currency"
+                FROM billing."Invoices" i
+                WHERE li."InvoiceId" = i."Id";
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE billing."Plans"
+                SET "AnnualPriceCurrency" = "Currency"
+                WHERE "AnnualPrice" IS NOT NULL;
+                """);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Currency",
+                schema: "billing",
+                table: "WalletTransactions",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AmountCurrency",
+                schema: "billing",
+                table: "InvoiceLineItems",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                schema: "billing",
+                table: "WalletTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "AnnualPriceCurrency",
+                schema: "billing",
+                table: "Plans");
+
+            migrationBuilder.DropColumn(
+                name: "AmountCurrency",
+                schema: "billing",
+                table: "InvoiceLineItems");
+        }
+    }
+}

--- a/src/Modules/Billing/Modules.Billing/Data/Configurations/BillingPlanConfiguration.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/Configurations/BillingPlanConfiguration.cs
@@ -17,10 +17,19 @@ public sealed class BillingPlanConfiguration : IEntityTypeConfiguration<BillingP
         builder.Property(x => x.Key).IsRequired().HasMaxLength(64);
         builder.HasIndex(x => x.Key).IsUnique();
         builder.Property(x => x.Name).IsRequired().HasMaxLength(128);
-        builder.Property(x => x.Currency).IsRequired().HasMaxLength(8);
-        builder.Property(x => x.MonthlyBasePrice).HasPrecision(18, 4);
+        builder.Ignore(x => x.Currency);
+        builder.OwnsOne(x => x.MonthlyBasePrice, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("MonthlyBasePrice").HasPrecision(18, 4).IsRequired();
+            m.Property(p => p.Currency).HasColumnName("Currency").HasMaxLength(8).IsRequired();
+        });
+        builder.Navigation(x => x.MonthlyBasePrice).IsRequired();
         builder.Property(x => x.Interval).HasConversion<int>().HasDefaultValue(Contracts.PlanInterval.Monthly);
-        builder.Property(x => x.AnnualPrice).HasPrecision(18, 4);
+        builder.OwnsOne(x => x.AnnualPrice, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("AnnualPrice").HasPrecision(18, 4);
+            m.Property(p => p.Currency).HasColumnName("AnnualPriceCurrency").HasMaxLength(8);
+        });
 
         // Overage rates map to jsonb so the plan's pricing schedule is a single column.
         builder.Property<Dictionary<QuotaResource, decimal>>("_overageRates")

--- a/src/Modules/Billing/Modules.Billing/Data/Configurations/InvoiceConfiguration.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/Configurations/InvoiceConfiguration.cs
@@ -13,8 +13,13 @@ public sealed class InvoiceConfiguration : IEntityTypeConfiguration<Invoice>
         builder.HasKey(x => x.Id);
         builder.Property(x => x.TenantId).IsRequired().HasMaxLength(64);
         builder.Property(x => x.InvoiceNumber).IsRequired().HasMaxLength(64);
-        builder.Property(x => x.Currency).IsRequired().HasMaxLength(8);
-        builder.Property(x => x.SubtotalAmount).HasPrecision(18, 4);
+        builder.Ignore(x => x.Currency);
+        builder.OwnsOne(x => x.SubtotalAmount, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("SubtotalAmount").HasPrecision(18, 4).IsRequired();
+            m.Property(p => p.Currency).HasColumnName("Currency").HasMaxLength(8).IsRequired();
+        });
+        builder.Navigation(x => x.SubtotalAmount).IsRequired();
         builder.Property(x => x.Status).HasConversion<int>();
         builder.Property(x => x.Purpose).HasConversion<int>().HasDefaultValue(Contracts.InvoicePurpose.Usage);
         builder.Property(x => x.PeriodStartUtc);

--- a/src/Modules/Billing/Modules.Billing/Data/Configurations/InvoiceLineItemConfiguration.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/Configurations/InvoiceLineItemConfiguration.cs
@@ -17,7 +17,12 @@ public sealed class InvoiceLineItemConfiguration : IEntityTypeConfiguration<Invo
         builder.Property(x => x.Description).IsRequired().HasMaxLength(512);
         builder.Property(x => x.Quantity).HasPrecision(18, 4);
         builder.Property(x => x.UnitPrice).HasPrecision(18, 4);
-        builder.Property(x => x.Amount).HasPrecision(18, 4);
+        builder.OwnsOne(x => x.Amount, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("Amount").HasPrecision(18, 4).IsRequired();
+            m.Property(p => p.Currency).HasColumnName("AmountCurrency").HasMaxLength(8).IsRequired();
+        });
+        builder.Navigation(x => x.Amount).IsRequired();
 
         builder.HasIndex(x => x.InvoiceId);
 

--- a/src/Modules/Billing/Modules.Billing/Data/Configurations/WalletConfiguration.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/Configurations/WalletConfiguration.cs
@@ -12,8 +12,13 @@ public sealed class WalletConfiguration : IEntityTypeConfiguration<Wallet>
         builder.ToTable("Wallets");
         builder.HasKey(x => x.Id);
         builder.Property(x => x.TenantId).IsRequired().HasMaxLength(64);
-        builder.Property(x => x.Currency).IsRequired().HasMaxLength(8);
-        builder.Property(x => x.Balance).HasPrecision(18, 4);
+        builder.Ignore(x => x.Currency);
+        builder.OwnsOne(x => x.Balance, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("Balance").HasPrecision(18, 4).IsRequired();
+            m.Property(p => p.Currency).HasColumnName("Currency").HasMaxLength(8).IsRequired();
+        });
+        builder.Navigation(x => x.Balance).IsRequired();
         builder.Property(x => x.Status).HasConversion<int>();
         builder.HasIndex(x => x.TenantId).IsUnique().HasDatabaseName("ux_wallets_tenantid");
 

--- a/src/Modules/Billing/Modules.Billing/Data/Configurations/WalletTransactionConfiguration.cs
+++ b/src/Modules/Billing/Modules.Billing/Data/Configurations/WalletTransactionConfiguration.cs
@@ -14,7 +14,12 @@ public sealed class WalletTransactionConfiguration : IEntityTypeConfiguration<Wa
         // Child reached only via Wallet.Transactions nav — pin Id generation or EF marks Modified, not Added.
         builder.Property(x => x.Id).ValueGeneratedNever();
         builder.Property(x => x.TenantId).IsRequired().HasMaxLength(64);
-        builder.Property(x => x.Amount).HasPrecision(18, 4);
+        builder.OwnsOne(x => x.Amount, m =>
+        {
+            m.Property(p => p.Amount).HasColumnName("Amount").HasPrecision(18, 4).IsRequired();
+            m.Property(p => p.Currency).HasColumnName("Currency").HasMaxLength(8).IsRequired();
+        });
+        builder.Navigation(x => x.Amount).IsRequired();
         builder.Property(x => x.Kind).HasConversion<int>();
         builder.Property(x => x.Description).IsRequired().HasMaxLength(256);
         builder.Property(x => x.ReferenceId).HasMaxLength(128);

--- a/src/Modules/Billing/Modules.Billing/Domain/BillingPlan.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/BillingPlan.cs
@@ -18,8 +18,8 @@ public sealed class BillingPlan : BaseEntity<Guid>, IGlobalEntity
 
     public string Key { get; private set; } = default!;
     public string Name { get; private set; } = default!;
-    public string Currency { get; private set; } = "USD";
-    public decimal MonthlyBasePrice { get; private set; }
+    public Money MonthlyBasePrice { get; private set; } = default!;
+    public string Currency => MonthlyBasePrice.Currency;
     public PlanInterval Interval { get; private set; } = PlanInterval.Monthly;
 
     /// <summary>
@@ -27,7 +27,7 @@ public sealed class BillingPlan : BaseEntity<Guid>, IGlobalEntity
     /// <see cref="PlanInterval.Yearly"/>; <c>null</c> falls back to twelve times the monthly base
     /// price so a yearly plan can be configured without restating the discount.
     /// </summary>
-    public decimal? AnnualPrice { get; private set; }
+    public Money? AnnualPrice { get; private set; }
     public bool IsActive { get; private set; } = true;
     public DateTime CreatedAtUtc { get; private set; }
     public DateTime? UpdatedAtUtc { get; private set; }
@@ -64,10 +64,9 @@ public sealed class BillingPlan : BaseEntity<Guid>, IGlobalEntity
             Key = key.ToLowerInvariant(),
 #pragma warning restore CA1308
             Name = name,
-            Currency = currency.ToUpperInvariant(),
-            MonthlyBasePrice = monthlyBasePrice,
+            MonthlyBasePrice = new Money(monthlyBasePrice, currency),
             Interval = interval,
-            AnnualPrice = annualPrice,
+            AnnualPrice = annualPrice is { } a ? new Money(a, currency) : null,
             IsActive = true,
             CreatedAtUtc = DateTime.UtcNow
         };
@@ -101,9 +100,9 @@ public sealed class BillingPlan : BaseEntity<Guid>, IGlobalEntity
         }
 
         Name = name;
-        MonthlyBasePrice = monthlyBasePrice;
+        MonthlyBasePrice = new Money(monthlyBasePrice, Currency);
         Interval = interval;
-        AnnualPrice = annualPrice;
+        AnnualPrice = annualPrice is { } a ? new Money(a, Currency) : null;
         _overageRates.Clear();
         if (overageRates is not null)
         {
@@ -131,8 +130,8 @@ public sealed class BillingPlan : BaseEntity<Guid>, IGlobalEntity
     /// Price charged for a single billing term: the monthly base price for monthly plans, or the
     /// annual price (falling back to twelve months) for yearly plans.
     /// </summary>
-    public decimal TermPrice =>
+    public Money TermPrice =>
         Interval == PlanInterval.Yearly
-            ? AnnualPrice ?? (MonthlyBasePrice * 12m)
+            ? AnnualPrice ?? MonthlyBasePrice.Multiply(12m)
             : MonthlyBasePrice;
 }

--- a/src/Modules/Billing/Modules.Billing/Domain/Invoice.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/Invoice.cs
@@ -29,8 +29,8 @@ public sealed class Invoice : AggregateRoot<Guid>
 
     /// <summary>End of the billed term (subscription invoices only).</summary>
     public DateTime? PeriodEndUtc { get; private set; }
-    public string Currency { get; private set; } = "USD";
-    public decimal SubtotalAmount { get; private set; }
+    public Money SubtotalAmount { get; private set; } = default!;
+    public string Currency => SubtotalAmount.Currency;
     public InvoiceStatus Status { get; private set; }
     public DateTime CreatedAtUtc { get; private set; }
     public DateTime? IssuedAtUtc { get; private set; }
@@ -84,7 +84,7 @@ public sealed class Invoice : AggregateRoot<Guid>
             Purpose = purpose,
             PeriodStartUtc = periodStartUtc is { } s ? DateTime.SpecifyKind(s, DateTimeKind.Utc) : null,
             PeriodEndUtc = periodEndUtc is { } e ? DateTime.SpecifyKind(e, DateTimeKind.Utc) : null,
-            Currency = currency.ToUpperInvariant(),
+            SubtotalAmount = Money.Zero(currency.ToUpperInvariant()),
             Status = InvoiceStatus.Draft,
             CreatedAtUtc = DateTime.UtcNow
         };
@@ -113,7 +113,7 @@ public sealed class Invoice : AggregateRoot<Guid>
     public InvoiceLineItem AddLineItem(InvoiceLineItemKind kind, string description, decimal quantity, decimal unitPrice)
     {
         RequireStatus(InvoiceStatus.Draft);
-        var line = InvoiceLineItem.Create(Id, kind, description, quantity, unitPrice);
+        var line = InvoiceLineItem.Create(Id, kind, description, quantity, unitPrice, Currency);
         _lineItems.Add(line);
         RecalculateTotals();
         return line;
@@ -177,6 +177,8 @@ public sealed class Invoice : AggregateRoot<Guid>
 
     private void RecalculateTotals()
     {
-        SubtotalAmount = _lineItems.Sum(l => l.Amount);
+        SubtotalAmount = _lineItems.Aggregate(
+            Money.Zero(SubtotalAmount.Currency),
+            (acc, l) => acc.Add(l.Amount));
     }
 }

--- a/src/Modules/Billing/Modules.Billing/Domain/InvoiceLineItem.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/InvoiceLineItem.cs
@@ -16,7 +16,7 @@ public sealed class InvoiceLineItem : BaseEntity<Guid>
     public string Description { get; private set; } = default!;
     public decimal Quantity { get; private set; }
     public decimal UnitPrice { get; private set; }
-    public decimal Amount { get; private set; }
+    public Money Amount { get; private set; } = default!;
 
     private InvoiceLineItem() { }
 
@@ -25,9 +25,11 @@ public sealed class InvoiceLineItem : BaseEntity<Guid>
         InvoiceLineItemKind kind,
         string description,
         decimal quantity,
-        decimal unitPrice)
+        decimal unitPrice,
+        string currency)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        ArgumentException.ThrowIfNullOrWhiteSpace(currency);
         if (quantity < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(quantity), "Quantity cannot be negative.");
@@ -45,7 +47,7 @@ public sealed class InvoiceLineItem : BaseEntity<Guid>
             Description = description,
             Quantity = quantity,
             UnitPrice = unitPrice,
-            Amount = Math.Round(quantity * unitPrice, 2, MidpointRounding.AwayFromZero)
+            Amount = new Money(quantity * unitPrice, currency).Round(2)
         };
     }
 

--- a/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
@@ -8,8 +8,8 @@ public sealed class Wallet : AggregateRoot<Guid>
     private readonly List<WalletTransaction> _transactions = new();
 
     public string TenantId { get; private set; } = default!;
-    public string Currency { get; private set; } = "USD";
-    public decimal Balance { get; private set; }
+    public Money Balance { get; private set; } = default!;
+    public string Currency => Balance.Currency;
     public WalletStatus Status { get; private set; }
     public DateTime CreatedAtUtc { get; private set; }
     public DateTime? UpdatedAtUtc { get; private set; }
@@ -25,8 +25,7 @@ public sealed class Wallet : AggregateRoot<Guid>
         {
             Id = Guid.CreateVersion7(),
             TenantId = tenantId,
-            Currency = string.IsNullOrWhiteSpace(currency) ? "USD" : currency,
-            Balance = 0m,
+            Balance = Money.Zero(string.IsNullOrWhiteSpace(currency) ? "USD" : currency),
             Status = WalletStatus.Active,
             CreatedAtUtc = DateTime.UtcNow
         };
@@ -35,9 +34,10 @@ public sealed class Wallet : AggregateRoot<Guid>
     public WalletTransaction Credit(decimal amount, WalletTransactionKind kind, string description, string? referenceId)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount, 0m);
-        var tx = WalletTransaction.Create(Id, TenantId, amount, kind, description, referenceId);
+        var credit = new Money(amount, Balance.Currency);
+        var tx = WalletTransaction.Create(Id, TenantId, credit, kind, description, referenceId);
         _transactions.Add(tx);
-        Balance += amount;
+        Balance = Balance.Add(credit);
         UpdatedAtUtc = DateTime.UtcNow;
         return tx;
     }
@@ -45,11 +45,12 @@ public sealed class Wallet : AggregateRoot<Guid>
     public WalletTransaction Debit(decimal amount, WalletTransactionKind kind, string description, string? referenceId)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount, 0m);
-        if (amount > Balance)
+        if (amount > Balance.Amount)
             throw new InvalidOperationException("Insufficient wallet balance.");
-        var tx = WalletTransaction.Create(Id, TenantId, -amount, kind, description, referenceId);
+        var debit = new Money(amount, Balance.Currency);
+        var tx = WalletTransaction.Create(Id, TenantId, new Money(-amount, Balance.Currency), kind, description, referenceId);
         _transactions.Add(tx);
-        Balance -= amount;
+        Balance = Balance.Subtract(debit);
         UpdatedAtUtc = DateTime.UtcNow;
         return tx;
     }

--- a/src/Modules/Billing/Modules.Billing/Domain/WalletTransaction.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/WalletTransaction.cs
@@ -7,7 +7,7 @@ public sealed class WalletTransaction : BaseEntity<Guid>
 {
     public Guid WalletId { get; private set; }
     public string TenantId { get; private set; } = default!;
-    public decimal Amount { get; private set; }
+    public Money Amount { get; private set; } = default!;
     public WalletTransactionKind Kind { get; private set; }
     public string Description { get; private set; } = default!;
     public string? ReferenceId { get; private set; }
@@ -16,7 +16,7 @@ public sealed class WalletTransaction : BaseEntity<Guid>
     private WalletTransaction() { }
 
     internal static WalletTransaction Create(
-        Guid walletId, string tenantId, decimal amount,
+        Guid walletId, string tenantId, Money amount,
         WalletTransactionKind kind, string description, string? referenceId)
         => new()
         {

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/InvoiceMappings.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/InvoiceMappings.cs
@@ -12,7 +12,7 @@ internal static class InvoiceMappings
         invoice.PeriodYear,
         invoice.PeriodMonth,
         invoice.Currency,
-        invoice.SubtotalAmount,
+        invoice.SubtotalAmount.Amount,
         invoice.Status,
         invoice.CreatedAtUtc,
         invoice.IssuedAtUtc,
@@ -21,7 +21,7 @@ internal static class InvoiceMappings
         invoice.VoidedAtUtc,
         invoice.Notes,
         invoice.LineItems
-            .Select(l => new InvoiceLineItemDto(l.Id, l.Kind, l.Resource, l.Description, l.Quantity, l.UnitPrice, l.Amount))
+            .Select(l => new InvoiceLineItemDto(l.Id, l.Kind, l.Resource, l.Description, l.Quantity, l.UnitPrice, l.Amount.Amount))
             .ToList(),
         invoice.Purpose,
         invoice.PeriodStartUtc,

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlanTerm/GetPlanTermQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlanTerm/GetPlanTermQueryHandler.cs
@@ -26,7 +26,7 @@ public sealed class GetPlanTermQueryHandler(BillingDbContext dbContext)
             plan.Name,
             plan.Interval,
             plan.TermMonths,
-            plan.TermPrice,
+            plan.TermPrice.Amount,
             plan.Currency);
     }
 }

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlans/GetPlansQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlans/GetPlansQueryHandler.cs
@@ -21,7 +21,7 @@ public sealed class GetPlansQueryHandler(BillingDbContext dbContext)
 
         var plans = await plansQuery.OrderBy(p => p.Key).ToListAsync(cancellationToken).ConfigureAwait(false);
         return plans
-            .Select(p => new BillingPlanDto(p.Id, p.Key, p.Name, p.Currency, p.MonthlyBasePrice, p.OverageRates, p.IsActive, p.Interval, p.AnnualPrice))
+            .Select(p => new BillingPlanDto(p.Id, p.Key, p.Name, p.Currency, p.MonthlyBasePrice.Amount, p.OverageRates, p.IsActive, p.Interval, p.AnnualPrice?.Amount))
             .ToList();
     }
 }

--- a/src/Modules/Billing/Modules.Billing/Mappings/WalletMappings.cs
+++ b/src/Modules/Billing/Modules.Billing/Mappings/WalletMappings.cs
@@ -6,11 +6,11 @@ namespace FSH.Modules.Billing.Mappings;
 internal static class WalletMappings
 {
     public static WalletTransactionDto ToDto(this WalletTransaction t)
-        => new(t.Id, t.Amount, t.Kind.ToString(), t.Description, t.ReferenceId, t.CreatedAtUtc);
+        => new(t.Id, t.Amount.Amount, t.Kind.ToString(), t.Description, t.ReferenceId, t.CreatedAtUtc);
 
     public static WalletDto ToDto(this Wallet w, int recentCount = 10)
         => new(
-            w.Id, w.TenantId, w.Currency, w.Balance, w.Status.ToString(), w.CreatedAtUtc,
+            w.Id, w.TenantId, w.Currency, w.Balance.Amount, w.Status.ToString(), w.CreatedAtUtc,
             w.Transactions
                 .OrderByDescending(t => t.CreatedAtUtc)
                 .Take(recentCount)

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -109,7 +109,7 @@ public sealed class BillingService : IBillingService
         if (_logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation("[Billing] generated draft invoice {InvoiceNumber} for tenant {TenantId} period {Year}-{Month:00} total={Total} {Currency}",
-                invoice.InvoiceNumber, tenantId, periodYear, periodMonth, invoice.SubtotalAmount, invoice.Currency);
+                invoice.InvoiceNumber, tenantId, periodYear, periodMonth, invoice.SubtotalAmount.Amount, invoice.Currency);
         }
         return invoice;
     }
@@ -211,7 +211,7 @@ public sealed class BillingService : IBillingService
         {
             _logger.LogInformation(
                 "[Billing] issued top-up invoice {InvoiceNumber} for tenant {TenantId} amount={Amount} {Currency}",
-                invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount, invoice.Currency);
+                invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount.Amount, invoice.Currency);
         }
 
         await _eventBus.PublishAsync(new InvoiceIssuedIntegrationEvent(
@@ -222,7 +222,7 @@ public sealed class BillingService : IBillingService
             Source: "Billing",
             InvoiceId: invoice.Id,
             InvoiceNumber: invoice.InvoiceNumber,
-            Amount: invoice.SubtotalAmount,
+            Amount: invoice.SubtotalAmount.Amount,
             Currency: invoice.Currency,
             DueAtUtc: invoice.DueAtUtc,
             PeriodYear: invoice.PeriodYear,
@@ -257,7 +257,7 @@ public sealed class BillingService : IBillingService
                 }
 
                 wallet.Credit(
-                    invoice.SubtotalAmount,
+                    invoice.SubtotalAmount.Amount,
                     WalletTransactionKind.Topup,
                     "WhatsApp wallet top-up",
                     topupRequest.Id.ToString());
@@ -303,7 +303,7 @@ public sealed class BillingService : IBillingService
             ?? throw new NotFoundException($"Plan {planId} not found for tenant {tenantId}.");
 
         var termPrice = plan.TermPrice;
-        if (termPrice <= 0)
+        if (termPrice.Amount <= 0m)
         {
             // Free / trial plan — validity is still set, but there is nothing to bill.
             if (_logger.IsEnabled(LogLevel.Information))
@@ -332,7 +332,7 @@ public sealed class BillingService : IBillingService
             InvoiceLineItemKind.BaseFee,
             $"{plan.Name} — {plan.Interval} subscription ({periodStart:yyyy-MM-dd} to {periodEnd:yyyy-MM-dd})",
             1m,
-            termPrice);
+            termPrice.Amount);
         invoice.Issue();
 
         _db.Invoices.Add(invoice);
@@ -340,7 +340,7 @@ public sealed class BillingService : IBillingService
         if (_logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation("[Billing] issued subscription invoice {InvoiceNumber} for tenant {TenantId} total={Total} {Currency}",
-                invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount, invoice.Currency);
+                invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount.Amount, invoice.Currency);
         }
 
         // Notify (e.g. email the tenant) that a real bill was issued. Only fires for newly-created
@@ -353,7 +353,7 @@ public sealed class BillingService : IBillingService
             Source: "Billing",
             InvoiceId: invoice.Id,
             InvoiceNumber: invoice.InvoiceNumber,
-            Amount: invoice.SubtotalAmount,
+            Amount: invoice.SubtotalAmount.Amount,
             Currency: invoice.Currency,
             DueAtUtc: invoice.DueAtUtc,
             PeriodYear: invoice.PeriodYear,

--- a/src/Tests/Billing.Tests/Domain/BillingPlanTests.cs
+++ b/src/Tests/Billing.Tests/Domain/BillingPlanTests.cs
@@ -15,7 +15,7 @@ public sealed class BillingPlanTests
 
         plan.Interval.ShouldBe(PlanInterval.Monthly);
         plan.TermMonths.ShouldBe(1);
-        plan.TermPrice.ShouldBe(30m);
+        plan.TermPrice.Amount.ShouldBe(30m);
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public sealed class BillingPlanTests
 
         plan.Interval.ShouldBe(PlanInterval.Yearly);
         plan.TermMonths.ShouldBe(12);
-        plan.TermPrice.ShouldBe(300m);
+        plan.TermPrice.Amount.ShouldBe(300m);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public sealed class BillingPlanTests
     {
         var plan = BillingPlan.Create("pro-yr", "Pro Annual", "USD", 30m, interval: PlanInterval.Yearly);
 
-        plan.TermPrice.ShouldBe(360m);
+        plan.TermPrice.Amount.ShouldBe(360m);
     }
 
     [Fact]
@@ -51,8 +51,8 @@ public sealed class BillingPlanTests
         plan.Update("Pro", 30m, null, PlanInterval.Yearly, 300m);
 
         plan.Interval.ShouldBe(PlanInterval.Yearly);
-        plan.AnnualPrice.ShouldBe(300m);
-        plan.TermPrice.ShouldBe(300m);
+        plan.AnnualPrice!.Amount.ShouldBe(300m);
+        plan.TermPrice.Amount.ShouldBe(300m);
     }
 
     #endregion
@@ -68,7 +68,7 @@ public sealed class BillingPlanTests
         plan.Currency.ShouldBe("USD");
         plan.Name.ShouldBe("Pro Plan");
         plan.IsActive.ShouldBeTrue();
-        plan.MonthlyBasePrice.ShouldBe(49m);
+        plan.MonthlyBasePrice.Amount.ShouldBe(49m);
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public sealed class BillingPlanTests
         plan.Update("Pro Max", 99m, newRates);
 
         plan.Name.ShouldBe("Pro Max");
-        plan.MonthlyBasePrice.ShouldBe(99m);
+        plan.MonthlyBasePrice.Amount.ShouldBe(99m);
         plan.GetOverageRate(QuotaResource.ApiCalls).ShouldBe(0m);
         plan.GetOverageRate(QuotaResource.Users).ShouldBe(2m);
         plan.UpdatedAtUtc.ShouldNotBeNull();
@@ -184,7 +184,7 @@ public sealed class BillingPlanTests
     {
         var plan = BillingPlan.Create("free", "Free", "USD", 0m);
 
-        plan.MonthlyBasePrice.ShouldBe(0m);
+        plan.MonthlyBasePrice.Amount.ShouldBe(0m);
     }
 
     #endregion

--- a/src/Tests/Billing.Tests/Domain/InvoiceLineItemTests.cs
+++ b/src/Tests/Billing.Tests/Domain/InvoiceLineItemTests.cs
@@ -23,7 +23,7 @@ public sealed class InvoiceLineItemTests
 
         line.Quantity.ShouldBe(100m);
         line.UnitPrice.ShouldBe(0.02m);
-        line.Amount.ShouldBe(2.00m);
+        line.Amount.Amount.ShouldBe(2.00m);
         line.InvoiceId.ShouldBe(inv.Id);
         line.Kind.ShouldBe(InvoiceLineItemKind.Overage);
     }
@@ -35,7 +35,7 @@ public sealed class InvoiceLineItemTests
 
         var line = inv.AddLineItem(InvoiceLineItemKind.Adjustment, "credit", 0m, 0m);
 
-        line.Amount.ShouldBe(0m);
+        line.Amount.Amount.ShouldBe(0m);
     }
 
     #endregion

--- a/src/Tests/Billing.Tests/Domain/InvoiceTests.cs
+++ b/src/Tests/Billing.Tests/Domain/InvoiceTests.cs
@@ -58,7 +58,7 @@ public sealed class InvoiceTests
 
         inv.Status.ShouldBe(InvoiceStatus.Draft);
         inv.Currency.ShouldBe("USD");
-        inv.SubtotalAmount.ShouldBe(0m);
+        inv.SubtotalAmount.Amount.ShouldBe(0m);
         inv.LineItems.ShouldBeEmpty();
     }
 
@@ -71,7 +71,7 @@ public sealed class InvoiceTests
         inv.AddLineItem(InvoiceLineItemKind.Overage, "Overage", 2m, 10m);
 
         inv.LineItems.Count.ShouldBe(2);
-        inv.SubtotalAmount.ShouldBe(69m);
+        inv.SubtotalAmount.Amount.ShouldBe(69m);
     }
 
     [Fact]
@@ -252,8 +252,8 @@ public sealed class InvoiceTests
         // 0.005 * 1 = 0.005 -> rounds to 0.01 (away from zero), not banker's 0.00
         var line = inv.AddLineItem(InvoiceLineItemKind.Overage, "tiny", 1m, 0.005m);
 
-        line.Amount.ShouldBe(0.01m);
-        inv.SubtotalAmount.ShouldBe(0.01m);
+        line.Amount.Amount.ShouldBe(0.01m);
+        inv.SubtotalAmount.Amount.ShouldBe(0.01m);
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public sealed class InvoiceTests
         // 3 * 0.333 = 0.999 -> 1.00
         var line = inv.AddLineItem(InvoiceLineItemKind.Overage, "units", 3m, 0.333m);
 
-        line.Amount.ShouldBe(1.00m);
+        line.Amount.Amount.ShouldBe(1.00m);
     }
 
     #endregion

--- a/src/Tests/Billing.Tests/Domain/WalletTests.cs
+++ b/src/Tests/Billing.Tests/Domain/WalletTests.cs
@@ -13,7 +13,7 @@ public sealed class WalletTests
         var w = Wallet.Create("tenant-a", "USD");
         w.TenantId.ShouldBe("tenant-a");
         w.Currency.ShouldBe("USD");
-        w.Balance.ShouldBe(0m);
+        w.Balance.Amount.ShouldBe(0m);
         w.Status.ShouldBe(WalletStatus.Active);
         w.Id.ShouldNotBe(Guid.Empty);
     }
@@ -23,8 +23,8 @@ public sealed class WalletTests
     {
         var w = Wallet.Create("tenant-a", "USD");
         var tx = w.Credit(50m, WalletTransactionKind.Topup, "Top-up", "req-1");
-        w.Balance.ShouldBe(50m);
-        tx.Amount.ShouldBe(50m);
+        w.Balance.Amount.ShouldBe(50m);
+        tx.Amount.Amount.ShouldBe(50m);
         tx.WalletId.ShouldBe(w.Id);
         tx.TenantId.ShouldBe("tenant-a");
         tx.ReferenceId.ShouldBe("req-1");

--- a/src/Tests/Framework.Tests/Core/MoneyTests.cs
+++ b/src/Tests/Framework.Tests/Core/MoneyTests.cs
@@ -65,6 +65,74 @@ public sealed class MoneyTests
 
     #endregion
 
+    #region Arithmetic
+
+    [Fact]
+    public void Add_Should_SumAmounts_When_CurrenciesMatch()
+    {
+        var sum = new Money(10m, "USD").Add(new Money(2.50m, "usd"));
+
+        sum.Amount.ShouldBe(12.50m);
+        sum.Currency.ShouldBe("USD");
+    }
+
+    [Fact]
+    public void Subtract_Should_DiffAmounts_When_CurrenciesMatch()
+    {
+        var diff = new Money(10m, "USD").Subtract(new Money(2.50m, "USD"));
+
+        diff.Amount.ShouldBe(7.50m);
+    }
+
+    [Fact]
+    public void Subtract_Should_AllowNegativeResult_When_RightExceedsLeft()
+    {
+        var diff = new Money(2m, "USD").Subtract(new Money(5m, "USD"));
+
+        diff.Amount.ShouldBe(-3m);
+    }
+
+    [Fact]
+    public void Multiply_Should_ScaleAmountAndKeepCurrency()
+    {
+        var product = new Money(3m, "USD").Multiply(4m);
+
+        product.Amount.ShouldBe(12m);
+        product.Currency.ShouldBe("USD");
+    }
+
+    [Fact]
+    public void Round_Should_RoundAwayFromZero()
+    {
+        new Money(1.005m, "USD").Round(2).Amount.ShouldBe(1.01m);
+        new Money(-1.005m, "USD").Round(2).Amount.ShouldBe(-1.01m);
+    }
+
+    [Fact]
+    public void Add_Should_Throw_When_CurrenciesDiffer()
+    {
+        Should.Throw<InvalidOperationException>(() => new Money(1m, "USD").Add(new Money(1m, "EUR")));
+    }
+
+    [Fact]
+    public void Subtract_Should_Throw_When_CurrenciesDiffer()
+    {
+        Should.Throw<InvalidOperationException>(() => new Money(1m, "USD").Subtract(new Money(1m, "EUR")));
+    }
+
+    [Fact]
+    public void Operators_Should_MirrorNamedMethods()
+    {
+        var a = new Money(10m, "USD");
+        var b = new Money(4m, "USD");
+
+        (a + b).Amount.ShouldBe(14m);
+        (a - b).Amount.ShouldBe(6m);
+        (a * 2m).Amount.ShouldBe(20m);
+    }
+
+    #endregion
+
     #region Equality
 
     [Fact]

--- a/src/Tests/Integration.Tests/Tests/Billing/BillingDomainEdgeTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/BillingDomainEdgeTests.cs
@@ -202,10 +202,10 @@ public sealed class BillingDomainEdgeTests
         {
             var inv = await db.Invoices.AsNoTracking().Include(i => i.LineItems).FirstAsync(i => i.Id == invoiceId);
             var overage = inv.LineItems.Single(l => l.Kind == InvoiceLineItemKind.Overage);
-            overage.Amount.ShouldBe(0.03m, "2.5 * 0.01 = 0.025 must round AwayFromZero to 0.03");
+            overage.Amount.Amount.ShouldBe(0.03m, "2.5 * 0.01 = 0.025 must round AwayFromZero to 0.03");
 
             // Subtotal recomputes across all lines (BaseFee 10 + overage 0.03).
-            inv.SubtotalAmount.ShouldBe(10.03m, "AddLineItem must recompute SubtotalAmount over every line");
+            inv.SubtotalAmount.Amount.ShouldBe(10.03m, "AddLineItem must recompute SubtotalAmount over every line");
         });
     }
 

--- a/src/Tests/Integration.Tests/Tests/Billing/MonthlyInvoiceJobTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/MonthlyInvoiceJobTests.cs
@@ -57,7 +57,7 @@ public sealed class MonthlyInvoiceJobTests
         invoice.PeriodYear.ShouldBe(previous.Year);
         invoice.PeriodMonth.ShouldBe(previous.Month);
         invoice.Purpose.ShouldBe(InvoicePurpose.Usage, "the monthly job produces usage invoices");
-        invoice.SubtotalAmount.ShouldBe(0m,
+        invoice.SubtotalAmount.Amount.ShouldBe(0m,
             "usage invoices bill metered overage only — the base fee is billed on the subscription invoice on create/renew, and root has no overage");
     }
 

--- a/src/Tests/Integration.Tests/Tests/Billing/WalletTopupServiceTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/WalletTopupServiceTests.cs
@@ -65,7 +65,7 @@ public sealed class WalletTopupServiceTests
 
         // Assert: wallet balance equals the top-up amount.
         var wallet = await billing.GetOrCreateWalletAsync(tenantId, "USD");
-        wallet.Balance.ShouldBe(50m);
+        wallet.Balance.Amount.ShouldBe(50m);
 
         // Assert: request transitioned to Completed.
         var reloaded = await db.TopupRequests.FindAsync(request.Id);


### PR DESCRIPTION
## What

Follow-up to #1316. Promoting `Money` to `BuildingBlocks` left the Billing module modeling money two ways: `Money` on `TopupRequest`, but raw `decimal` + `Currency` on `Wallet`, `WalletTransaction`, `Invoice`, `InvoiceLineItem` and `BillingPlan`. As requested in the #1316 review ("land the follow-up promptly so the half-state stays short-lived"), this folds the remaining money-bearing fields into `Money` and reintroduces the `Money` arithmetic (`Add`/`Subtract`/`Multiply`/`Round` and the `+`/`-`/`*` operators) that was trimmed from #1316, now justified by real production callers:

| Method | Production caller |
|---|---|
| `Add` | `Wallet.Credit` balance, `Invoice.RecalculateTotals` subtotal over line items |
| `Subtract` | `Wallet.Debit` balance |
| `Multiply` | `BillingPlan.TermPrice` (annual fallback = monthly base * 12) |
| `Round` | `InvoiceLineItem` amount (`quantity * unitPrice`, away-from-zero) |

## Persistence

Aggregate-level amounts that already had a paired `Currency` column reuse it through `OwnsOne`, so those adoptions are pure no-op remaps with no schema change:

- `Wallet.Balance`
- `Invoice.SubtotalAmount`
- `BillingPlan.MonthlyBasePrice`

Sub-entity and optional amounts gain a per-row currency column, since a `Money` value object carries its own currency:

- `WalletTransaction.Currency` (new, NOT NULL)
- `InvoiceLineItem.AmountCurrency` (new, NOT NULL)
- `BillingPlan.AnnualPriceCurrency` (new, nullable, only set when `AnnualPrice` is present)

Migration `20260701063312_BillingMoneyValueObjectAdoption` adds the three columns as nullable, backfills each from the owning aggregate's currency (`WalletTransaction` from its `Wallet`, `InvoiceLineItem` from its `Invoice`, `BillingPlan.AnnualPriceCurrency` from the plan's own `Currency`), then enforces NOT NULL on the two required ones. Existing rows keep their aggregate's currency; no data loss.

## Contract impact

None. All contract DTOs stay `decimal` and are unwrapped at the mapping boundary (same pattern #1316 used for `TopupRequestDto`), so there is no API or frontend change.

## BuildingBlocks

The only `BuildingBlocks` change is reintroducing the `Money` arithmetic, which is exactly the reintroduction pre-approved in the #1316 review. `Money` stays dependency-free and passes the BuildingBlocks independence, immutability and layering architecture tests.

## Verification

- Build clean with `-warnaserror`, 0 errors.
- Unit: Framework 112, Billing 123, Catalog 65, Architecture 51.
- Integration: 730 passed, 1 skipped, 0 failed, against real PostgreSQL (Testcontainers).
- Backfill exercised on populated data in a throwaway PostgreSQL: rows seeded with distinct currencies (EUR wallet, GBP invoice, BRL plan) before the migration, all inherited the parent's currency correctly after it.
- `dotnet ef migrations has-pending-model-changes` reports no drift versus the snapshot.

## Heads-up (unrelated)

A fresh `dotnet restore` currently fails repo-wide on `NU1903` because the transitively resolved `Microsoft.OpenApi 2.0.0` (via `Microsoft.AspNetCore.OpenApi` / `Scalar.AspNetCore`) is flagged by advisory GHSA-v5pm-xwqc-g5wc, and `TreatWarningsAsErrors` promotes it to an error. This is pre-existing and independent of this PR (it affects `main` on any clean restore). Happy to send a separate PR bumping `Microsoft.OpenApi` to the patched `2.7.5` if useful.
