### PR TITLE
fix(deploy): fail fast when the image push fails in deploy.ps1 (#1339)

### DIFF
--- a/deploy/terraform/apps/starter/deploy.ps1
+++ b/deploy/terraform/apps/starter/deploy.ps1
@@ -97,6 +97,10 @@ if ($BuildApi) {
     -p:ContainerRegistry="$registryHost" `
     -p:ContainerRepository="$apiRepo" `
     -p:ContainerImageTags="$ImageTag"
+  # Native exes don't trip $ErrorActionPreference — check $LASTEXITCODE, else a
+  # denied/failed push (e.g. a fork with no write access to $Registry) falls
+  # through and only surfaces later as an ECS CannotPullContainerError.
+  if ($LASTEXITCODE -ne 0) { Die "API image build/push failed (exit $LASTEXITCODE) — check you're logged in to '$registryHost' and have push access to '$apiRepo' (a fork can't push to ghcr.io/fullstackhero; pass -Registry <your-registry> or -ImageTag <a-published-tag>)." }
   Write-Host "==> Building & pushing migrator image $registryHost/$migratorRepo`:$ImageTag"
   dotnet publish "$RepoRoot/src/Host/FSH.Starter.DbMigrator/FSH.Starter.DbMigrator.csproj" `
     -c Release -r linux-x64 `
@@ -104,6 +108,7 @@ if ($BuildApi) {
     -p:ContainerRegistry="$registryHost" `
     -p:ContainerRepository="$migratorRepo" `
     -p:ContainerImageTags="$ImageTag"
+  if ($LASTEXITCODE -ne 0) { Die "migrator image build/push failed (exit $LASTEXITCODE) — check you're logged in to '$registryHost' and have push access to '$migratorRepo' (a fork can't push to ghcr.io/fullstackhero; pass -Registry <your-registry> or -ImageTag <a-published-tag>)." }
   $tfImageArgs = @('-var', "container_registry=$Registry", '-var', "api_image_name=$ApiImageName", '-var', "migrator_image_name=$MigratorImageName", '-var', "container_image_tag=$ImageTag")
 }
 elseif ($ImageTag) {


### PR DESCRIPTION
## Problem

Reported in #1339: an AWS deploy failed with

```
CannotPullContainerError: ... ghcr.io/fullstackhero/fsh-db-migrator:488a56ef6051: not found
```

Root cause is in `deploy.ps1`, not the infra. The two `dotnet publish /t:PublishContainer` pushes had **no `$LASTEXITCODE` guard**, unlike every `terraform`/`aws` call in the same script. Because `$ErrorActionPreference='Stop'` does **not** trip on native-executable exit codes (the exact gotcha the author already documents at the terraform step), a denied or failed push fell through to `terraform apply` + the migrator run. Terraform was handed a `container_image_tag` (the local git short-SHA `488a56ef6051`) that had never been published — because the reporter was deploying a **fork** against the default `ghcr.io/fullstackhero` registry they can't push to — so ECS surfaced it minutes later as a cryptic `CannotPullContainerError`.

## Fix

Add an exit-code guard after each `dotnet publish` push, matching the existing pattern used after `terraform init/apply` and `run-task`. The message names the cause and the two unblock paths:

```powershell
if ($LASTEXITCODE -ne 0) { Die "API image build/push failed (exit $LASTEXITCODE) — check you're logged in to '$registryHost' and have push access to '$apiRepo' (a fork can't push to ghcr.io/fullstackhero; pass -Registry <your-registry> or -ImageTag <a-published-tag>)." }
```

Now a failed push stops the deploy immediately with an actionable error, instead of an opaque ECS pull failure later.

`deploy.sh` needs no change — `set -euo pipefail` already aborts on a failed push.

## Testing

- Script parses clean (`PSParser::Tokenize`, no errors).
- Verified no other unguarded `dotnet publish` calls remain in `deploy.ps1`.

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)