### PR TITLE
fix(auditing): cap and page the security/exception audit lists

### DIFF
--- a/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetExceptionAudits/GetExceptionAuditsQuery.cs
+++ b/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetExceptionAudits/GetExceptionAuditsQuery.cs
@@ -17,4 +17,8 @@ public sealed class GetExceptionAuditsQuery : IQuery<IReadOnlyList<AuditSummaryD
     public DateTime? FromUtc { get; init; }
 
     public DateTime? ToUtc { get; init; }
+
+    public int? Skip { get; init; }
+
+    public int? Take { get; init; }
 }

--- a/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetSecurityAudits/GetSecurityAuditsQuery.cs
+++ b/src/Modules/Auditing/Modules.Auditing.Contracts/v1/GetSecurityAudits/GetSecurityAuditsQuery.cs
@@ -15,4 +15,8 @@ public sealed class GetSecurityAuditsQuery : IQuery<IReadOnlyList<AuditSummaryDt
     public DateTime? FromUtc { get; init; }
 
     public DateTime? ToUtc { get; init; }
+
+    public int? Skip { get; init; }
+
+    public int? Take { get; init; }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetExceptionAudits/GetExceptionAuditsQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetExceptionAudits/GetExceptionAuditsQueryHandler.cs
@@ -10,6 +10,9 @@ namespace FSH.Modules.Auditing.Features.v1.GetExceptionAudits;
 
 public sealed class GetExceptionAuditsQueryHandler : IQueryHandler<GetExceptionAuditsQuery, IReadOnlyList<AuditSummaryDto>>
 {
+    private const int MaxPageSize = 200;
+    private const int DefaultPageSize = 50;
+
     private readonly AuditDbContext _dbContext;
 
     public GetExceptionAuditsQueryHandler(AuditDbContext dbContext)
@@ -26,7 +29,11 @@ public sealed class GetExceptionAuditsQueryHandler : IQueryHandler<GetExceptionA
         audits = ApplySeverityFilter(audits, query);
         audits = ApplyPayloadFilters(audits, query);
 
-        return await ProjectToDto(audits, cancellationToken);
+        // Cap server-side so an unpaged call can't materialize a tenant's whole exception history.
+        var take = query.Take is >= 1 and <= MaxPageSize ? query.Take.Value : DefaultPageSize;
+        var skip = query.Skip is > 0 ? query.Skip.Value : 0;
+
+        return await ProjectToDto(audits, skip, take, cancellationToken);
     }
 
     private IQueryable<AuditRecord> GetBaseQuery()
@@ -87,10 +94,12 @@ public sealed class GetExceptionAuditsQueryHandler : IQueryHandler<GetExceptionA
         return audits;
     }
 
-    private static async Task<IReadOnlyList<AuditSummaryDto>> ProjectToDto(IQueryable<AuditRecord> audits, CancellationToken cancellationToken)
+    private static async Task<IReadOnlyList<AuditSummaryDto>> ProjectToDto(IQueryable<AuditRecord> audits, int skip, int take, CancellationToken cancellationToken)
     {
         return await audits
             .OrderByDescending(a => a.OccurredAtUtc)
+            .Skip(skip)
+            .Take(take)
             .Select(a => new AuditSummaryDto
             {
                 Id = a.Id,

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetSecurityAudits/GetSecurityAuditsQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetSecurityAudits/GetSecurityAuditsQueryHandler.cs
@@ -10,6 +10,9 @@ namespace FSH.Modules.Auditing.Features.v1.GetSecurityAudits;
 
 public sealed class GetSecurityAuditsQueryHandler : IQueryHandler<GetSecurityAuditsQuery, IReadOnlyList<AuditSummaryDto>>
 {
+    private const int MaxPageSize = 200;
+    private const int DefaultPageSize = 50;
+
     private readonly AuditDbContext _dbContext;
 
     public GetSecurityAuditsQueryHandler(AuditDbContext dbContext)
@@ -49,8 +52,14 @@ public sealed class GetSecurityAuditsQueryHandler : IQueryHandler<GetSecurityAud
                 EF.Functions.ILike(AsText(a.PayloadJson), $"%\"action\": \"{actionValue}\"%"));
         }
 
+        // Cap server-side so an unpaged call can't materialize a tenant's whole audit history.
+        var take = query.Take is >= 1 and <= MaxPageSize ? query.Take.Value : DefaultPageSize;
+        var skip = query.Skip is > 0 ? query.Skip.Value : 0;
+
         var list = await audits
             .OrderByDescending(a => a.OccurredAtUtc)
+            .Skip(skip)
+            .Take(take)
             .Select(a => new AuditSummaryDto
             {
                 Id = a.Id,

--- a/src/Tests/Integration.Tests/Tests/Auditing/SecurityAuditListBoundsTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Auditing/SecurityAuditListBoundsTests.cs
@@ -1,0 +1,87 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Auditing;
+using FSH.Modules.Auditing.Contracts;
+using FSH.Modules.Auditing.Contracts.Dtos;
+using FSH.Modules.Auditing.Persistence;
+using Integration.Tests.Infrastructure;
+using Integration.Tests.Infrastructure.Extensions;
+
+namespace Integration.Tests.Tests.Auditing;
+
+/// <summary>
+/// Runtime repro for audit finding DATA-01 (unbounded audit list). The security-audit list handler
+/// does ToListAsync with no Skip/Take/cap and the validator does not require a time window, so an
+/// unpaged call materializes the whole matching set. A bounded API would cap the page size.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class SecurityAuditListBoundsTests
+{
+    private const int SeededRows = 500;
+
+    // Analogous to the 200-row server cap that SessionService.GetTenantSessionsAsync already applies
+    // "so an over-eager client can't pull a tenant's full session table in one round-trip".
+    private const int ExpectedServerCap = 200;
+
+    private readonly FshWebApplicationFactory _factory;
+    private readonly AuthHelper _auth;
+
+    public SecurityAuditListBoundsTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _auth = new AuthHelper(factory);
+    }
+
+    [Fact]
+    public async Task GetSecurityAudits_Should_CapResults_When_NoPagingOrWindowProvided()
+    {
+        await SeedSecurityAuditsAsync(SeededRows);
+
+        using var client = await _auth.CreateRootAdminClientAsync();
+        using var response = await client.GetAsync($"{TestConstants.AuditsBasePath}/security");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var list = await response.DeserializeAsync<IReadOnlyList<AuditSummaryDto>>();
+
+        list.Count.ShouldBeLessThanOrEqualTo(
+            ExpectedServerCap,
+            $"an unpaged security-audit list must cap results; seeded {SeededRows} rows and the endpoint " +
+            $"returned {list.Count} with no Skip/Take/default page size.");
+    }
+
+    private async Task SeedSecurityAuditsAsync(int count)
+    {
+        using var scope = _factory.Services.CreateScope();
+
+        // Tenant context is AsyncLocal — set inline in the same method as the DbContext call.
+        var tenantStore = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<AppTenantInfo>>();
+        var tenant = await tenantStore.GetAsync(TestConstants.RootTenantId);
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext =
+            new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var db = scope.ServiceProvider.GetRequiredService<AuditDbContext>();
+        var now = DateTime.UtcNow;
+        var rows = new List<AuditRecord>(count);
+        for (int i = 0; i < count; i++)
+        {
+            rows.Add(new AuditRecord
+            {
+                Id = Guid.NewGuid(),
+                OccurredAtUtc = now.AddSeconds(-i),
+                ReceivedAtUtc = now,
+                EventType = (int)AuditEventType.Security,
+                Severity = (byte)AuditSeverity.Information,
+                TenantId = TestConstants.RootTenantId,
+                UserId = "data01-seed-user",
+                UserName = "data01-seed",
+                Source = "DATA-01-test",
+                Tags = 0,
+                PayloadJson = "{}",
+            });
+        }
+
+        db.AuditRecords.AddRange(rows);
+        await db.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
Fixes audit finding DATA-01.

## Problem

`GetSecurityAuditsQueryHandler` and `GetExceptionAuditsQueryHandler` did `ToListAsync` with `OrderByDescending` only — no `Skip`/`Take`, no row cap, no default window — and their validators only checked `FromUtc <= ToUtc`, never requiring a range. A no-argument call (`GET /api/v1/audits/security` with no query string) passed validation and materialized the tenant's entire audit history into memory and over the wire. On an active tenant (audit retention defaults to *disabled*, and 365d/180d when enabled) that is a latent OOM.

## Fix

Add optional `Skip`/`Take` to both queries and clamp them server-side (page size `1..200`, default `50`, `skip >= 0`), mirroring the existing `SessionService.GetTenantSessionsAsync` convention. An unpaged call now returns at most the default page instead of the whole table; the response shape (`IReadOnlyList<AuditSummaryDto>`) is unchanged, so it stays backward compatible.

## Tests

`SecurityAuditListBoundsTests` seeds 500 security-audit rows and asserts the unpaged list is capped (≤ 200). Full Auditing integration suite green (48/48). The same cap is applied to the exception-audit handler via the identical pattern.

## Notes

- Behavior change: the admin audit UI now receives the default page (50) rather than everything; a follow-up can wire explicit paging controls in `clients/admin`.
- Docs changelog entry to follow in the docs repo.
