### PR TITLE
fix(deps): pin Microsoft.OpenApi to 2.7.5 to clear GHSA-v5pm-xwqc-g5wc

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -99,6 +99,10 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="UAParser" Version="3.1.47" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <!-- Pinned above the transitive 2.0.0 pulled by AspNetCore.OpenApi/Scalar to clear advisory
+         GHSA-v5pm-xwqc-g5wc (circular-schema stack overflow). Transitive pinning is enabled, so this
+         floors Microsoft.OpenApi everywhere it resolves. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
## What

`Microsoft.OpenApi 2.0.0` resolves transitively (via `Microsoft.AspNetCore.OpenApi 10.0.8` and `Scalar.AspNetCore 2.14.14`) and is flagged by advisory [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) / CVE-2026-49451: a circular schema reference can stack-overflow the parser and terminate the process (availability only, no RCE or data exposure).

Because the repo builds with `TreatWarningsAsErrors`, the `NU1903` audit warning is promoted to an error, so a fresh `dotnet restore` fails repo-wide on any clean checkout or CI runner. A cached restore does not re-audit, which is why existing local builds still pass.

## Fix

Central Package Transitive Pinning is already enabled in `Directory.Packages.props`, so a single `PackageVersion` entry floors `Microsoft.OpenApi` at the patched `2.7.5` everywhere it resolves. It stays on the same `2.x` major and is compatible with `Microsoft.AspNetCore.OpenApi 10.0.8`.

## Verification

Fresh `dotnet restore` plus full solution build clean with `-warnaserror`, 0 errors, `NU1903` gone. The full test suite runs in CI on this PR (local host-boot smoke was blocked by a Windows Application Control policy in the throwaway worktree, unrelated to the change).