### PR TITLE
fix(eventing): back off outbox retries and make dead-letters recoverable

### DIFF
--- a/src/BuildingBlocks/Eventing/EventingOptions.cs
+++ b/src/BuildingBlocks/Eventing/EventingOptions.cs
@@ -21,6 +21,17 @@ public sealed class EventingOptions
     public int OutboxMaxRetries { get; set; } = 5;
 
     /// <summary>
+    /// Base delay (seconds) for exponential retry backoff after a failed dispatch. The n-th retry
+    /// waits <c>base * 2^(n-1)</c>, capped at <see cref="OutboxRetryMaxDelaySeconds"/>.
+    /// </summary>
+    public int OutboxRetryBaseDelaySeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Upper bound (seconds) on the exponential retry backoff.
+    /// </summary>
+    public int OutboxRetryMaxDelaySeconds { get; set; } = 3600;
+
+    /// <summary>
     /// Whether inbox-based idempotent handling is enabled.
     /// </summary>
     public bool EnableInbox { get; set; } = true;

--- a/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Eventing.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace FSH.Framework.Eventing.Outbox;
 
@@ -15,17 +16,21 @@ public sealed class EfCoreOutboxStore<TDbContext> : IOutboxStore
     private readonly IEventSerializer _serializer;
     private readonly ILogger<EfCoreOutboxStore<TDbContext>> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly EventingOptions _options;
 
     public EfCoreOutboxStore(
         TDbContext dbContext,
         IEventSerializer serializer,
         ILogger<EfCoreOutboxStore<TDbContext>> logger,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IOptions<EventingOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         _dbContext = dbContext;
         _serializer = serializer;
         _logger = logger;
         _timeProvider = timeProvider;
+        _options = options.Value;
     }
 
     public async Task AddAsync(IIntegrationEvent @event, CancellationToken ct = default)
@@ -51,8 +56,9 @@ public sealed class EfCoreOutboxStore<TDbContext> : IOutboxStore
 
     public async Task<IReadOnlyList<OutboxMessage>> GetPendingBatchAsync(int batchSize, CancellationToken ct = default)
     {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
         return await _dbContext.Set<OutboxMessage>()
-            .Where(m => !m.IsDead && m.ProcessedOnUtc == null)
+            .Where(m => !m.IsDead && m.ProcessedOnUtc == null && (m.NextRetryAt == null || m.NextRetryAt <= now))
             .OrderBy(m => m.CreatedOnUtc)
             .Take(batchSize)
             .ToListAsync(ct)
@@ -75,11 +81,62 @@ public sealed class EfCoreOutboxStore<TDbContext> : IOutboxStore
         message.RetryCount++;
         message.LastError = error;
         message.IsDead = isDead;
+        // Space out retries with exponential backoff so a persistently failing message doesn't
+        // re-fire every dispatch cycle. A dead message won't be retried, so leave it eligible-null.
+        message.NextRetryAt = isDead ? null : _timeProvider.GetUtcNow().UtcDateTime.Add(BackoffFor(message.RetryCount));
         _dbContext.Set<OutboxMessage>().Update(message);
 
-        _logger.LogWarning("Outbox message {MessageId} failed. RetryCount={RetryCount}, IsDead={IsDead}, Error={Error}",
-            message.Id, message.RetryCount, message.IsDead, error);
-
         await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<OutboxMessage>> GetDeadLetteredAsync(int max, CancellationToken ct = default)
+    {
+        if (max <= 0) max = 100;
+        return await _dbContext.Set<OutboxMessage>()
+            .Where(m => m.IsDead)
+            .OrderBy(m => m.CreatedOnUtc)
+            .Take(max)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<int> RedriveDeadLettersAsync(IReadOnlyCollection<Guid>? ids, CancellationToken ct = default)
+    {
+        var query = _dbContext.Set<OutboxMessage>().Where(m => m.IsDead);
+        if (ids is { Count: > 0 })
+        {
+            query = query.Where(m => ids.Contains(m.Id));
+        }
+
+        var dead = await query.ToListAsync(ct).ConfigureAwait(false);
+        foreach (var message in dead)
+        {
+            message.IsDead = false;
+            message.RetryCount = 0;
+            message.LastError = null;
+            message.NextRetryAt = null;
+        }
+
+        if (dead.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+            Telemetry.EventingTelemetry.OutboxRedriven.Add(dead.Count);
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("Redrove {Count} dead-lettered outbox message(s) for another attempt.", dead.Count);
+            }
+        }
+
+        return dead.Count;
+    }
+
+    private TimeSpan BackoffFor(int retryCount)
+    {
+        var baseSeconds = _options.OutboxRetryBaseDelaySeconds > 0 ? _options.OutboxRetryBaseDelaySeconds : 30;
+        var maxSeconds = _options.OutboxRetryMaxDelaySeconds > 0 ? _options.OutboxRetryMaxDelaySeconds : 3600;
+        // retryCount is 1 after the first failure → first backoff is exactly baseSeconds.
+        var exponent = Math.Min(retryCount - 1, 30); // clamp so the shift can't overflow
+        var seconds = Math.Min((double)baseSeconds * Math.Pow(2, exponent), maxSeconds);
+        return TimeSpan.FromSeconds(seconds);
     }
 }

--- a/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
@@ -14,4 +14,14 @@ public interface IOutboxStore
     Task MarkAsProcessedAsync(OutboxMessage message, CancellationToken ct = default);
 
     Task MarkAsFailedAsync(OutboxMessage message, string error, bool isDead, CancellationToken ct = default);
+
+    /// <summary>Lists dead-lettered (exhausted) messages so an operator can inspect them.</summary>
+    Task<IReadOnlyList<OutboxMessage>> GetDeadLetteredAsync(int max, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resets dead-lettered messages for another dispatch attempt (clears the dead flag, retry
+    /// count, last error and backoff). Pass specific ids, or <c>null</c> to redrive them all.
+    /// Returns the number of messages redriven.
+    /// </summary>
+    Task<int> RedriveDeadLettersAsync(IReadOnlyCollection<Guid>? ids, CancellationToken ct = default);
 }

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcher.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcher.cs
@@ -1,4 +1,5 @@
 using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Eventing.Telemetry;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -80,6 +81,7 @@ public sealed partial class OutboxDispatcher
                 if (isDead)
                 {
                     deadLetterCount++;
+                    EventingTelemetry.OutboxDeadLettered.Add(1);
                 }
 
                 if (isDead)

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
@@ -33,6 +33,13 @@ public class OutboxMessage : IGlobalEntity
     public string? LastError { get; set; }
 
     public bool IsDead { get; set; }
+
+    /// <summary>
+    /// Earliest UTC time the message is eligible for another dispatch attempt. Set to a
+    /// backed-off future time after a failure so retries space out instead of re-firing every
+    /// dispatch cycle; <c>null</c> means immediately eligible (fresh message or after a redrive).
+    /// </summary>
+    public DateTime? NextRetryAt { get; set; }
 }
 
 public sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>

--- a/src/BuildingBlocks/Eventing/Telemetry/EventingTelemetry.cs
+++ b/src/BuildingBlocks/Eventing/Telemetry/EventingTelemetry.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Metrics;
+
+namespace FSH.Framework.Eventing.Telemetry;
+
+/// <summary>
+/// OpenTelemetry metrics for the eventing building block. Register with
+/// <c>metrics.AddMeter(EventingTelemetry.MeterName)</c> in the OTel setup.
+/// </summary>
+public static class EventingTelemetry
+{
+    /// <summary>Name of the <see cref="Meter"/> used for eventing metrics.</summary>
+    public const string MeterName = "FSH.Eventing";
+
+    internal static readonly Meter Meter = new(MeterName);
+
+    /// <summary>Outbox messages that exhausted their retries and were dead-lettered.</summary>
+    internal static readonly Counter<long> OutboxDeadLettered = Meter.CreateCounter<long>(
+        "fsh.eventing.outbox.deadlettered",
+        unit: "{message}",
+        description: "Number of outbox messages moved to dead-letter after exhausting retries.");
+
+    /// <summary>Dead-lettered outbox messages reset for another dispatch attempt.</summary>
+    internal static readonly Counter<long> OutboxRedriven = Meter.CreateCounter<long>(
+        "fsh.eventing.outbox.redriven",
+        unit: "{message}",
+        description: "Number of dead-lettered outbox messages redriven for another attempt.");
+}

--- a/src/BuildingBlocks/Web/Observability/OpenTelemetry/Extensions.cs
+++ b/src/BuildingBlocks/Web/Observability/OpenTelemetry/Extensions.cs
@@ -105,6 +105,10 @@ public static class Extensions
                 // Auditing pipeline metrics (published, dropped, flush, dead-letter).
                 metrics.AddMeter("FSH.Modules.Auditing");
 
+                // Eventing outbox metrics (dead-letter, redrive) — string literal matches
+                // EventingTelemetry.MeterName; Web does not reference the Eventing project.
+                metrics.AddMeter("FSH.Eventing");
+
                 foreach (var meterName in options.Metrics.MeterNames ?? Array.Empty<string>())
                 {
                     metrics.AddMeter(meterName);

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260711220711_OutboxNextRetryAt.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260711220711_OutboxNextRetryAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Identity
 {
     [DbContext(typeof(IdentityDbContext))]
-    partial class IdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711220711_OutboxNextRetryAt")]
+    partial class OutboxNextRetryAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260711220711_OutboxNextRetryAt.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260711220711_OutboxNextRetryAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Identity
+{
+    /// <inheritdoc />
+    public partial class OutboxNextRetryAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextRetryAt",
+                schema: "identity",
+                table: "OutboxMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NextRetryAt",
+                schema: "identity",
+                table: "OutboxMessages");
+        }
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Eventing/OutboxRetryTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Eventing/OutboxRetryTests.cs
@@ -1,0 +1,94 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Outbox;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Identity.Data;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Eventing;
+
+/// <summary>
+/// Covers audit finding REL-02: a failed outbox message was retried every dispatch cycle with no
+/// backoff, then dead-lettered with no way to recover it. Exercises the real
+/// <see cref="EfCoreOutboxStore{TDbContext}"/> (Identity owns the OutboxMessages set) over Postgres.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class OutboxRetryTests
+{
+    private readonly FshWebApplicationFactory _factory;
+
+    public OutboxRetryTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task MarkAsFailed_NotDead_Should_BackOff_And_ExcludeFromPendingUntilDue()
+    {
+        using var scope = await CreateTenantScopeAsync();
+        var db = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var message = NewMessage();
+        db.Set<OutboxMessage>().Add(message);
+        await db.SaveChangesAsync();
+
+        await store.MarkAsFailedAsync(message, "transient boom", isDead: false);
+
+        message.NextRetryAt.ShouldNotBeNull("a non-dead failure must schedule a backed-off retry");
+        message.NextRetryAt!.Value.ShouldBeGreaterThan(
+            DateTime.UtcNow.AddSeconds(20),
+            "the first retry backs off by the base delay (30s), not the next 10s cycle");
+
+        var pending = await store.GetPendingBatchAsync(500);
+        pending.ShouldNotContain(
+            m => m.Id == message.Id,
+            "a message whose NextRetryAt is in the future must be excluded from the dispatch batch");
+    }
+
+    [Fact]
+    public async Task RedriveDeadLetters_Should_ResetDeadMessage_And_MakeItPendingAgain()
+    {
+        using var scope = await CreateTenantScopeAsync();
+        var db = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var message = NewMessage();
+        message.IsDead = true;
+        message.RetryCount = 5;
+        message.LastError = "exhausted";
+        db.Set<OutboxMessage>().Add(message);
+        await db.SaveChangesAsync();
+
+        var redriven = await store.RedriveDeadLettersAsync([message.Id]);
+
+        redriven.ShouldBe(1);
+        (await store.GetDeadLetteredAsync(500)).ShouldNotContain(m => m.Id == message.Id);
+        (await store.GetPendingBatchAsync(500)).ShouldContain(
+            m => m.Id == message.Id,
+            "a redriven message clears IsDead/RetryCount/NextRetryAt and becomes eligible again");
+    }
+
+    private static OutboxMessage NewMessage() => new()
+    {
+        Id = Guid.NewGuid(),
+        // Old timestamp so it sorts first in the CreatedOnUtc-ascending pending batch.
+        CreatedOnUtc = DateTime.UtcNow.AddDays(-1),
+        Type = "REL-02.OutboxRetryTest",
+        Payload = "{}",
+        TenantId = TestConstants.RootTenantId,
+        RetryCount = 0,
+        IsDead = false,
+    };
+
+    private async Task<IServiceScope> CreateTenantScopeAsync()
+    {
+        var scope = _factory.Services.CreateScope();
+        var tenant = await scope.ServiceProvider
+            .GetRequiredService<IMultiTenantStore<AppTenantInfo>>()
+            .GetAsync(TestConstants.RootTenantId);
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+        return scope;
+    }
+}


### PR DESCRIPTION
Fixes audit finding REL-02.

## Problem

A failing outbox message was retried on **every** dispatch cycle (~10s) with no backoff, hit `IsDead` after 5 attempts in ~50s, and was then **lost**: `IsDead` appears only in the store/entity/migrations — there was no replay path and no metric, only a log line. So a persistently failing integration event hammered the bus for ~50s and then silently vanished.

## Fix

- **Backoff** — new `NextRetryAt` column with exponential backoff (`base * 2^(n-1)`, default base 30s, cap 1h; both configurable via `EventingOptions`). `GetPendingBatchAsync` skips messages whose `NextRetryAt` is still in the future, so retries space out instead of re-firing each cycle.
- **Recovery** — `IOutboxStore.GetDeadLetteredAsync` lists dead-lettered messages and `RedriveDeadLettersAsync(ids?)` resets them (clears `IsDead`/`RetryCount`/`LastError`/`NextRetryAt`) for another attempt.
- **Observability** — a new OpenTelemetry meter `FSH.Eventing` with `fsh.eventing.outbox.deadlettered` and `fsh.eventing.outbox.redriven` counters, registered in the OTel setup, so dead-lettering is alertable rather than only visible via the existing `Error` log.

## Migration

Additive only: a nullable `NextRetryAt` column on `OutboxMessages` (Identity schema — the sole outbox-backed context). No drops, expand-safe.

## Tests

`OutboxRetryTests` (Testcontainers, real Postgres via the Identity store): a non-dead failure schedules a future `NextRetryAt` and is excluded from the pending batch; a redrive resets a dead-lettered message and makes it pending again. Full Integration suite green (732 passed).

## Follow-up

Redrive is exposed as a store API; wiring an admin endpoint or `fsh` CLI verb to trigger it operationally is a small follow-up. Docs changelog entry to follow.
