### PR TITLE
chore(host): point default CORS allow-list at the React client origins

### DIFF
--- a/src/Host/FSH.Starter.Api/appsettings.json
+++ b/src/Host/FSH.Starter.Api/appsettings.json
@@ -97,8 +97,8 @@
   "CorsOptions": {
     "AllowAll": false,
     "AllowedOrigins": [
-      "https://localhost:4200",
-      "https://localhost:7140"
+      "http://localhost:5173",
+      "http://localhost:5174"
     ],
     "AllowedHeaders": [ "content-type", "authorization" ],
     "AllowedMethods": [ "GET", "POST", "PUT", "DELETE" ]


### PR DESCRIPTION
## What

`CorsOptions.AllowedOrigins` in `appsettings.json` listed `https://localhost:4200` (Angular's default dev port) and `https://localhost:7140`, neither of which any client in this repo uses.

The two front-ends the kit actually ships and runs (via the Aspire AppHost) are:

- `clients/admin` → `http://localhost:5173`
- `clients/dashboard` → `http://localhost:5174`

This replaces the stale entries with the real React dev origins so the default configuration matches the apps out of the box.

## Note

This touches the same `AllowedOrigins` block as #1323 (per-request front-end origin resolution), which adds `:5173`/`:5174` on top of the existing entries. Whichever merges first, the other will need a trivial rebase of this one array. Happy to sequence them however you prefer.