### PR TITLE
fix(billing): enforce currency match on wallet credit/debit

### DIFF
--- a/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
@@ -31,26 +31,27 @@ public sealed class Wallet : AggregateRoot<Guid>
         };
     }
 
-    public WalletTransaction Credit(decimal amount, WalletTransactionKind kind, string description, string? referenceId)
+    public WalletTransaction Credit(Money amount, WalletTransactionKind kind, string description, string? referenceId)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount, 0m);
-        var credit = new Money(amount, Balance.Currency);
-        var tx = WalletTransaction.Create(Id, TenantId, credit, kind, description, referenceId);
+        ArgumentNullException.ThrowIfNull(amount);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount.Amount, 0m);
+        var tx = WalletTransaction.Create(Id, TenantId, amount, kind, description, referenceId);
         _transactions.Add(tx);
-        Balance = Balance.Add(credit);
+        Balance = Balance.Add(amount);
         UpdatedAtUtc = DateTime.UtcNow;
         return tx;
     }
 
-    public WalletTransaction Debit(decimal amount, WalletTransactionKind kind, string description, string? referenceId)
+    public WalletTransaction Debit(Money amount, WalletTransactionKind kind, string description, string? referenceId)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount, 0m);
-        if (amount > Balance.Amount)
+        ArgumentNullException.ThrowIfNull(amount);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount.Amount, 0m);
+        var remaining = Balance.Subtract(amount);
+        if (remaining.Amount < 0m)
             throw new InvalidOperationException("Insufficient wallet balance.");
-        var debit = new Money(amount, Balance.Currency);
-        var tx = WalletTransaction.Create(Id, TenantId, new Money(-amount, Balance.Currency), kind, description, referenceId);
+        var tx = WalletTransaction.Create(Id, TenantId, amount with { Amount = -amount.Amount }, kind, description, referenceId);
         _transactions.Add(tx);
-        Balance = Balance.Subtract(debit);
+        Balance = remaining;
         UpdatedAtUtc = DateTime.UtcNow;
         return tx;
     }

--- a/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
+++ b/src/Modules/Billing/Modules.Billing/Domain/Wallet.cs
@@ -35,9 +35,13 @@ public sealed class Wallet : AggregateRoot<Guid>
     {
         ArgumentNullException.ThrowIfNull(amount);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(amount.Amount, 0m);
+        // Validate currency before touching the aggregate: Money.Add throws on a
+        // mismatch, so computing the new balance first keeps a rejected credit from
+        // leaving a phantom ledger row behind.
+        var newBalance = Balance.Add(amount);
         var tx = WalletTransaction.Create(Id, TenantId, amount, kind, description, referenceId);
         _transactions.Add(tx);
-        Balance = Balance.Add(amount);
+        Balance = newBalance;
         UpdatedAtUtc = DateTime.UtcNow;
         return tx;
     }
@@ -49,7 +53,7 @@ public sealed class Wallet : AggregateRoot<Guid>
         var remaining = Balance.Subtract(amount);
         if (remaining.Amount < 0m)
             throw new InvalidOperationException("Insufficient wallet balance.");
-        var tx = WalletTransaction.Create(Id, TenantId, amount with { Amount = -amount.Amount }, kind, description, referenceId);
+        var tx = WalletTransaction.Create(Id, TenantId, amount.Multiply(-1m), kind, description, referenceId);
         _transactions.Add(tx);
         Balance = remaining;
         UpdatedAtUtc = DateTime.UtcNow;

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -260,7 +260,7 @@ public sealed class BillingService : IBillingService
                 {
                     throw new CustomException(
                         $"Cannot credit a {invoice.Currency} top-up to a {wallet.Currency} wallet.",
-                        (IEnumerable<string>?)null,
+                        errors: null,
                         HttpStatusCode.Conflict);
                 }
 

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Eventing.Abstractions;
@@ -255,9 +256,16 @@ public sealed class BillingService : IBillingService
                     wallet = Wallet.Create(invoice.TenantId, invoice.Currency);
                     _db.Wallets.Add(wallet);
                 }
+                else if (!string.Equals(wallet.Currency, invoice.Currency, StringComparison.Ordinal))
+                {
+                    throw new CustomException(
+                        $"Cannot credit a {invoice.Currency} top-up to a {wallet.Currency} wallet.",
+                        (IEnumerable<string>?)null,
+                        HttpStatusCode.Conflict);
+                }
 
                 wallet.Credit(
-                    invoice.SubtotalAmount.Amount,
+                    invoice.SubtotalAmount,
                     WalletTransactionKind.Topup,
                     "WhatsApp wallet top-up",
                     topupRequest.Id.ToString());

--- a/src/Tests/Billing.Tests/Domain/WalletTests.cs
+++ b/src/Tests/Billing.Tests/Domain/WalletTests.cs
@@ -42,6 +42,22 @@ public sealed class WalletTests
         var w = Wallet.Create("tenant-a", "USD");
         Should.Throw<InvalidOperationException>(
             () => w.Credit(new Money(50m, "EUR"), WalletTransactionKind.Topup, "Top-up", null));
+        // The rejected credit must leave the aggregate untouched — no phantom
+        // ledger row, balance still zero.
+        w.Transactions.ShouldBeEmpty();
+        w.Balance.Amount.ShouldBe(0m);
+    }
+
+    [Fact]
+    public void Debit_rejects_currency_mismatch()
+    {
+        var w = Wallet.Create("tenant-a", "USD");
+        w.Credit(new Money(50m, "USD"), WalletTransactionKind.Topup, "Top-up", null);
+        Should.Throw<InvalidOperationException>(
+            () => w.Debit(new Money(10m, "EUR"), WalletTransactionKind.MessageCharge, "msg", null));
+        // Only the opening credit survives; the mismatched debit adds nothing.
+        w.Transactions.Count.ShouldBe(1);
+        w.Balance.Amount.ShouldBe(50m);
     }
 
     [Fact]

--- a/src/Tests/Billing.Tests/Domain/WalletTests.cs
+++ b/src/Tests/Billing.Tests/Domain/WalletTests.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Domain;
 using FSH.Modules.Billing.Contracts;
 using FSH.Modules.Billing.Domain;
 using Shouldly;
@@ -22,7 +23,7 @@ public sealed class WalletTests
     public void Credit_increases_balance_and_returns_ledger_row()
     {
         var w = Wallet.Create("tenant-a", "USD");
-        var tx = w.Credit(50m, WalletTransactionKind.Topup, "Top-up", "req-1");
+        var tx = w.Credit(new Money(50m, "USD"), WalletTransactionKind.Topup, "Top-up", "req-1");
         w.Balance.Amount.ShouldBe(50m);
         tx.Amount.Amount.ShouldBe(50m);
         tx.WalletId.ShouldBe(w.Id);
@@ -33,14 +34,22 @@ public sealed class WalletTests
     [Fact]
     public void Credit_rejects_non_positive_amount()
         => Should.Throw<ArgumentOutOfRangeException>(
-            () => Wallet.Create("t", "USD").Credit(0m, WalletTransactionKind.Topup, "x", null));
+            () => Wallet.Create("t", "USD").Credit(new Money(0m, "USD"), WalletTransactionKind.Topup, "x", null));
+
+    [Fact]
+    public void Credit_rejects_currency_mismatch()
+    {
+        var w = Wallet.Create("tenant-a", "USD");
+        Should.Throw<InvalidOperationException>(
+            () => w.Credit(new Money(50m, "EUR"), WalletTransactionKind.Topup, "Top-up", null));
+    }
 
     [Fact]
     public void Debit_beyond_balance_throws()
     {
         var w = Wallet.Create("tenant-a", "USD");
-        w.Credit(10m, WalletTransactionKind.Topup, "Top-up", null);
+        w.Credit(new Money(10m, "USD"), WalletTransactionKind.Topup, "Top-up", null);
         Should.Throw<InvalidOperationException>(
-            () => w.Debit(25m, WalletTransactionKind.MessageCharge, "msg", null));
+            () => w.Debit(new Money(25m, "USD"), WalletTransactionKind.MessageCharge, "msg", null));
     }
 }

--- a/src/Tests/Billing.Tests/Mappings/WalletMappingTests.cs
+++ b/src/Tests/Billing.Tests/Mappings/WalletMappingTests.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Domain;
 using FSH.Modules.Billing.Domain;
 using FSH.Modules.Billing.Mappings;
 using FSH.Modules.Billing.Contracts;
@@ -12,7 +13,7 @@ public sealed class WalletMappingTests
     public void Wallet_ToDto_emits_string_status_and_balance()
     {
         var w = Wallet.Create("tenant-a", "USD");
-        w.Credit(50m, WalletTransactionKind.Topup, "Top-up", "req-1");
+        w.Credit(new Money(50m, "USD"), WalletTransactionKind.Topup, "Top-up", "req-1");
         var dto = w.ToDto();
         dto.Balance.ShouldBe(50m);
         dto.Status.ShouldBe("Active");


### PR DESCRIPTION
## Problem

`Wallet.Credit` and `Wallet.Debit` took a raw `decimal` and stamped the wallet's **own** currency onto the resulting `Money`. `BillingService.MarkInvoicePaidAsync` credited a top-up by passing `invoice.SubtotalAmount.Amount`, dropping `invoice.Currency` on the way in.

The effect: a top-up invoice in one currency credited to a wallet in another currency was applied at **face value** with the wallet's currency label. For example, a 100 EUR invoice paid against a pre-existing USD wallet credited 100 USD. The `Money.Add`/`Money.Subtract` currency guard never fired, because by the time it ran both operands had already been forced to the wallet's currency.

This is latent while the product is single-currency (a freshly created wallet at line 255 inherits `invoice.Currency`, so it always matches). It becomes a real, silent balance error the moment a pre-existing wallet's currency diverges from a later invoice.

## Fix

Now that both sides are `Money` (following the recent Money value-object adoption in Billing):

- `Wallet.Credit`/`Wallet.Debit` take a `Money` instead of a `decimal` and route the balance through `Money.Add`/`Money.Subtract`, which throw on a currency mismatch. The hole closes at the domain boundary.
- `BillingService` passes `invoice.SubtotalAmount` through unchanged and guards the top-up credit: if a pre-existing wallet's currency differs from the invoice, it throws a `CustomException` with `HttpStatusCode.Conflict` and a clear message, so the mismatch surfaces as a meaningful error rather than a raw 500 bubbling out of `Money`.

## Testing

- `dotnet build` clean, 0 warnings (`TreatWarningsAsErrors`).
- Full `Billing.Tests` suite: 124 passed, 0 failed. Adds `Credit_rejects_currency_mismatch` as a regression guard for the closed hole; existing Wallet tests migrated to the `Money` signature.
- Integration tests (`WalletTopupServiceTests`) were not run in this environment (require Docker/Testcontainers); the change to the credit path is value-preserving on the happy path and the new guard only fires on a currency mismatch those tests do not set up.

## Notes

- `Wallet.Credit`/`Debit` signature changes `decimal` -> `Money`. `Wallet` is internal domain, so no public HTTP surface changes; no endpoint, config, or docs change is required. Flagging the signature change for reviewer awareness.
