### PR TITLE
feat(eventing): per-tenant dispatch, row leases, real atomicity, outbox-only publishing (#1349)

### DIFF
--- a/.agents/rules/eventing.md
+++ b/.agents/rules/eventing.md
@@ -9,19 +9,39 @@ Read before publishing/handling cross-module events. `src/BuildingBlocks/Eventin
 
 ## The Outbox is the only way to publish
 
-**Do not call `IEventBus` directly from a handler.** Publish via the outbox so it commits in the same transaction and survives crashes:
+**Do not call `IEventBus` directly from a handler.** Publish via the outbox so the event commits with the business write and survives a crash:
 
 ```csharp
-await _outboxStore.AddAsync(integrationEvent, ct).ConfigureAwait(false);
+await _outbox.AddAsync(integrationEvent, ct).ConfigureAwait(false);   // IOutboxWriter
 ```
 
-`EfCoreOutboxStore.AddAsync` serializes + `SaveChanges` immediately. `OutboxDispatcherHostedService` polls every `OutboxDispatchIntervalSeconds` (default 10), `OutboxDispatcher` pulls a batch (`OutboxBatchSize`, default 100), publishes via `IEventBus`, and dead-letters after `OutboxMaxRetries` (default 5) → `IsDead`. `OutboxMessage`/`InboxMessage` are `IGlobalEntity` (no tenant filter — the dispatcher has no tenant context; `TenantId` is an explicit column).
+Inject **`IOutboxWriter`** (`FSH.Framework.Eventing.Abstractions`) — the publish-side contract, and all a module ever needs. `IOutboxStore` is the full dispatcher-side surface and lives in the eventing runtime, which modules don't reference.
+
+`EfCoreOutboxStore.AddAsync` serializes + `SaveChanges` immediately, joining the caller's transaction when there is one. `OutboxDispatcherHostedService` polls every `OutboxDispatchIntervalSeconds` (default 10), `OutboxDispatcher` **claims** a batch (`OutboxBatchSize`, default 100), publishes via `IEventBus`, and dead-letters after `OutboxMaxRetries` (default 5) → `IsDead`. Failures back off exponentially (`NextRetryAt`); `RedriveDeadLettersAsync` recovers dead rows. `OutboxMessage`/`InboxMessage` are `IGlobalEntity` (no tenant filter — the dispatcher has no tenant context; `TenantId` is an explicit column).
+
+**Publishing is asynchronous.** The consumer runs on the next dispatch cycle, not inside the request. Don't write a caller — or a test — that assumes the side effect already happened. Integration tests drain explicitly via `OutboxDrain.DrainAsync`.
+
+**The one documented exception:** Chat `SendMessageCommandHandler` still publishes mentions on the bus, because the Notifications handler pushes over SignalR and a delayed mention badge reads as broken. Adding a second exception needs the same kind of reason, in a comment at the call site.
 
 ## One store, owned by the framework
 
 `OutboxMessages`/`InboxMessages` live in schema `framework`, owned by `EventingDbContext` (`src/BuildingBlocks/Eventing/Persistence/`) — **not** by any module's context. That is what keeps `IOutboxStore`/`IInboxStore` to a single, non-keyed DI registration: registering them per module DbContext made .NET DI resolve whichever module registered last for the whole application, so a second module publishing broke every module's outbox (issue #1349). `EventingRegistrationTests` guards the registration count; don't add a second one.
 
 `EventingDbContext` derives from `BaseDbContext`, so a tenant with a dedicated database gets its outbox rows in that database, next to the business data they accompany.
+
+## Dispatch across tenant databases
+
+Because rows follow the tenant connection, the dispatcher can't just poll one database. Each cycle it asks `IEventingDrainTargetProvider` for the drain targets and runs one pass per target inside `IEventingDrainScope`, which installs the tenant context **before** the scope's `EventingDbContext` is built (it captures `TenantInfo`, and with it the connection string, at construction).
+
+Defaults in BuildingBlocks are single-database (`SingleDatabaseDrainTargetProvider`, `NullEventingDrainScope`); the multitenancy module replaces them with `TenantStoreDrainTargetProvider` (default DB + one target per distinct **active** per-tenant connection string; tenants sharing a database collapse to one target) and `FinbuckleEventingDrainScope`. One unreachable tenant database is logged and skipped, not fatal to the cycle.
+
+## Multi-instance safety
+
+`ClaimBatchAsync` leases rows with `FOR UPDATE SKIP LOCKED` in a single `UPDATE … RETURNING`, so several API instances partition a batch instead of all publishing the same message. `ClaimedUntilUtc` is an expiry (`OutboxClaimLeaseSeconds`, default 300), so a dispatcher that dies mid-batch has its rows recovered rather than stranded — raise it if a batch can take longer than the lease, or a second instance re-claims rows still in flight. Completing or failing a message releases the lease. Non-Postgres providers have no portable `SKIP LOCKED`: they fall back to an unclaimed read and log a warning that only one instance is safe.
+
+## Atomicity
+
+`IScopedDbConnectionProvider` gives every DbContext in a DI scope the same `DbConnection`, which is the only way EF Core can enlist a second context in a transaction another one opened (Npgsql has no distributed-transaction promotion). `AmbientDbTransactionRegistry` — an `IDbTransactionInterceptor` on every Hero context — records open transactions, since `DbConnection` can't be asked. `AddAsync` joins the ambient transaction when there is one, so the outbox row commits or rolls back with the business data; with none, it commits on its own exactly as before.
 
 ## Idempotency is free (in-memory bus)
 
@@ -41,7 +61,7 @@ A **module** only registers its handlers:
 services.AddIntegrationEventHandlers(typeof(MyModule).Assembly);        // scans IIntegrationEventHandler<>
 ```
 
-There is no per-module store registration — `AddEventingForDbContext<T>` was removed in #1349. A module publishes by injecting `IOutboxStore`; nothing else is needed.
+There is no per-module store registration — `AddEventingForDbContext<T>` was removed in #1349. A module publishes by injecting `IOutboxWriter`; nothing else is needed.
 
 Bus = `EventingOptions.Provider`: `"RabbitMQ"` → `RabbitMqEventBus` (durable topic exchange); else `InMemoryEventBus` (default).
 
@@ -49,5 +69,6 @@ Bus = `EventingOptions.Provider`: `"RabbitMQ"` → `RabbitMqEventBus` (durable t
 
 - **Renaming/moving an integration event type breaks deserialization** — the outbox stores the assembly-qualified type name; `Type.GetType()` returns null → the message dead-letters. Keep event type names/namespaces stable, or migrate dead rows.
 - **Background handlers carry no HTTP/tenant context.** An open-generic or background handler that reads a tenant-filtered DbContext must restore Finbuckle context first via `IMultiTenantContextSetter` (see `WebhookFanoutHandler`, `modules/webhooks.md`).
-- In-memory bus runs handlers **synchronously in the publisher's scope** — keep handler work minimal; exceptions surface to the originating request (relevant for Notifications consuming Chat events).
+- In-memory bus runs handlers **synchronously in the publisher's scope** — keep handler work minimal; exceptions surface to the originating request (relevant for Notifications consuming Chat events). Via the outbox that scope is the dispatcher's, not the request's.
 - Set `UseHostedServiceDispatcher=false` to drive the outbox via Hangfire instead of the hosted service.
+- A background publisher must set the tenant context **before** `AddAsync` — otherwise, with per-tenant databases, the row lands in the wrong one (see `TenantExpiryScanJob`).

--- a/.agents/skills/add-integration-event/SKILL.md
+++ b/.agents/skills/add-integration-event/SKILL.md
@@ -30,10 +30,10 @@ public sealed record {Event}IntegrationEvent(
 
 ## Step 2 — Publish via the Outbox (source handler)
 
-The source module must have eventing wired (`add-module` Step 1): `AddEventingCore` + `AddEventingForDbContext<{Source}DbContext>`. Inject `IOutboxStore` and add the event in the same unit of work:
+Publishing needs **no module registration** — the outbox is framework-owned and the host wires it once. Inject `IOutboxWriter` (from `FSH.Framework.Eventing.Abstractions`) and add the event in the same unit of work:
 
 ```csharp
-public sealed class Do{Thing}CommandHandler({Source}DbContext db, IOutboxStore outbox)
+public sealed class Do{Thing}CommandHandler({Source}DbContext db, IOutboxWriter outbox)
     : ICommandHandler<Do{Thing}Command, Unit>
 {
     public async ValueTask<Unit> Handle(Do{Thing}Command command, CancellationToken cancellationToken)
@@ -81,14 +81,14 @@ builder.Services.AddIntegrationEventHandlers(typeof({Consumer}Module).Assembly);
 ## Gotchas
 
 - **Idempotency is free** with the in-memory bus (the Inbox dedups by `{eventId, handlerName}`) — don't hand-roll it.
-- The in-memory bus runs handlers **synchronously in the publisher's scope** — keep the handler lean; a throw surfaces to the originating request.
+- The in-memory bus runs handlers **synchronously in the publisher's scope** — keep the handler lean; a throw surfaces to the originating request. Published via the outbox, that scope belongs to the dispatcher, so the consumer runs on the next cycle and its failures never reach the caller. Don't let a caller (or a test) assume the side effect already happened; integration tests drain with `OutboxDrain.DrainAsync`.
 - If the handler reads a **tenant-filtered** DbContext from a background path (open-generic handler, Hangfire job), restore Finbuckle context first via `IMultiTenantContextSetter` (see `WebhookFanoutHandler`).
 - **Module load order:** the consumer must load before the publisher if it must react (`Order` in `[assembly: FshModule]`) — e.g. Notifications (750) before Chat (800).
 
 ## Checklist
 
 - [ ] Event in source Contracts, implements `IIntegrationEvent`, stable type name
-- [ ] Source module has `AddEventingCore` + `AddEventingForDbContext<T>`; published via `IOutboxStore.AddAsync` (not the bus)
+- [ ] Published via `IOutboxWriter.AddAsync` (not the bus); no per-module eventing registration needed
 - [ ] Consumer handler `sealed : IIntegrationEventHandler<T>`; `AddIntegrationEventHandlers(assembly)` registered
 - [ ] Background readers restore tenant context; module `Order` lets the consumer load first
 - [ ] Build + tests green

--- a/.agents/skills/add-module/SKILL.md
+++ b/.agents/skills/add-module/SKILL.md
@@ -39,10 +39,12 @@ public sealed class {Name}Module : IModule
         builder.Services.AddHeroDbContext<{Name}DbContext>();
         builder.Services.AddScoped<IDbInitializer, {Name}DbInitializer>();
 
-        // Only if the module publishes/handles integration events:
-        // builder.Services.AddEventingCore(builder.Configuration);
-        // builder.Services.AddEventingForDbContext<{Name}DbContext>();
+        // Only if the module HANDLES integration events:
         // builder.Services.AddIntegrationEventHandlers(typeof({Name}Module).Assembly);
+        //
+        // Publishing needs no registration at all — the outbox is framework-owned
+        // (host calls AddEventingCore once). Inject IOutboxWriter and publish.
+        // Never register a per-module outbox store; see .agents/rules/eventing.md.
 
         builder.Services.AddHealthChecks()
             .AddDbContextCheck<{Name}DbContext>(name: "db:{name}");

--- a/.agents/workflows/code-reviewer.md
+++ b/.agents/workflows/code-reviewer.md
@@ -33,7 +33,7 @@ playbook is the review procedure, not a second copy of the rules.
 **Cross-cutting**
 - **Structured logging only** — no `$"..."` interpolation in log calls.
 - `CancellationToken` propagated into EF/IO calls.
-- Cross-module events go via the Outbox (`IOutboxStore.AddAsync`), not a direct bus publish.
+- Cross-module events go via the Outbox (`IOutboxWriter.AddAsync`), not a direct bus publish. The only sanctioned exception is Chat mentions, which carries its reason in a comment.
 
 **Frontend** (`frontend/*` rules)
 - Hand-written types + `apiFetch`; mutation data passed via `mutate(arg)`; query keys hierarchical; admin gates routes with `RouteGuard` + mirrors the permission; dashboard uses `withSuspense`.

--- a/src/BuildingBlocks/Eventing.Abstractions/EventingDrainTarget.cs
+++ b/src/BuildingBlocks/Eventing.Abstractions/EventingDrainTarget.cs
@@ -1,0 +1,13 @@
+namespace FSH.Framework.Eventing.Abstractions;
+
+/// <summary>
+/// One database the outbox dispatcher must drain.
+///
+/// A null <paramref name="ConnectionString"/> means the default configured database, which holds
+/// the outbox for every tenant that does not have a dedicated one. Tenants sharing the default
+/// database need no separate target: outbox rows are <c>IGlobalEntity</c>, so a single pass over
+/// that database sees all of them regardless of which tenant wrote them.
+/// </summary>
+/// <param name="TenantId">Tenant whose context is installed while draining, or null for the default pass.</param>
+/// <param name="ConnectionString">Dedicated connection string, or null for the default.</param>
+public sealed record EventingDrainTarget(string? TenantId, string? ConnectionString);

--- a/src/BuildingBlocks/Eventing.Abstractions/IEventingDrainScope.cs
+++ b/src/BuildingBlocks/Eventing.Abstractions/IEventingDrainScope.cs
@@ -1,0 +1,15 @@
+namespace FSH.Framework.Eventing.Abstractions;
+
+/// <summary>
+/// Installs the ambient tenant context — including the dedicated connection string — for the
+/// duration of one drain pass, so an <c>EventingDbContext</c> resolved inside that scope targets
+/// the right database.
+///
+/// Distinct from <see cref="IEventTenantScope"/>, which sets tenant identity only and is
+/// deliberately connection-string-agnostic: that one runs when dispatching an event to handlers,
+/// this one runs when choosing which database to read the outbox from.
+/// </summary>
+public interface IEventingDrainScope
+{
+    IDisposable Begin(EventingDrainTarget target);
+}

--- a/src/BuildingBlocks/Eventing.Abstractions/IEventingDrainTargetProvider.cs
+++ b/src/BuildingBlocks/Eventing.Abstractions/IEventingDrainTargetProvider.cs
@@ -1,0 +1,14 @@
+namespace FSH.Framework.Eventing.Abstractions;
+
+/// <summary>
+/// Enumerates the distinct databases holding outbox rows.
+///
+/// The framework default returns a single target (the configured connection). The multitenancy
+/// module replaces it with one that also returns each distinct active per-tenant connection
+/// string — without it, a tenant with a dedicated database writes outbox rows the dispatcher
+/// never looks at.
+/// </summary>
+public interface IEventingDrainTargetProvider
+{
+    Task<IReadOnlyList<EventingDrainTarget>> GetTargetsAsync(CancellationToken ct = default);
+}

--- a/src/BuildingBlocks/Eventing.Abstractions/IOutboxWriter.cs
+++ b/src/BuildingBlocks/Eventing.Abstractions/IOutboxWriter.cs
@@ -1,0 +1,18 @@
+namespace FSH.Framework.Eventing.Abstractions;
+
+/// <summary>
+/// The publish side of the transactional outbox — all a module ever needs.
+///
+/// Deliberately separate from the full store: draining is expressed in terms of the persisted
+/// message entity and belongs to the eventing runtime, while publishing is just "record this
+/// event". Keeping the writer here means a module depends on the eventing abstractions only,
+/// exactly as it did when it published straight to <see cref="IEventBus"/>.
+///
+/// Prefer this over <see cref="IEventBus"/> in module code: the row commits with the caller's
+/// transaction and survives a crash, where a direct publish does neither.
+/// </summary>
+public interface IOutboxWriter
+{
+    /// <summary>Records an integration event for durable, at-least-once delivery.</summary>
+    Task AddAsync(IIntegrationEvent @event, CancellationToken ct = default);
+}

--- a/src/BuildingBlocks/Eventing/AssemblyInfo.cs
+++ b/src/BuildingBlocks/Eventing/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Framework.Tests")]

--- a/src/BuildingBlocks/Eventing/EventingOptions.cs
+++ b/src/BuildingBlocks/Eventing/EventingOptions.cs
@@ -32,6 +32,13 @@ public sealed class EventingOptions
     public int OutboxRetryMaxDelaySeconds { get; set; } = 3600;
 
     /// <summary>
+    /// Seconds a claimed outbox row stays leased to one dispatcher. Must exceed the worst-case
+    /// time to publish a batch, or a second instance re-claims rows still in flight and
+    /// double-publishes them.
+    /// </summary>
+    public int OutboxClaimLeaseSeconds { get; set; } = 300;
+
+    /// <summary>
     /// Whether inbox-based idempotent handling is enabled.
     /// </summary>
     public bool EnableInbox { get; set; } = true;

--- a/src/BuildingBlocks/Eventing/NullEventingDrainScope.cs
+++ b/src/BuildingBlocks/Eventing/NullEventingDrainScope.cs
@@ -1,0 +1,22 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Framework.Eventing;
+
+/// <summary>
+/// No-op drain scope used when no multitenancy composition is wired: there is only the default
+/// database, so nothing needs installing before a drain pass.
+/// </summary>
+public sealed class NullEventingDrainScope : IEventingDrainScope
+{
+    private static readonly IDisposable Noop = new NoopScope();
+
+    public IDisposable Begin(EventingDrainTarget target) => Noop;
+
+    private sealed class NoopScope : IDisposable
+    {
+        public void Dispose()
+        {
+            // Nothing to restore — the ambient context was never touched.
+        }
+    }
+}

--- a/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
@@ -1,6 +1,8 @@
 using FSH.Framework.Eventing.Abstractions;
 using FSH.Framework.Eventing.Persistence;
+using FSH.Framework.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -20,13 +22,15 @@ public sealed partial class EfCoreOutboxStore : IOutboxStore
     private readonly ILogger<EfCoreOutboxStore> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly EventingOptions _options;
+    private readonly AmbientDbTransactionRegistry _ambientTransactions;
 
     public EfCoreOutboxStore(
         EventingDbContext dbContext,
         IEventSerializer serializer,
         ILogger<EfCoreOutboxStore> logger,
         TimeProvider timeProvider,
-        IOptions<EventingOptions> options)
+        IOptions<EventingOptions> options,
+        AmbientDbTransactionRegistry ambientTransactions)
     {
         ArgumentNullException.ThrowIfNull(options);
         _dbContext = dbContext;
@@ -34,11 +38,14 @@ public sealed partial class EfCoreOutboxStore : IOutboxStore
         _logger = logger;
         _timeProvider = timeProvider;
         _options = options.Value;
+        _ambientTransactions = ambientTransactions;
     }
 
     public async Task AddAsync(IIntegrationEvent @event, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(@event);
+
+        await EnlistInAmbientTransactionAsync(ct).ConfigureAwait(false);
 
         var payload = _serializer.Serialize(@event);
         var message = new OutboxMessage
@@ -175,6 +182,40 @@ public sealed partial class EfCoreOutboxStore : IOutboxStore
         }
 
         return dead.Count;
+    }
+
+    /// <summary>
+    /// Joins the caller's transaction when there is one, so the outbox row commits or rolls back
+    /// with the business data it accompanies. Without this the row is its own transaction and a
+    /// crash between the two writes either loses the event or publishes one for work that was
+    /// rolled back.
+    ///
+    /// Only possible because every context in the scope shares one DbConnection
+    /// (<see cref="IScopedDbConnectionProvider"/>) — EF Core cannot enlist a context in a
+    /// transaction opened on a different connection. With no ambient transaction this is a no-op
+    /// and the write behaves exactly as before.
+    /// </summary>
+    private async Task EnlistInAmbientTransactionAsync(CancellationToken ct)
+    {
+        var ambient = _ambientTransactions.Find(_dbContext.Database.GetDbConnection());
+        var current = _dbContext.Database.CurrentTransaction;
+
+        if (ambient is null)
+        {
+            // The transaction we previously joined has since completed; drop the stale handle so
+            // this write opens its own transaction instead of failing on a disposed one.
+            if (current is not null)
+            {
+                await _dbContext.Database.UseTransactionAsync(null, ct).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        if (!ReferenceEquals(current?.GetDbTransaction(), ambient))
+        {
+            await _dbContext.Database.UseTransactionAsync(ambient, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/EfCoreOutboxStore.cs
@@ -13,7 +13,7 @@ namespace FSH.Framework.Eventing.Outbox;
 /// <c>IOutboxStore</c> registration per module, and .NET DI resolved the last
 /// one registered for the entire application (issue #1349).
 /// </summary>
-public sealed class EfCoreOutboxStore : IOutboxStore
+public sealed partial class EfCoreOutboxStore : IOutboxStore
 {
     private readonly EventingDbContext _dbContext;
     private readonly IEventSerializer _serializer;
@@ -57,13 +57,54 @@ public sealed class EfCoreOutboxStore : IOutboxStore
         await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<OutboxMessage>> GetPendingBatchAsync(int batchSize, CancellationToken ct = default)
+    public async Task<IReadOnlyList<OutboxMessage>> ClaimBatchAsync(
+        int batchSize,
+        string claimedBy,
+        TimeSpan lease,
+        CancellationToken ct = default)
     {
         var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var until = now.Add(lease);
+
+        if (!_dbContext.Database.IsNpgsql())
+        {
+            // No portable SKIP LOCKED outside Postgres. Fall back to an unclaimed read, which is
+            // safe only while a single dispatcher instance runs.
+            LogClaimUnsupported(_dbContext.Database.ProviderName);
+            return await _dbContext.Set<OutboxMessage>()
+                .Where(m => !m.IsDead
+                    && m.ProcessedOnUtc == null
+                    && (m.NextRetryAt == null || m.NextRetryAt <= now))
+                .OrderBy(m => m.CreatedOnUtc)
+                .Take(batchSize)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+        }
+
+        // The inner SELECT ... FOR UPDATE SKIP LOCKED picks rows no other transaction holds and
+        // the outer UPDATE stamps the lease on exactly those, in one statement. Two dispatchers
+        // racing therefore partition the batch instead of both publishing the same message.
+        // The schema name is a compile-time constant; every runtime value is parameterised.
+        var sql = $$"""
+            UPDATE "{{EventingConstants.SchemaName}}"."OutboxMessages" AS o
+            SET "ClaimedUntilUtc" = {1}, "ClaimedBy" = {2}
+            FROM (
+                SELECT "Id"
+                FROM "{{EventingConstants.SchemaName}}"."OutboxMessages"
+                WHERE "IsDead" = FALSE
+                  AND "ProcessedOnUtc" IS NULL
+                  AND ("NextRetryAt" IS NULL OR "NextRetryAt" <= {0})
+                  AND ("ClaimedUntilUtc" IS NULL OR "ClaimedUntilUtc" < {0})
+                ORDER BY "CreatedOnUtc"
+                LIMIT {3}
+                FOR UPDATE SKIP LOCKED
+            ) AS c
+            WHERE o."Id" = c."Id"
+            RETURNING o.*
+            """;
+
         return await _dbContext.Set<OutboxMessage>()
-            .Where(m => !m.IsDead && m.ProcessedOnUtc == null && (m.NextRetryAt == null || m.NextRetryAt <= now))
-            .OrderBy(m => m.CreatedOnUtc)
-            .Take(batchSize)
+            .FromSqlRaw(sql, now, until, claimedBy, batchSize)
             .ToListAsync(ct)
             .ConfigureAwait(false);
     }
@@ -73,6 +114,7 @@ public sealed class EfCoreOutboxStore : IOutboxStore
         ArgumentNullException.ThrowIfNull(message);
 
         message.ProcessedOnUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        ReleaseClaim(message);
         _dbContext.Set<OutboxMessage>().Update(message);
         await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -87,6 +129,7 @@ public sealed class EfCoreOutboxStore : IOutboxStore
         // Space out retries with exponential backoff so a persistently failing message doesn't
         // re-fire every dispatch cycle. A dead message won't be retried, so leave it eligible-null.
         message.NextRetryAt = isDead ? null : _timeProvider.GetUtcNow().UtcDateTime.Add(BackoffFor(message.RetryCount));
+        ReleaseClaim(message);
         _dbContext.Set<OutboxMessage>().Update(message);
 
         await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
@@ -118,6 +161,7 @@ public sealed class EfCoreOutboxStore : IOutboxStore
             message.RetryCount = 0;
             message.LastError = null;
             message.NextRetryAt = null;
+            ReleaseClaim(message);
         }
 
         if (dead.Count > 0)
@@ -132,6 +176,21 @@ public sealed class EfCoreOutboxStore : IOutboxStore
 
         return dead.Count;
     }
+
+    /// <summary>
+    /// Drops the lease once a message reaches a terminal state for this attempt. Leaving a stale
+    /// lease on a retryable row would keep it invisible to every dispatcher until it expired.
+    /// </summary>
+    private static void ReleaseClaim(OutboxMessage message)
+    {
+        message.ClaimedUntilUtc = null;
+        message.ClaimedBy = null;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Provider {Provider} does not support SKIP LOCKED; outbox claiming is disabled. Run a single dispatcher instance.")]
+    private partial void LogClaimUnsupported(string? provider);
 
     private TimeSpan BackoffFor(int retryCount)
     {

--- a/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
@@ -9,7 +9,20 @@ public interface IOutboxStore
 {
     Task AddAsync(IIntegrationEvent @event, CancellationToken ct = default);
 
-    Task<IReadOnlyList<OutboxMessage>> GetPendingBatchAsync(int batchSize, CancellationToken ct = default);
+    /// <summary>
+    /// Atomically leases up to <paramref name="batchSize"/> pending messages to this dispatcher
+    /// and returns them. Rows already leased by another instance are skipped rather than waited
+    /// on, so instances never block each other and never both publish the same message.
+    /// </summary>
+    /// <param name="batchSize">Maximum number of messages to claim.</param>
+    /// <param name="claimedBy">Diagnostic identifier of the claiming dispatcher instance.</param>
+    /// <param name="lease">How long the claim holds before another instance may re-claim.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<OutboxMessage>> ClaimBatchAsync(
+        int batchSize,
+        string claimedBy,
+        TimeSpan lease,
+        CancellationToken ct = default);
 
     Task MarkAsProcessedAsync(OutboxMessage message, CancellationToken ct = default);
 

--- a/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/IOutboxStore.cs
@@ -3,12 +3,11 @@ using FSH.Framework.Eventing.Abstractions;
 namespace FSH.Framework.Eventing.Outbox;
 
 /// <summary>
-/// Abstraction for persisting and reading outbox messages.
+/// Abstraction for persisting and reading outbox messages. Modules only ever need the publish
+/// side (<see cref="IOutboxWriter"/>); the rest of this surface belongs to the dispatcher.
 /// </summary>
-public interface IOutboxStore
+public interface IOutboxStore : IOutboxWriter
 {
-    Task AddAsync(IIntegrationEvent @event, CancellationToken ct = default);
-
     /// <summary>
     /// Atomically leases up to <paramref name="batchSize"/> pending messages to this dispatcher
     /// and returns them. Rows already leased by another instance are skipped rather than waited

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcher.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcher.cs
@@ -11,6 +11,13 @@ namespace FSH.Framework.Eventing.Outbox;
 /// </summary>
 public sealed partial class OutboxDispatcher
 {
+    /// <summary>
+    /// Identifies this process in the lease it takes on a row. Diagnostic only — correctness comes
+    /// from SKIP LOCKED, not from the identifier being unique.
+    /// </summary>
+    private static readonly string InstanceId =
+        $"{Environment.MachineName}:{Environment.ProcessId}";
+
     private readonly IOutboxStore _outbox;
     private readonly IEventBus _bus;
     private readonly IEventSerializer _serializer;
@@ -38,7 +45,8 @@ public sealed partial class OutboxDispatcher
         var batchSize = _options.OutboxBatchSize;
         if (batchSize <= 0) batchSize = 100;
 
-        var messages = await _outbox.GetPendingBatchAsync(batchSize, ct).ConfigureAwait(false);
+        var lease = TimeSpan.FromSeconds(_options.OutboxClaimLeaseSeconds > 0 ? _options.OutboxClaimLeaseSeconds : 300);
+        var messages = await _outbox.ClaimBatchAsync(batchSize, InstanceId, lease, ct).ConfigureAwait(false);
         if (messages.Count == 0)
         {
             _logger.LogDebug("No outbox messages to dispatch.");

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxDispatcherHostedService.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Eventing.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -63,13 +64,49 @@ public sealed partial class OutboxDispatcherHostedService : BackgroundService
         _logger.LogInformation("Outbox dispatcher hosted service stopped");
     }
 
-    private async Task DispatchOutboxAsync(CancellationToken ct)
+    /// <summary>
+    /// Drains one cycle: every database that can hold outbox rows, not just the default one.
+    /// A tenant with a dedicated connection string writes its rows into its own database, so a
+    /// single-database poll leaves them undispatched forever.
+    /// </summary>
+    /// <remarks>Internal rather than private so the per-cycle behaviour is testable without timing.</remarks>
+    internal async Task DispatchOutboxAsync(CancellationToken ct)
     {
-        using var scope = _scopeFactory.CreateScope();
-        var dispatcher = scope.ServiceProvider.GetRequiredService<OutboxDispatcher>();
-        await dispatcher.DispatchAsync(ct).ConfigureAwait(false);
+        // Resolved per cycle: tenants — and therefore databases — can be added at runtime.
+        using var providerScope = _scopeFactory.CreateScope();
+        var targetProvider = providerScope.ServiceProvider.GetRequiredService<IEventingDrainTargetProvider>();
+        var drainScope = providerScope.ServiceProvider.GetRequiredService<IEventingDrainScope>();
+
+        var targets = await targetProvider.GetTargetsAsync(ct).ConfigureAwait(false);
+
+        foreach (var target in targets)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                // The tenant context must be installed BEFORE the scope's EventingDbContext is
+                // constructed — BaseDbContext captures TenantInfo, and with it the connection
+                // string, at construction time.
+                using (drainScope.Begin(target))
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var dispatcher = scope.ServiceProvider.GetRequiredService<OutboxDispatcher>();
+                    await dispatcher.DispatchAsync(ct).ConfigureAwait(false);
+                }
+            }
+            // Broad catch is intentional: one unreachable tenant database must not stop the
+            // others from draining this cycle.
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                LogDrainFailed(ex, target.TenantId ?? "(default)");
+            }
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Outbox dispatcher hosted service started. Dispatch interval: {Interval}s")]
     private partial void LogServiceStarted(double interval);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to drain the outbox for tenant {TenantId}")]
+    private partial void LogDrainFailed(Exception exception, string tenantId);
 }

--- a/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
+++ b/src/BuildingBlocks/Eventing/Outbox/OutboxMessage.cs
@@ -40,6 +40,16 @@ public class OutboxMessage : IGlobalEntity
     /// dispatch cycle; <c>null</c> means immediately eligible (fresh message or after a redrive).
     /// </summary>
     public DateTime? NextRetryAt { get; set; }
+
+    /// <summary>
+    /// Lease expiry. A dispatcher claims a row by stamping this into the future; another instance
+    /// may re-claim only once it has passed, so a crashed dispatcher's rows are recovered rather
+    /// than stranded. <c>null</c> means unclaimed.
+    /// </summary>
+    public DateTime? ClaimedUntilUtc { get; set; }
+
+    /// <summary>Identifier of the dispatcher instance holding the lease. Diagnostic only.</summary>
+    public string? ClaimedBy { get; set; }
 }
 
 public sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>
@@ -74,5 +84,14 @@ public sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<Outbox
 
         builder.Property(o => o.CreatedOnUtc)
             .IsRequired();
+
+        builder.Property(o => o.ClaimedBy)
+            .HasMaxLength(128);
+
+        // Covers the claim scan: eligible rows are filtered on IsDead/ProcessedOnUtc/ClaimedUntilUtc
+        // and ordered by CreatedOnUtc. Without it the claim degrades to a sequential scan under a
+        // row lock, which is exactly where contention hurts most.
+        builder.HasIndex(o => new { o.IsDead, o.ProcessedOnUtc, o.ClaimedUntilUtc, o.CreatedOnUtc })
+            .HasDatabaseName("IX_OutboxMessages_Pending");
     }
 }

--- a/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
@@ -65,6 +65,10 @@ public static class ServiceCollectionExtensions
         services.AddHeroDbContext<EventingDbContext>();
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IDbInitializer, EventingDbInitializer>());
         services.TryAddScoped<IOutboxStore, EfCoreOutboxStore>();
+
+        // Modules inject the publish-side contract from Eventing.Abstractions and stay off the
+        // eventing runtime; it is the same instance as the store.
+        services.TryAddScoped<IOutboxWriter>(sp => sp.GetRequiredService<IOutboxStore>());
         services.TryAddScoped<IInboxStore, EfCoreInboxStore>();
         services.TryAddScoped<OutboxDispatcher>();
 

--- a/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/Eventing/ServiceCollectionExtensions.cs
@@ -33,6 +33,11 @@ public static class ServiceCollectionExtensions
         // so background publishers establish the tenant before tenant-filtered handler DbContexts build.
         services.TryAddSingleton<IEventTenantScope, NullEventTenantScope>();
 
+        // Which databases the dispatcher drains. Defaults to the configured connection only;
+        // the multitenancy module replaces both so per-tenant databases are drained too.
+        services.TryAddSingleton<IEventingDrainTargetProvider, SingleDatabaseDrainTargetProvider>();
+        services.TryAddSingleton<IEventingDrainScope, NullEventingDrainScope>();
+
         // Register event bus based on configured provider
         var options = configuration.GetSection(nameof(EventingOptions)).Get<EventingOptions>() ?? new EventingOptions();
 

--- a/src/BuildingBlocks/Eventing/SingleDatabaseDrainTargetProvider.cs
+++ b/src/BuildingBlocks/Eventing/SingleDatabaseDrainTargetProvider.cs
@@ -1,0 +1,16 @@
+using FSH.Framework.Eventing.Abstractions;
+
+namespace FSH.Framework.Eventing;
+
+/// <summary>
+/// Default provider for single-database deployments: one pass over the configured connection.
+/// The multitenancy module replaces this when per-tenant databases are in play.
+/// </summary>
+public sealed class SingleDatabaseDrainTargetProvider : IEventingDrainTargetProvider
+{
+    private static readonly IReadOnlyList<EventingDrainTarget> DefaultOnly =
+        [new EventingDrainTarget(null, null)];
+
+    public Task<IReadOnlyList<EventingDrainTarget>> GetTargetsAsync(CancellationToken ct = default)
+        => Task.FromResult(DefaultOnly);
+}

--- a/src/BuildingBlocks/Persistence/AmbientDbTransactionRegistry.cs
+++ b/src/BuildingBlocks/Persistence/AmbientDbTransactionRegistry.cs
@@ -1,0 +1,55 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace FSH.Framework.Persistence;
+
+/// <summary>
+/// Tracks the open transaction on each connection in the current DI scope.
+///
+/// <see cref="DbConnection"/> exposes no way to ask "is a transaction open on you?", so a context
+/// that wants to join another context's transaction has no way to find it. This interceptor is
+/// attached to every Hero DbContext and records transactions as they start and end, which is what
+/// lets the outbox write enlist in the business transaction instead of committing separately.
+/// </summary>
+public sealed class AmbientDbTransactionRegistry : IDbTransactionInterceptor
+{
+    private readonly Dictionary<DbConnection, DbTransaction> _open = [];
+
+    /// <summary>
+    /// The transaction currently open on <paramref name="connection"/>, or null when there is
+    /// none — in which case a write simply commits on its own, as it always has.
+    /// </summary>
+    public DbTransaction? Find(DbConnection connection)
+        => connection is not null && _open.TryGetValue(connection, out var transaction) ? transaction : null;
+
+    public void TransactionStarted(DbConnection connection, TransactionEndEventData eventData)
+        => Track(connection, eventData?.Transaction);
+
+    public void TransactionUsed(DbConnection connection, TransactionEventData eventData)
+        => Track(connection, eventData?.Transaction);
+
+    public void TransactionCommitted(DbTransaction transaction, TransactionEndEventData eventData)
+        => Forget(transaction);
+
+    public void TransactionRolledBack(DbTransaction transaction, TransactionEndEventData eventData)
+        => Forget(transaction);
+
+    public void TransactionFailed(DbTransaction transaction, TransactionErrorEventData eventData)
+        => Forget(transaction);
+
+    private void Track(DbConnection connection, DbTransaction? transaction)
+    {
+        if (connection is not null && transaction is not null)
+        {
+            _open[connection] = transaction;
+        }
+    }
+
+    private void Forget(DbTransaction? transaction)
+    {
+        if (transaction?.Connection is not null)
+        {
+            _open.Remove(transaction.Connection);
+        }
+    }
+}

--- a/src/BuildingBlocks/Persistence/Context/BaseDbContext.cs
+++ b/src/BuildingBlocks/Persistence/Context/BaseDbContext.cs
@@ -4,6 +4,8 @@ using FSH.Framework.Core.Domain;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Framework.Shared.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -48,14 +50,37 @@ public class BaseDbContext(IMultiTenantContextAccessor<AppTenantInfo> multiTenan
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);
 
-        if (!string.IsNullOrWhiteSpace(multiTenantContextAccessor?.MultiTenantContext.TenantInfo?.ConnectionString))
+        var tenantConnectionString = multiTenantContextAccessor?.MultiTenantContext.TenantInfo?.ConnectionString;
+        if (string.IsNullOrWhiteSpace(tenantConnectionString))
+        {
+            return;
+        }
+
+        // Route the tenant connection through the scope's connection provider too. Opening a
+        // private connection here would defeat the sharing that lets an outbox write join the
+        // business transaction — a tenant-database context would be the one case that silently
+        // lost atomicity. Falls back to the connection string when no provider is available
+        // (hand-constructed contexts in tests, design-time tooling).
+        var connectionProvider = optionsBuilder.Options
+            .FindExtension<CoreOptionsExtension>()?
+            .ApplicationServiceProvider?
+            .GetService<IScopedDbConnectionProvider>();
+
+        if (connectionProvider is null)
         {
             optionsBuilder.ConfigureHeroDatabase(
                 _settings.Provider,
-                multiTenantContextAccessor.MultiTenantContext.TenantInfo.ConnectionString!,
+                tenantConnectionString,
                 _settings.MigrationsAssembly,
                 environment.IsDevelopment());
+            return;
         }
+
+        optionsBuilder.ConfigureHeroDatabase(
+            _settings.Provider,
+            connectionProvider.GetConnection(_settings.Provider, tenantConnectionString),
+            _settings.MigrationsAssembly,
+            environment.IsDevelopment());
     }
 
     /// <summary>

--- a/src/BuildingBlocks/Persistence/IScopedDbConnectionProvider.cs
+++ b/src/BuildingBlocks/Persistence/IScopedDbConnectionProvider.cs
@@ -1,0 +1,21 @@
+using System.Data.Common;
+
+namespace FSH.Framework.Persistence;
+
+/// <summary>
+/// One <see cref="DbConnection"/> per connection string per DI scope, shared by every DbContext in
+/// that scope.
+///
+/// Required for cross-context transactions: EF Core can enlist a second context in an existing
+/// transaction only when both contexts use the same connection instance, and Npgsql has no
+/// distributed-transaction promotion to fall back on. Without this, the outbox write is always a
+/// separate transaction from the business write it is supposed to accompany.
+/// </summary>
+public interface IScopedDbConnectionProvider
+{
+    /// <summary>
+    /// Returns the scope's connection for <paramref name="connectionString"/>, creating it on
+    /// first use. The connection is owned by the scope, not by any DbContext.
+    /// </summary>
+    DbConnection GetConnection(string dbProvider, string connectionString);
+}

--- a/src/BuildingBlocks/Persistence/OptionsBuilderExtensions.cs
+++ b/src/BuildingBlocks/Persistence/OptionsBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using FSH.Framework.Shared.Persistence;
+﻿using System.Data.Common;
+using FSH.Framework.Shared.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -30,8 +31,7 @@ public static class OptionsBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNullOrWhiteSpace(dbProvider);
 
-        builder.ConfigureWarnings(warnings =>
-            warnings.Log(RelationalEventId.PendingModelChangesWarning));
+        ConfigureCommon(builder, isDevelopment);
 
         switch (dbProvider.ToUpperInvariant())
         {
@@ -55,12 +55,65 @@ public static class OptionsBuilderExtensions
                     $"Database Provider {dbProvider} is not supported.");
         }
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the provider against an existing <see cref="DbConnection"/> owned by the DI scope
+    /// rather than a connection string.
+    ///
+    /// Every context in a scope sharing one connection object is what allows the outbox write to
+    /// join the business transaction — EF Core can only enlist a context in an existing transaction
+    /// when both contexts sit on the same connection.
+    /// </summary>
+    public static DbContextOptionsBuilder ConfigureHeroDatabase(
+        this DbContextOptionsBuilder builder,
+        string dbProvider,
+        DbConnection connection,
+        string migrationsAssembly,
+        bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(dbProvider);
+
+        ConfigureCommon(builder, isDevelopment);
+
+        switch (dbProvider.ToUpperInvariant())
+        {
+            case DbProviders.PostgreSQL:
+                // contextOwnsConnection: false — the scope disposes it, not the first context to finish.
+                builder.UseNpgsql(connection, contextOwnsConnection: false, e =>
+                {
+                    e.MigrationsAssembly(migrationsAssembly);
+                });
+                break;
+
+            case DbProviders.MSSQL:
+                builder.UseSqlServer(connection, contextOwnsConnection: false, e =>
+                {
+                    e.MigrationsAssembly(migrationsAssembly);
+                    e.EnableRetryOnFailure();
+                });
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Database Provider {dbProvider} is not supported.");
+        }
+
+        return builder;
+    }
+
+    private static void ConfigureCommon(DbContextOptionsBuilder builder, bool isDevelopment)
+    {
+        builder.ConfigureWarnings(warnings =>
+            warnings.Log(RelationalEventId.PendingModelChangesWarning));
+
         if (isDevelopment)
         {
             builder.EnableSensitiveDataLogging();
             builder.EnableDetailedErrors();
         }
-
-        return builder;
     }
 }

--- a/src/BuildingBlocks/Persistence/PersistenceExtensions.cs
+++ b/src/BuildingBlocks/Persistence/PersistenceExtensions.cs
@@ -34,6 +34,8 @@ public static class PersistenceExtensions
         services.TryAddSingleton(TimeProvider.System);
         services.AddScoped<ISaveChangesInterceptor, AuditableEntitySaveChangesInterceptor>();
         services.AddScoped<ISaveChangesInterceptor, DomainEventsInterceptor>();
+        services.TryAddScoped<IScopedDbConnectionProvider, ScopedDbConnectionProvider>();
+        services.TryAddScoped<AmbientDbTransactionRegistry>();
         return services;
     }
 
@@ -53,8 +55,15 @@ public static class PersistenceExtensions
         {
             var env = sp.GetRequiredService<IHostEnvironment>();
             var dbConfig = sp.GetRequiredService<IOptions<DatabaseOptions>>().Value;
-            options.ConfigureHeroDatabase(dbConfig.Provider, dbConfig.ConnectionString, dbConfig.MigrationsAssembly, env.IsDevelopment());
+
+            // Every context in the scope gets the same DbConnection object, so a write on one can
+            // join a transaction opened on another (see IScopedDbConnectionProvider).
+            var connection = sp.GetRequiredService<IScopedDbConnectionProvider>()
+                .GetConnection(dbConfig.Provider, dbConfig.ConnectionString);
+
+            options.ConfigureHeroDatabase(dbConfig.Provider, connection, dbConfig.MigrationsAssembly, env.IsDevelopment());
             options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
+            options.AddInterceptors(sp.GetRequiredService<AmbientDbTransactionRegistry>());
         });
         return services;
     }

--- a/src/BuildingBlocks/Persistence/ScopedDbConnectionProvider.cs
+++ b/src/BuildingBlocks/Persistence/ScopedDbConnectionProvider.cs
@@ -1,0 +1,74 @@
+using System.Data.Common;
+using FSH.Framework.Shared.Persistence;
+using Microsoft.Data.SqlClient;
+using Npgsql;
+
+namespace FSH.Framework.Persistence;
+
+/// <summary>
+/// Default <see cref="IScopedDbConnectionProvider"/>: caches one connection per connection string
+/// for the lifetime of the DI scope and disposes them all at scope end.
+///
+/// Connections are handed to EF Core unopened and un-owned, so EF keeps its usual open/close
+/// behaviour around each operation and the underlying pooled connection is returned as normal.
+/// What changes is only the identity of the <see cref="DbConnection"/> object: contexts in the same
+/// scope now share one, which is what makes a cross-context transaction possible.
+/// </summary>
+public sealed class ScopedDbConnectionProvider : IScopedDbConnectionProvider, IAsyncDisposable, IDisposable
+{
+    private readonly Dictionary<string, DbConnection> _connections = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public DbConnection GetConnection(string dbProvider, string connectionString)
+    {
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(dbProvider);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_connections.TryGetValue(connectionString, out var existing))
+        {
+            return existing;
+        }
+
+        DbConnection connection = dbProvider.ToUpperInvariant() switch
+        {
+            DbProviders.PostgreSQL => new NpgsqlConnection(connectionString),
+            DbProviders.MSSQL => new SqlConnection(connectionString),
+            _ => throw new InvalidOperationException($"Database Provider {dbProvider} is not supported."),
+        };
+
+        _connections[connectionString] = connection;
+        return connection;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        foreach (var connection in _connections.Values)
+        {
+            connection.Dispose();
+        }
+
+        _connections.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        foreach (var connection in _connections.Values)
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _connections.Clear();
+    }
+}

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Eventing/20260807073222_OutboxClaimLease.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Eventing/20260807073222_OutboxClaimLease.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Framework.Eventing.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Eventing
 {
     [DbContext(typeof(EventingDbContext))]
-    partial class EventingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807073222_OutboxClaimLease")]
+    partial class OutboxClaimLease
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Eventing/20260807073222_OutboxClaimLease.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Eventing/20260807073222_OutboxClaimLease.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Eventing
+{
+    /// <inheritdoc />
+    public partial class OutboxClaimLease : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClaimedBy",
+                schema: "framework",
+                table: "OutboxMessages",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClaimedUntilUtc",
+                schema: "framework",
+                table: "OutboxMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Pending",
+                schema: "framework",
+                table: "OutboxMessages",
+                columns: new[] { "IsDead", "ProcessedOnUtc", "ClaimedUntilUtc", "CreatedOnUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_Pending",
+                schema: "framework",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimedBy",
+                schema: "framework",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimedUntilUtc",
+                schema: "framework",
+                table: "OutboxMessages");
+        }
+    }
+}

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -18,7 +18,7 @@ public sealed class BillingService : IBillingService
     private readonly IUsageReporter _usageReporter;
     private readonly IMultiTenantStore<AppTenantInfo> _tenantStore;
     private readonly IMultiTenantContextAccessor<AppTenantInfo> _tenantAccessor;
-    private readonly IEventBus _eventBus;
+    private readonly IOutboxWriter _outbox;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<BillingService> _logger;
 
@@ -27,7 +27,7 @@ public sealed class BillingService : IBillingService
         IUsageReporter usageReporter,
         IMultiTenantStore<AppTenantInfo> tenantStore,
         IMultiTenantContextAccessor<AppTenantInfo> tenantAccessor,
-        IEventBus eventBus,
+        IOutboxWriter outbox,
         TimeProvider timeProvider,
         ILogger<BillingService> logger)
     {
@@ -35,7 +35,7 @@ public sealed class BillingService : IBillingService
         _usageReporter = usageReporter;
         _tenantStore = tenantStore;
         _tenantAccessor = tenantAccessor;
-        _eventBus = eventBus;
+        _outbox = outbox;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -214,7 +214,7 @@ public sealed class BillingService : IBillingService
                 invoice.InvoiceNumber, tenantId, invoice.SubtotalAmount.Amount, invoice.Currency);
         }
 
-        await _eventBus.PublishAsync(new InvoiceIssuedIntegrationEvent(
+        await _outbox.AddAsync(new InvoiceIssuedIntegrationEvent(
             Id: Guid.NewGuid(),
             OccurredOnUtc: now,
             TenantId: tenantId,
@@ -345,7 +345,7 @@ public sealed class BillingService : IBillingService
 
         // Notify (e.g. email the tenant) that a real bill was issued. Only fires for newly-created
         // invoices — the idempotent early-return above skips this on event redelivery.
-        await _eventBus.PublishAsync(new InvoiceIssuedIntegrationEvent(
+        await _outbox.AddAsync(new InvoiceIssuedIntegrationEvent(
             Id: Guid.NewGuid(),
             OccurredOnUtc: _timeProvider.GetUtcNow().UtcDateTime,
             TenantId: tenantId,

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
@@ -99,6 +99,13 @@ public sealed class SendMessageCommandHandler(
             .ConfigureAwait(false);
 
         // One integration event per distinct mentioned user. Notifications module subscribes.
+        //
+        // Deliberately still on the bus, not the outbox (the documented exception to
+        // .agents/rules/eventing.md): the Notifications handler writes the row AND pushes it over
+        // SignalR, and a mention that lands in the bell up to OutboxDispatchIntervalSeconds after
+        // the message appears in the channel reads as broken. Durability matters less here than
+        // anywhere else in the kit — the message itself is already persisted and visible, so a lost
+        // notification costs a badge, not data. Every other publish in the kit goes via the outbox.
         if (notifyUserIds.Count > 0)
         {
             var correlationId = Activity.Current?.TraceId.ToString() ?? Guid.NewGuid().ToString();

--- a/src/Modules/Files/Modules.Files/Features/v1/FinalizeUpload/FinalizeUploadCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/FinalizeUpload/FinalizeUploadCommandHandler.cs
@@ -23,7 +23,7 @@ public sealed class FinalizeUploadCommandHandler(
     IStorageService storage,
     IFileScanner scanner,
     IQuotaService quotas,
-    IEventBus events,
+    IOutboxWriter outbox,
     ICurrentUser currentUser)
     : ICommandHandler<FinalizeUploadCommand, FileAssetDto>
 {
@@ -83,7 +83,10 @@ public sealed class FinalizeUploadCommandHandler(
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         var correlationId = Activity.Current?.Id ?? Guid.NewGuid().ToString();
-        await events.PublishAsync(new FileFinalizedIntegrationEvent(
+
+        // Outbox rather than the bus: a crash between the SaveChanges above and delivery would
+        // otherwise leave the file marked available with no consumer ever told about it.
+        await outbox.AddAsync(new FileFinalizedIntegrationEvent(
             Id: Guid.NewGuid(),
             OccurredOnUtc: DateTime.UtcNow,
             TenantId: tenantId,

--- a/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEventHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Events/UserRegisteredEventHandler.cs
@@ -11,7 +11,7 @@ namespace FSH.Modules.Identity.Events;
 /// so other modules can react to new user registrations.
 /// </summary>
 public sealed class UserRegisteredHandler(
-    IEventBus eventBus,
+    IOutboxWriter outbox,
     ILogger<UserRegisteredHandler> logger)
     : INotificationHandler<UserRegisteredEvent>
 {
@@ -38,6 +38,6 @@ public sealed class UserRegisteredHandler(
             FirstName: notification.FirstName ?? string.Empty,
             LastName: notification.LastName ?? string.Empty);
 
-        await eventBus.PublishAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
+        await outbox.AddAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/IdentityModule.cs
+++ b/src/Modules/Identity/Modules.Identity/IdentityModule.cs
@@ -186,8 +186,9 @@ public class IdentityModule : IModule
         group.MapGenerateTokenEndpoint().AllowAnonymous().RequireRateLimiting("auth");
         group.MapRefreshTokenEndpoint().AllowAnonymous().RequireRateLimiting("auth");
 
-        // The outbox is dispatched by the framework's OutboxDispatcherHostedService (on by default). A second dispatcher
-        // here would race the same rows (no row-level claim) → duplicate handlers + PK_InboxMessages collisions, so this module registers none.
+        // The outbox is dispatched by the framework's OutboxDispatcherHostedService (on by default), which now claims
+        // rows with FOR UPDATE SKIP LOCKED so several instances can drain safely. This module still registers no
+        // dispatcher of its own: the outbox is framework infrastructure, not Identity's.
 
         // roles
         group.MapGetRolesEndpoint();

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandHandler.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed class CreateTenantCommandHandler(
     ITenantProvisioningService provisioningService,
     ITenantInitialPasswordBuffer passwordBuffer,
     IMediator mediator,
-    IEventBus events,
+    IOutboxWriter outbox,
     IOptions<TenantBillingOptions> billingOptions,
     TimeProvider timeProvider)
     : ICommandHandler<CreateTenantCommand, CreateTenantCommandResponse>
@@ -52,7 +52,7 @@ public sealed class CreateTenantCommandHandler(
 
         // Drive the billing side-effects (subscription + term invoice) via an integration event so
         // Multitenancy stays decoupled from the Billing runtime.
-        await events.PublishAsync(new TenantSubscribedIntegrationEvent(
+        await outbox.AddAsync(new TenantSubscribedIntegrationEvent(
             Id: Guid.NewGuid(),
             OccurredOnUtc: periodStart,
             TenantId: tenantId,

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/RenewTenant/RenewTenantCommandHandler.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/RenewTenant/RenewTenantCommandHandler.cs
@@ -11,7 +11,7 @@ namespace FSH.Modules.Multitenancy.Features.v1.RenewTenant;
 public sealed class RenewTenantCommandHandler(
     ITenantService tenantService,
     IMediator mediator,
-    IEventBus events,
+    IOutboxWriter outbox,
     IOptions<TenantBillingOptions> billingOptions,
     TimeProvider timeProvider)
     : ICommandHandler<RenewTenantCommand, RenewTenantCommandResponse>
@@ -33,7 +33,7 @@ public sealed class RenewTenantCommandHandler(
         var (periodStart, validUpto, planChanged) = await tenantService
             .RenewAsync(command.TenantId, term.Key, term.TermMonths, cancellationToken).ConfigureAwait(false);
 
-        await events.PublishAsync(new TenantRenewedIntegrationEvent(
+        await outbox.AddAsync(new TenantRenewedIntegrationEvent(
             Id: Guid.NewGuid(),
             OccurredOnUtc: timeProvider.GetUtcNow().UtcDateTime,
             TenantId: command.TenantId,

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -74,6 +74,14 @@ public sealed class MultitenancyModule : IModule
         builder.Services.Replace(
             ServiceDescriptor.Singleton<IEventTenantScope, FinbuckleEventTenantScope>());
 
+        // Same idea one level up: the outbox dispatcher must visit every database that can hold
+        // outbox rows. Without these, a tenant with a dedicated connection string writes rows the
+        // dispatcher never polls. Scoped provider — IMultiTenantStore is scoped.
+        builder.Services.Replace(
+            ServiceDescriptor.Singleton<IEventingDrainScope, FinbuckleEventingDrainScope>());
+        builder.Services.Replace(
+            ServiceDescriptor.Scoped<IEventingDrainTargetProvider, TenantStoreDrainTargetProvider>());
+
         builder.Services
             .AddMultiTenant<AppTenantInfo>(options =>
             {

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/FinbuckleEventingDrainScope.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/FinbuckleEventingDrainScope.cs
@@ -1,0 +1,78 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+
+namespace FSH.Modules.Multitenancy.Services;
+
+/// <summary>
+/// Installs an <see cref="AppTenantInfo"/> carrying the tenant's connection string, so an
+/// <c>EventingDbContext</c> built inside the scope routes to that tenant's database.
+///
+/// Deliberately distinct from <see cref="FinbuckleEventTenantScope"/>, which sets tenant identity
+/// only: that scope wraps handler dispatch, where the row-level tenant filter is what matters.
+/// This one wraps a drain pass, where the target <i>database</i> is what matters.
+/// </summary>
+public sealed class FinbuckleEventingDrainScope : IEventingDrainScope
+{
+    private readonly IMultiTenantContextAccessor<AppTenantInfo> _accessor;
+    private readonly IMultiTenantContextSetter _setter;
+
+    public FinbuckleEventingDrainScope(
+        IMultiTenantContextAccessor<AppTenantInfo> accessor,
+        IMultiTenantContextSetter setter)
+    {
+        _accessor = accessor;
+        _setter = setter;
+    }
+
+    public IDisposable Begin(EventingDrainTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (target.TenantId is null && target.ConnectionString is null)
+        {
+            // Default pass: leave the ambient context alone so the context falls through to the
+            // configured default connection.
+            return NoopScope.Instance;
+        }
+
+        var previous = _accessor.MultiTenantContext;
+
+        // Built by hand rather than via the tenant-shaped constructor: only the id and the
+        // connection string matter for routing, and the richer constructor also stamps validity
+        // and activation state we have no business inventing here.
+        var info = new AppTenantInfo(target.TenantId!, target.TenantId!)
+        {
+            ConnectionString = target.ConnectionString ?? string.Empty,
+        };
+
+        _setter.MultiTenantContext = new MultiTenantContext<AppTenantInfo>(info);
+
+        return new RestoreScope(_setter, previous);
+    }
+
+    private sealed class RestoreScope : IDisposable
+    {
+        private readonly IMultiTenantContextSetter _setter;
+        private readonly IMultiTenantContext<AppTenantInfo> _previous;
+
+        public RestoreScope(IMultiTenantContextSetter setter, IMultiTenantContext<AppTenantInfo> previous)
+        {
+            _setter = setter;
+            _previous = previous;
+        }
+
+        public void Dispose() => _setter.MultiTenantContext = _previous;
+    }
+
+    private sealed class NoopScope : IDisposable
+    {
+        public static readonly NoopScope Instance = new();
+
+        public void Dispose()
+        {
+            // Nothing to restore — the ambient context was never touched.
+        }
+    }
+}

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantExpiryScanJob.cs
@@ -21,7 +21,7 @@ public sealed class TenantExpiryScanJob
 {
     private readonly IMultiTenantStore<AppTenantInfo> _tenantStore;
     private readonly TenantDbContext _db;
-    private readonly IEventBus _eventBus;
+    private readonly IOutboxWriter _outbox;
     private readonly IMultiTenantContextSetter _tenantContextSetter;
     private readonly TimeProvider _timeProvider;
     private readonly TenantBillingOptions _options;
@@ -30,7 +30,7 @@ public sealed class TenantExpiryScanJob
     public TenantExpiryScanJob(
         IMultiTenantStore<AppTenantInfo> tenantStore,
         TenantDbContext db,
-        IEventBus eventBus,
+        IOutboxWriter outbox,
         IMultiTenantContextSetter tenantContextSetter,
         TimeProvider timeProvider,
         IOptions<TenantBillingOptions> options,
@@ -39,7 +39,7 @@ public sealed class TenantExpiryScanJob
         ArgumentNullException.ThrowIfNull(options);
         _tenantStore = tenantStore;
         _db = db;
-        _eventBus = eventBus;
+        _outbox = outbox;
         _tenantContextSetter = tenantContextSetter;
         _timeProvider = timeProvider;
         _options = options.Value;
@@ -120,7 +120,7 @@ public sealed class TenantExpiryScanJob
         // tenant-filtered DbContexts that NRE without it, since a background job carries no HTTP request.
         _tenantContextSetter.MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
 
-        await _eventBus.PublishAsync(BuildEvent(noticeType, tenant, validUpto, graceEnds, now), ct).ConfigureAwait(false);
+        await _outbox.AddAsync(BuildEvent(noticeType, tenant, validUpto, graceEnds, now), ct).ConfigureAwait(false);
         return true;
     }
 

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantStoreDrainTargetProvider.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantStoreDrainTargetProvider.cs
@@ -1,0 +1,34 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+
+namespace FSH.Modules.Multitenancy.Services;
+
+/// <summary>
+/// Returns the default database plus one target per distinct active per-tenant connection string.
+///
+/// Tenants sharing a database collapse to a single target: outbox rows are <c>IGlobalEntity</c>
+/// and carry an explicit TenantId column, so one pass over a database drains every tenant living
+/// in it. Draining once per tenant instead would multiply the work and have several passes race
+/// for the same rows.
+/// </summary>
+public sealed class TenantStoreDrainTargetProvider : IEventingDrainTargetProvider
+{
+    private readonly IMultiTenantStore<AppTenantInfo> _tenantStore;
+
+    public TenantStoreDrainTargetProvider(IMultiTenantStore<AppTenantInfo> tenantStore)
+        => _tenantStore = tenantStore;
+
+    public async Task<IReadOnlyList<EventingDrainTarget>> GetTargetsAsync(CancellationToken ct = default)
+    {
+        var tenants = await _tenantStore.GetAllAsync().ConfigureAwait(false);
+
+        var dedicated = tenants
+            .Where(t => t.IsActive && !string.IsNullOrWhiteSpace(t.ConnectionString))
+            .GroupBy(t => t.ConnectionString, StringComparer.Ordinal)
+            .Select(g => new EventingDrainTarget(g.First().Id, g.Key));
+
+        // The default pass always runs: it covers every tenant without a dedicated database.
+        return [new EventingDrainTarget(null, null), .. dedicated];
+    }
+}

--- a/src/Tests/Framework.Tests/Eventing/EfCoreOutboxStoreTests.cs
+++ b/src/Tests/Framework.Tests/Eventing/EfCoreOutboxStoreTests.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Eventing;
 using FSH.Framework.Eventing.Abstractions;
 using FSH.Framework.Eventing.Outbox;
 using FSH.Framework.Eventing.Serialization;
+using FSH.Framework.Persistence;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Shouldly;
@@ -27,7 +28,8 @@ public class EfCoreOutboxStoreTests
             new JsonEventSerializer(),
             NullLogger<EfCoreOutboxStore>.Instance,
             TimeProvider.System,
-            Options.Create(new EventingOptions()));
+            Options.Create(new EventingOptions()),
+            new AmbientDbTransactionRegistry());
 
         var evt = new SampleEvent(
             Guid.CreateVersion7(),

--- a/src/Tests/Framework.Tests/Eventing/EventingDbContextModelTests.cs
+++ b/src/Tests/Framework.Tests/Eventing/EventingDbContextModelTests.cs
@@ -51,6 +51,18 @@ public class EventingDbContextModelTests
     }
 
     [Fact]
+    public void Outbox_Has_Claim_Index_For_Pending_Scan()
+    {
+        using var context = CreateContext();
+        var entity = context.Model.FindEntityType(typeof(OutboxMessage));
+
+        entity.ShouldNotBeNull();
+        entity!.GetIndexes()
+            .Any(i => i.GetDatabaseName() == "IX_OutboxMessages_Pending")
+            .ShouldBeTrue("the claim scan filters and orders on these columns under a row lock");
+    }
+
+    [Fact]
     public void Maps_InboxMessages_To_Framework_Schema()
     {
         using var context = CreateContext();

--- a/src/Tests/Framework.Tests/Eventing/OutboxDispatcherHostedServiceTests.cs
+++ b/src/Tests/Framework.Tests/Eventing/OutboxDispatcherHostedServiceTests.cs
@@ -1,0 +1,119 @@
+using FSH.Framework.Eventing;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Eventing.Outbox;
+using FSH.Framework.Eventing.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Framework.Tests.Eventing;
+
+public class OutboxDispatcherHostedServiceTests
+{
+    private static readonly EventingDrainTarget Default = new(null, null);
+    private static readonly EventingDrainTarget Acme = new("acme", "Host=acme;Database=acme;Username=u;Password=p");
+
+    [Fact]
+    public async Task Drains_Once_Per_Target()
+    {
+        var targets = new List<EventingDrainTarget> { Default, Acme };
+        var recording = new RecordingDrainScope();
+        var store = EmptyStore();
+
+        await RunOneCycleAsync(targets, recording, store);
+
+        recording.Begun.ShouldBe(targets, "every database holding outbox rows must be drained each cycle");
+        await store.Received(2).GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Single_Target_Behaves_As_Before()
+    {
+        var recording = new RecordingDrainScope();
+        var store = EmptyStore();
+
+        await RunOneCycleAsync([Default], recording, store);
+
+        recording.Begun.ShouldHaveSingleItem();
+        await store.Received(1).GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task One_Unreachable_Database_Does_Not_Stop_The_Others()
+    {
+        var recording = new RecordingDrainScope();
+        var store = Substitute.For<IOutboxStore>();
+        store.GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(
+                _ => throw new InvalidOperationException("acme is down"),
+                _ => Task.FromResult<IReadOnlyList<OutboxMessage>>([]));
+
+        await RunOneCycleAsync([Acme, Default], recording, store);
+
+        recording.Begun.Count.ShouldBe(
+            2,
+            "a tenant database being down must not strand every other tenant's outbox for the cycle");
+        recording.Disposed.ShouldBe(2, "each drain scope must be released even when the drain throws");
+    }
+
+    private static IOutboxStore EmptyStore()
+    {
+        var store = Substitute.For<IOutboxStore>();
+        store.GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<OutboxMessage>>([]));
+        return store;
+    }
+
+    private static async Task RunOneCycleAsync(
+        IReadOnlyList<EventingDrainTarget> targets,
+        IEventingDrainScope drainScope,
+        IOutboxStore store)
+    {
+        var provider = Substitute.For<IEventingDrainTargetProvider>();
+        provider.GetTargetsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(targets));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(store);
+        services.AddSingleton(Substitute.For<IEventBus>());
+        services.AddSingleton<IEventSerializer, JsonEventSerializer>();
+        services.AddSingleton(provider);
+        services.AddSingleton(drainScope);
+        services.AddSingleton(Options.Create(new EventingOptions()));
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<OutboxDispatcher>();
+
+        await using var root = services.BuildServiceProvider();
+
+        using var sut = new OutboxDispatcherHostedService(
+            root.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new EventingOptions()),
+            NullLogger<OutboxDispatcherHostedService>.Instance);
+
+        await sut.DispatchOutboxAsync(CancellationToken.None);
+    }
+
+    private sealed class RecordingDrainScope : IEventingDrainScope
+    {
+        public List<EventingDrainTarget> Begun { get; } = [];
+
+        public int Disposed { get; private set; }
+
+        public IDisposable Begin(EventingDrainTarget target)
+        {
+            Begun.Add(target);
+            return new Handle(this);
+        }
+
+        private sealed class Handle : IDisposable
+        {
+            private readonly RecordingDrainScope _owner;
+
+            public Handle(RecordingDrainScope owner) => _owner = owner;
+
+            public void Dispose() => _owner.Disposed++;
+        }
+    }
+}

--- a/src/Tests/Framework.Tests/Eventing/OutboxDispatcherHostedServiceTests.cs
+++ b/src/Tests/Framework.Tests/Eventing/OutboxDispatcherHostedServiceTests.cs
@@ -26,7 +26,7 @@ public class OutboxDispatcherHostedServiceTests
         await RunOneCycleAsync(targets, recording, store);
 
         recording.Begun.ShouldBe(targets, "every database holding outbox rows must be drained each cycle");
-        await store.Received(2).GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await store.Received(2).ClaimBatchAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class OutboxDispatcherHostedServiceTests
         await RunOneCycleAsync([Default], recording, store);
 
         recording.Begun.ShouldHaveSingleItem();
-        await store.Received(1).GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await store.Received(1).ClaimBatchAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class OutboxDispatcherHostedServiceTests
     {
         var recording = new RecordingDrainScope();
         var store = Substitute.For<IOutboxStore>();
-        store.GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+        store.ClaimBatchAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
             .Returns(
                 _ => throw new InvalidOperationException("acme is down"),
                 _ => Task.FromResult<IReadOnlyList<OutboxMessage>>([]));
@@ -62,7 +62,7 @@ public class OutboxDispatcherHostedServiceTests
     private static IOutboxStore EmptyStore()
     {
         var store = Substitute.For<IOutboxStore>();
-        store.GetPendingBatchAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+        store.ClaimBatchAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<OutboxMessage>>([]));
         return store;
     }

--- a/src/Tests/Framework.Tests/Eventing/SingleDatabaseDrainTargetProviderTests.cs
+++ b/src/Tests/Framework.Tests/Eventing/SingleDatabaseDrainTargetProviderTests.cs
@@ -1,0 +1,20 @@
+using FSH.Framework.Eventing;
+using Shouldly;
+using Xunit;
+
+namespace Framework.Tests.Eventing;
+
+public class SingleDatabaseDrainTargetProviderTests
+{
+    [Fact]
+    public async Task Returns_One_Default_Target()
+    {
+        var provider = new SingleDatabaseDrainTargetProvider();
+
+        var targets = await provider.GetTargetsAsync(CancellationToken.None);
+
+        targets.Count.ShouldBe(1, "a single-database deployment must drain exactly once per cycle");
+        targets[0].TenantId.ShouldBeNull();
+        targets[0].ConnectionString.ShouldBeNull("null means the configured default connection");
+    }
+}

--- a/src/Tests/Integration.Tests/Infrastructure/OutboxDrain.cs
+++ b/src/Tests/Integration.Tests/Infrastructure/OutboxDrain.cs
@@ -1,0 +1,48 @@
+using FSH.Framework.Eventing.Outbox;
+using FSH.Framework.Eventing.Persistence;
+
+namespace Integration.Tests.Infrastructure;
+
+/// <summary>
+/// Drains the outbox synchronously until it stops making progress.
+///
+/// Publishing via the outbox makes delivery asynchronous — in production the hosted dispatcher
+/// picks the row up within <c>OutboxDispatchIntervalSeconds</c> (it is switched off in this host).
+/// A test asserting on a consumer's side effect therefore has to drain first.
+///
+/// It loops rather than dispatching once for two reasons: one cycle claims at most
+/// <c>OutboxBatchSize</c> rows, and the whole suite shares one database, so unrelated tests' rows
+/// can sit ahead of the one under test in CreatedOnUtc order. Chained events (TenantSubscribed →
+/// InvoiceIssued) also need a cycle each. Stops as soon as a pass clears nothing, so rows another
+/// test still holds a lease on cannot spin it.
+/// </summary>
+internal static class OutboxDrain
+{
+    private const int MaxPasses = 10;
+
+    public static async Task DrainAsync(IServiceProvider services)
+    {
+        for (int pass = 0; pass < MaxPasses; pass++)
+        {
+            var before = await CountUnprocessedAsync(services);
+
+            using (var scope = services.CreateScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<OutboxDispatcher>().DispatchAsync();
+            }
+
+            var after = await CountUnprocessedAsync(services);
+            if (after >= before)
+            {
+                return;
+            }
+        }
+    }
+
+    private static async Task<int> CountUnprocessedAsync(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<EventingDbContext>();
+        return await context.OutboxMessages.CountAsync(m => m.ProcessedOnUtc == null && !m.IsDead);
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Billing/InvoicePdfTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/InvoicePdfTests.cs
@@ -16,10 +16,12 @@ public sealed class InvoicePdfTests
     private const string BillingBasePath = "/api/v1/billing";
 
     private readonly AuthHelper _auth;
+    private readonly FshWebApplicationFactory _factory;
 
     public InvoicePdfTests(FshWebApplicationFactory factory)
     {
         _auth = new AuthHelper(factory);
+        _factory = factory;
     }
 
     [Fact]
@@ -32,6 +34,10 @@ public sealed class InvoicePdfTests
         var planKey = await CreatePlanAsync(rootClient, $"pdf-m-{unique}", 29m);
         await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
         await WaitForProvisioningAsync(rootClient, tenantId);
+
+        // TenantSubscribed goes through the outbox now, so the invoice is issued on the next
+        // dispatch cycle rather than inside the create request.
+        await OutboxDrain.DrainAsync(_factory.Services);
 
         // The subscription invoice was issued on create; grab its id from the operator list.
         var invoiceId = await GetFirstInvoiceIdAsync(rootClient, tenantId);

--- a/src/Tests/Integration.Tests/Tests/Billing/TenantBillingLifecycleTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Billing/TenantBillingLifecycleTests.cs
@@ -27,10 +27,12 @@ public sealed class TenantBillingLifecycleTests
     };
 
     private readonly AuthHelper _auth;
+    private readonly FshWebApplicationFactory _factory;
 
     public TenantBillingLifecycleTests(FshWebApplicationFactory factory)
     {
         _auth = new AuthHelper(factory);
+        _factory = factory;
     }
 
     [Fact]
@@ -41,6 +43,10 @@ public sealed class TenantBillingLifecycleTests
         var planKey = await CreatePlanAsync(rootClient, $"life-{unique}", monthlyBasePrice: 20m);
         var tenantId = $"life-{unique}";
         await CreateTenantAsync(rootClient, tenantId, $"life-{unique}@tenant.com", planKey);
+
+        // TenantSubscribed now goes through the outbox, so Billing reacts on the next dispatch
+        // cycle rather than inside the create request.
+        await OutboxDrain.DrainAsync(_factory.Services);
 
         // Active subscription on the new plan.
         var subscription = await rootClient.GetFromJsonAsync<SubscriptionDto>(
@@ -73,6 +79,7 @@ public sealed class TenantBillingLifecycleTests
         var planKey = await CreatePlanAsync(rootClient, $"free-{unique}", monthlyBasePrice: 0m);
         var tenantId = $"free-{unique}";
         await CreateTenantAsync(rootClient, tenantId, $"free-{unique}@tenant.com", planKey);
+        await OutboxDrain.DrainAsync(_factory.Services);
 
         var subscription = await rootClient.GetFromJsonAsync<SubscriptionDto>(
             $"{BillingBasePath}/subscriptions?tenantId={tenantId}", Json);

--- a/src/Tests/Integration.Tests/Tests/Eventing/OutboxAtomicityTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Eventing/OutboxAtomicityTests.cs
@@ -1,0 +1,206 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Abstractions;
+using FSH.Framework.Eventing.Outbox;
+using FSH.Framework.Eventing.Persistence;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Billing.Contracts.Events;
+using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Domain;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Eventing;
+
+/// <summary>
+/// Covers plan Phase 4. The outbox is only "transactional" if its row shares the caller's
+/// transaction; before this, AddAsync committed on its own, so a business write that later rolled
+/// back still published its event — and a crash between the two writes lost it.
+///
+/// Enlistment depends on every context in the scope sharing one DbConnection, which is asserted
+/// directly here too: it is the load-bearing precondition, and a silent regression to
+/// per-context connections would leave these rollbacks passing for the wrong reason.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class OutboxAtomicityTests
+{
+    private readonly FshWebApplicationFactory _factory;
+
+    public OutboxAtomicityTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Module_Context_And_Eventing_Context_Share_One_Connection()
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+
+        var catalog = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+        var eventing = scope.ServiceProvider.GetRequiredService<EventingDbContext>();
+
+        ReferenceEquals(catalog.Database.GetDbConnection(), eventing.Database.GetDbConnection())
+            .ShouldBeTrue("a shared DbConnection is what lets the outbox write join the business transaction");
+    }
+
+    [Fact]
+    public async Task Outbox_Write_Rolls_Back_With_The_Business_Transaction()
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var catalog = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var brand = Brand.Create($"atomicity-{Guid.CreateVersion7():N}", null, null);
+        var eventId = Guid.CreateVersion7();
+
+        await using (var transaction = await catalog.Database.BeginTransactionAsync())
+        {
+            catalog.Brands.Add(brand);
+            await catalog.SaveChangesAsync();
+
+            await store.AddAsync(NewEvent(eventId));
+
+            await transaction.RollbackAsync();
+        }
+
+        await AssertOutboxRowAsync(eventId, shouldExist: false,
+            "the outbox row must not survive a rolled-back business transaction");
+        await AssertBrandAsync(brand.Id, shouldExist: false);
+    }
+
+    [Fact]
+    public async Task Outbox_Write_Commits_With_The_Business_Transaction()
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var catalog = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var brand = Brand.Create($"atomicity-{Guid.CreateVersion7():N}", null, null);
+        var eventId = Guid.CreateVersion7();
+
+        await using (var transaction = await catalog.Database.BeginTransactionAsync())
+        {
+            catalog.Brands.Add(brand);
+            await catalog.SaveChangesAsync();
+
+            await store.AddAsync(NewEvent(eventId));
+
+            await transaction.CommitAsync();
+        }
+
+        await AssertOutboxRowAsync(eventId, shouldExist: true,
+            "enlisting must not swallow the write — a committed transaction keeps both rows");
+        await AssertBrandAsync(brand.Id, shouldExist: true);
+    }
+
+    [Fact]
+    public async Task Write_Outside_A_Transaction_Still_Commits_On_Its_Own()
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var eventId = Guid.CreateVersion7();
+
+        await store.AddAsync(NewEvent(eventId));
+
+        await AssertOutboxRowAsync(eventId, shouldExist: true,
+            "with no ambient transaction the store must behave exactly as it always has");
+    }
+
+    [Fact]
+    public async Task A_Second_Write_After_The_Transaction_Completes_Is_Not_Blocked_By_The_Stale_Handle()
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var catalog = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var insideId = Guid.CreateVersion7();
+        await using (var transaction = await catalog.Database.BeginTransactionAsync())
+        {
+            await store.AddAsync(NewEvent(insideId));
+            await transaction.RollbackAsync();
+        }
+
+        // The eventing context is still holding the transaction it joined; a naive implementation
+        // would now fail or silently write into a completed transaction.
+        var afterId = Guid.CreateVersion7();
+        await store.AddAsync(NewEvent(afterId));
+
+        await AssertOutboxRowAsync(insideId, shouldExist: false, "rolled back with its transaction");
+        await AssertOutboxRowAsync(afterId, shouldExist: true, "a later write must stand on its own again");
+    }
+
+    private static InvoiceIssuedIntegrationEvent NewEvent(Guid id) => new(
+        id,
+        DateTime.UtcNow,
+        TestConstants.RootTenantId,
+        $"corr-{id:N}",
+        "Billing",
+        Guid.CreateVersion7(),
+        "INV-ATOMIC",
+        10.00m,
+        "USD",
+        DateTime.UtcNow.AddDays(7),
+        2026,
+        8);
+
+    private async Task AssertOutboxRowAsync(Guid eventId, bool shouldExist, string because)
+    {
+        // A fresh scope: the assertion must read committed state, not the writing context's tracker.
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var eventing = scope.ServiceProvider.GetRequiredService<EventingDbContext>();
+
+        (await eventing.OutboxMessages.AsNoTracking().AnyAsync(m => m.Id == eventId))
+            .ShouldBe(shouldExist, because);
+    }
+
+    private async Task AssertBrandAsync(Guid brandId, bool shouldExist)
+    {
+        var (scope, tenant) = await NewScopeAsync();
+        using var scopeHandle = scope;
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+
+        var catalog = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+
+        (await catalog.Brands.AsNoTracking().AnyAsync(b => b.Id == brandId))
+            .ShouldBe(shouldExist, "the business row and the outbox row must share one fate");
+    }
+
+    /// <summary>
+    /// Returns a scope plus the root tenant, leaving the caller to install the tenant context
+    /// INLINE. Finbuckle keeps that context in an AsyncLocal, so a set inside an awaited helper
+    /// does not flow back out — the multi-tenant entities in these tests would then fail with
+    /// "MultiTenant Entity cannot be changed if TenantInfo is null".
+    /// </summary>
+    private async Task<(IServiceScope Scope, AppTenantInfo Tenant)> NewScopeAsync()
+    {
+        var scope = _factory.Services.CreateScope();
+        var tenant = await scope.ServiceProvider
+            .GetRequiredService<IMultiTenantStore<AppTenantInfo>>()
+            .GetAsync(TestConstants.RootTenantId);
+        return (scope, tenant!);
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Eventing/OutboxClaimTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Eventing/OutboxClaimTests.cs
@@ -1,0 +1,150 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Eventing.Outbox;
+using FSH.Framework.Eventing.Persistence;
+using FSH.Framework.Shared.Multitenancy;
+using Integration.Tests.Infrastructure;
+
+namespace Integration.Tests.Tests.Eventing;
+
+/// <summary>
+/// Covers plan Phase 3: without row claiming, two API instances both drain the same outbox rows
+/// and publish every integration event twice. Claiming is a concurrency behaviour, so it needs a
+/// real Postgres — SKIP LOCKED has no in-memory equivalent.
+/// </summary>
+[Collection(FshCollectionDefinition.Name)]
+public sealed class OutboxClaimTests
+{
+    private static readonly TimeSpan Lease = TimeSpan.FromMinutes(5);
+
+    private readonly FshWebApplicationFactory _factory;
+
+    public OutboxClaimTests(FshWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Concurrent_Claims_Never_Return_The_Same_Row()
+    {
+        var marker = $"claim-{Guid.CreateVersion7():N}";
+        await SeedAsync(marker, count: 50);
+
+        // Two scopes = two DbContexts = two connections, which is what makes this a real race.
+        using var scopeA = await CreateTenantScopeAsync();
+        using var scopeB = await CreateTenantScopeAsync();
+        var storeA = scopeA.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var storeB = scopeB.ServiceProvider.GetRequiredService<IOutboxStore>();
+
+        var results = await Task.WhenAll(
+            storeA.ClaimBatchAsync(50, "instance-a", Lease),
+            storeB.ClaimBatchAsync(50, "instance-b", Lease));
+
+        var claimedIds = results
+            .SelectMany(r => r)
+            .Where(m => m.Type == marker)
+            .Select(m => m.Id)
+            .ToList();
+
+        claimedIds.Distinct().Count().ShouldBe(
+            claimedIds.Count,
+            "SKIP LOCKED must hand each row to exactly one claimant, or the event is published twice");
+        claimedIds.Count.ShouldBe(50, "between them the two instances must still claim every pending row");
+    }
+
+    [Fact]
+    public async Task Claimed_Rows_Are_Invisible_To_A_Second_Claimant()
+    {
+        var marker = $"claim-{Guid.CreateVersion7():N}";
+        await SeedAsync(marker, count: 5);
+
+        using var scopeA = await CreateTenantScopeAsync();
+        var first = await scopeA.ServiceProvider.GetRequiredService<IOutboxStore>()
+            .ClaimBatchAsync(500, "instance-a", Lease);
+        first.Count(m => m.Type == marker).ShouldBe(5);
+
+        using var scopeB = await CreateTenantScopeAsync();
+        var second = await scopeB.ServiceProvider.GetRequiredService<IOutboxStore>()
+            .ClaimBatchAsync(500, "instance-b", Lease);
+
+        second.ShouldNotContain(
+            m => m.Type == marker,
+            "a live lease must hide the row from every other dispatcher");
+    }
+
+    [Fact]
+    public async Task Expired_Lease_Is_Reclaimable()
+    {
+        var marker = $"claim-{Guid.CreateVersion7():N}";
+        // Lease already in the past: this is the crashed-dispatcher case.
+        await SeedAsync(marker, count: 3, claimedUntilUtc: DateTime.UtcNow.AddMinutes(-1), claimedBy: "dead-instance");
+
+        using var scope = await CreateTenantScopeAsync();
+        var reclaimed = await scope.ServiceProvider.GetRequiredService<IOutboxStore>()
+            .ClaimBatchAsync(500, "instance-b", Lease);
+
+        reclaimed.Count(m => m.Type == marker).ShouldBe(
+            3,
+            "a crashed dispatcher's rows must be recovered once its lease expires, not stranded forever");
+    }
+
+    [Fact]
+    public async Task Completing_A_Message_Releases_Its_Lease()
+    {
+        var marker = $"claim-{Guid.CreateVersion7():N}";
+        await SeedAsync(marker, count: 1);
+
+        using var scope = await CreateTenantScopeAsync();
+        var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var context = scope.ServiceProvider.GetRequiredService<EventingDbContext>();
+
+        var claimed = (await store.ClaimBatchAsync(500, "instance-a", Lease)).Single(m => m.Type == marker);
+        claimed.ClaimedUntilUtc.ShouldNotBeNull();
+
+        await store.MarkAsFailedAsync(claimed, "boom", isDead: false);
+
+        var stored = await context.OutboxMessages.AsNoTracking().SingleAsync(m => m.Id == claimed.Id);
+        stored.ClaimedUntilUtc.ShouldBeNull(
+            "a retryable row must not stay hidden behind a stale lease until it expires");
+        stored.ClaimedBy.ShouldBeNull();
+    }
+
+    private async Task SeedAsync(
+        string marker,
+        int count,
+        DateTime? claimedUntilUtc = null,
+        string? claimedBy = null)
+    {
+        using var scope = await CreateTenantScopeAsync();
+        var context = scope.ServiceProvider.GetRequiredService<EventingDbContext>();
+
+        for (int i = 0; i < count; i++)
+        {
+            context.OutboxMessages.Add(new OutboxMessage
+            {
+                Id = Guid.CreateVersion7(),
+                CreatedOnUtc = DateTime.UtcNow.AddDays(-1).AddMilliseconds(i),
+                Type = marker,
+                Payload = "{}",
+                TenantId = TestConstants.RootTenantId,
+                RetryCount = 0,
+                IsDead = false,
+                ClaimedUntilUtc = claimedUntilUtc,
+                ClaimedBy = claimedBy,
+            });
+        }
+
+        await context.SaveChangesAsync();
+    }
+
+    private async Task<IServiceScope> CreateTenantScopeAsync()
+    {
+        var scope = _factory.Services.CreateScope();
+        var tenant = await scope.ServiceProvider
+            .GetRequiredService<IMultiTenantStore<AppTenantInfo>>()
+            .GetAsync(TestConstants.RootTenantId);
+        scope.ServiceProvider.GetRequiredService<IMultiTenantContextSetter>()
+            .MultiTenantContext = new MultiTenantContext<AppTenantInfo>(tenant);
+        return scope;
+    }
+}

--- a/src/Tests/Integration.Tests/Tests/Eventing/OutboxRetryTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Eventing/OutboxRetryTests.cs
@@ -40,7 +40,7 @@ public sealed class OutboxRetryTests
             DateTime.UtcNow.AddSeconds(20),
             "the first retry backs off by the base delay (30s), not the next 10s cycle");
 
-        var pending = await store.GetPendingBatchAsync(500);
+        var pending = await ClaimAsync(store);
         pending.ShouldNotContain(
             m => m.Id == message.Id,
             "a message whose NextRetryAt is in the future must be excluded from the dispatch batch");
@@ -64,10 +64,13 @@ public sealed class OutboxRetryTests
 
         redriven.ShouldBe(1);
         (await store.GetDeadLetteredAsync(500)).ShouldNotContain(m => m.Id == message.Id);
-        (await store.GetPendingBatchAsync(500)).ShouldContain(
+        (await ClaimAsync(store)).ShouldContain(
             m => m.Id == message.Id,
             "a redriven message clears IsDead/RetryCount/NextRetryAt and becomes eligible again");
     }
+
+    private static Task<IReadOnlyList<OutboxMessage>> ClaimAsync(IOutboxStore store) =>
+        store.ClaimBatchAsync(500, "OutboxRetryTests", TimeSpan.FromMinutes(5));
 
     private static OutboxMessage NewMessage() => new()
     {

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/RenewTenantTests.cs
@@ -142,11 +142,17 @@ public sealed class RenewTenantTests
         await CreateTenantAsync(rootClient, tenantId, $"renew-drift-{unique}@tenant.com", planKey);
         await WaitForProvisioningAsync(rootClient, tenantId);
 
+        // TenantSubscribed/TenantRenewed go through the outbox now, so Billing reacts on the next
+        // dispatch cycle rather than inside the request.
+        await OutboxDrain.DrainAsync(_factory.Services);
+
         var before = await GetSubscriptionEndUtcAsync(rootClient, tenantId);
         before.ShouldNotBeNull("a plan-bound tenant has an active subscription with an end date");
 
         var result = await RenewAsync(rootClient, tenantId, planKey);
         result.PlanChanged.ShouldBeFalse("renewing the same plan does not change it");
+
+        await OutboxDrain.DrainAsync(_factory.Services);
 
         var after = await PollSubscriptionEndUtcAdvancedAsync(rootClient, tenantId, before!.Value);
         after.ShouldNotBeNull();

--- a/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryScanJobTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Multitenancy/TenantExpiryScanJobTests.cs
@@ -72,8 +72,12 @@ public sealed class TenantExpiryScanJobTests
         var mail = (NoOpMailService)_factory.Services.GetRequiredService<IMailService>();
         mail.Clear();
 
-        // Creating a tenant on a paid plan issues the subscription invoice synchronously, which emails the admin.
+        // Creating a tenant on a paid plan issues the subscription invoice, which emails the admin.
+        // Both hops are outbox-driven now — TenantSubscribed, then InvoiceIssued — so this takes
+        // two dispatch cycles rather than happening inside the create request.
         await CreateTenantAsync(rootClient, tenantId, adminEmail, planKey);
+        await OutboxDrain.DrainAsync(_factory.Services);
+        await OutboxDrain.DrainAsync(_factory.Services);
 
         mail.Sent.ShouldContain(
             m => m.To.Contains(adminEmail) && m.Subject.Contains("Invoice", StringComparison.OrdinalIgnoreCase),
@@ -85,6 +89,9 @@ public sealed class TenantExpiryScanJobTests
         using var scope = _factory.Services.CreateScope();
         var job = scope.ServiceProvider.GetRequiredService<TenantExpiryScanJob>();
         await job.RunAsync(CancellationToken.None);
+
+        // The job records its notice via the outbox; the email handler runs on dispatch.
+        await OutboxDrain.DrainAsync(_factory.Services);
     }
 
     private async Task<int> CountNoticesAsync(string tenantId, string noticeType)

--- a/src/Tests/Multitenancy.Tests/TenantStoreDrainTargetProviderTests.cs
+++ b/src/Tests/Multitenancy.Tests/TenantStoreDrainTargetProviderTests.cs
@@ -1,0 +1,59 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Modules.Multitenancy.Services;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Multitenancy.Tests;
+
+public class TenantStoreDrainTargetProviderTests
+{
+    private const string AcmeConnection = "Host=acme;Database=acme;Username=u;Password=p";
+
+    [Fact]
+    public async Task Returns_Default_Plus_One_Target_Per_Distinct_Connection_String()
+    {
+        var provider = new TenantStoreDrainTargetProvider(StoreWith(
+            Tenant("shared-a", connectionString: null),
+            Tenant("shared-b", connectionString: null),
+            Tenant("acme", AcmeConnection),
+            Tenant("acme-2", AcmeConnection),
+            Tenant("gone", "Host=gone;Database=gone;Username=u;Password=p", isActive: false)));
+
+        var targets = await provider.GetTargetsAsync(CancellationToken.None);
+
+        targets.Count.ShouldBe(2, "the default pass plus one per distinct active connection string");
+        targets.ShouldContain(t => t.ConnectionString == null, "the default database is always drained");
+        targets.Count(t => t.ConnectionString == AcmeConnection)
+            .ShouldBe(1, "two tenants sharing a database must be drained once, not twice");
+        targets.ShouldNotContain(t => t.TenantId == "gone", "inactive tenants are not drained");
+    }
+
+    [Fact]
+    public async Task Returns_Only_The_Default_When_No_Tenant_Has_A_Dedicated_Database()
+    {
+        var provider = new TenantStoreDrainTargetProvider(StoreWith(
+            Tenant("shared-a", connectionString: null),
+            Tenant("shared-b", connectionString: "   ")));
+
+        var targets = await provider.GetTargetsAsync(CancellationToken.None);
+
+        targets.ShouldHaveSingleItem().ConnectionString.ShouldBeNull(
+            "a whitespace connection string is not a dedicated database");
+    }
+
+    private static IMultiTenantStore<AppTenantInfo> StoreWith(params AppTenantInfo[] tenants)
+    {
+        var store = Substitute.For<IMultiTenantStore<AppTenantInfo>>();
+        store.GetAllAsync().Returns(tenants.AsEnumerable());
+        return store;
+    }
+
+    private static AppTenantInfo Tenant(string id, string? connectionString, bool isActive = true) =>
+        new(id, id, id)
+        {
+            ConnectionString = connectionString ?? string.Empty,
+            IsActive = isActive,
+        };
+}

--- a/superpowers/plans/2026-08-06-framework-owned-transactional-outbox.md
+++ b/superpowers/plans/2026-08-06-framework-owned-transactional-outbox.md
@@ -47,8 +47,29 @@ Each phase is independently shippable and leaves the build green.
 | 1.6 strip Identity + host wiring | done | `161b364c` |
 | 1.7 migrations + data carry-over | done | `161b364c` |
 | 1.8 multi-module integration test | done | `161b364c` |
-| **Phase 1 complete** — #1349 fixed end to end | | |
-| Phases 2–6 | todo | — |
+| **Phase 1 complete** — #1349 fixed end to end | shipped | PR #1353 |
+| 2.1 drain-target abstractions | done | |
+| 2.2 dispatch every target | done | |
+| 2.3 multitenancy provider + scope | done | |
+| 3.1 lease columns and index | done | |
+| 3.2 claim via FOR UPDATE SKIP LOCKED | done | |
+| 4.1 scoped shared connection | done | |
+| 4.2 enlist in the caller's transaction | done | |
+| 5.1–5.8 call sites | 7 moved, 1 documented exception | |
+| 6.1 rules and skills | done | |
+| 6.2 docs site + changelog | done (committed in the docs repo, **not pushed**) | |
+| 6.3 issue reply | done on #1349 | |
+
+**Phases 2–6 completed 2026-08-07.** Full suite green: 1053 unit + 747 integration.
+
+Deviations from the plan text, all deliberate:
+
+- **Task 5 left Chat mentions on the bus.** The Notifications handler writes the row *and* pushes it over SignalR; a mention landing in the bell a dispatch cycle after the message appears reads as broken, and durability matters least there (the message itself is already persisted). The plan's Step 5 explicitly allows this; it is the only exception, and the reason is in a comment at the call site.
+- **Modules inject `IOutboxWriter`, not `IOutboxStore`.** `IOutboxStore` lives in the eventing runtime, which modules don't reference (and shouldn't — it would drag EF Core into every module). Added `IOutboxWriter` to `Eventing.Abstractions` as the publish-side contract; `IOutboxStore` extends it.
+- **Phase 4 needed a transaction registry, and the plan's fallback was the right call.** `DbConnection` exposes no way to ask whether a transaction is open on it, so `AmbientDbTransactionRegistry` (an `IDbTransactionInterceptor` on every Hero context) records them. Also: enlistment must *detach* a completed transaction, or the next write in the same scope fails on a disposed handle.
+- **Phase 5 broke six integration tests that encoded synchronous delivery.** They now drain via a new `OutboxDrain.DrainAsync` helper, which loops until a pass makes no progress — one cycle claims at most `OutboxBatchSize`, the suite shares one database so other tests' rows sit ahead in `CreatedOnUtc` order, and `TenantSubscribed → InvoiceIssued` needs a cycle each. A single `DispatchAsync` passed in isolation and failed in the full suite.
+
+Phase 4 landed without the feared fallout: the whole integration suite stayed green on the first run after connection sharing.
 
 Phase 1 exit criteria met 2026-08-07: build 0 warnings, 1040 unit tests green,
 737 integration tests green (1 pre-existing skip). Phase 6's `eventing.md` update


### PR DESCRIPTION
Completes the outbox redesign started in #1353. That PR made the outbox usable by more than one module (the defect reported in #1349); this one makes it correct on every deployment topology, safe to scale, and actually transactional — Phases 2–6 of `superpowers/plans/2026-08-06-framework-owned-transactional-outbox.md`.

## Phase 2 — every tenant's outbox gets dispatched

`BaseDbContext` swaps to the tenant's connection string, so a tenant with a dedicated database had its outbox rows written *there*, while the dispatcher ran with no tenant context and polled the default connection. Those events were never delivered. Pre-existing, and it affected Identity today.

The dispatcher now asks `IEventingDrainTargetProvider` which databases to drain and runs one pass per target inside `IEventingDrainScope`, which installs the tenant context **before** the scope builds its `EventingDbContext` — that context captures `TenantInfo`, and with it the connection string, at construction. The multitenancy module supplies the default database plus one target per distinct **active** per-tenant connection string; tenants sharing a database collapse to a single pass, since outbox rows are global entities with an explicit `TenantId`. One unreachable tenant database is logged and skipped rather than stalling the cycle. Single-database deployments are unchanged.

## Phase 3 — multi-instance safety

There was no row-level claim, so two API instances draining concurrently both published every message. `ClaimBatchAsync` now leases rows with `FOR UPDATE SKIP LOCKED` in one `UPDATE … RETURNING`, so instances partition a batch.

The claim also honours `NextRetryAt` — dropping it would have quietly undone the backoff from #1336. The lease is an expiry (`OutboxClaimLeaseSeconds`, default 300) so a dispatcher that dies mid-batch has its rows recovered, not stranded; completing or failing a message releases it, or a retryable row would stay invisible until the lease ran out. Providers without `SKIP LOCKED` fall back to the old unclaimed read and log that only one instance is safe.

## Phase 4 — the outbox write is finally transactional

Flagged in the plan as the highest-risk phase. `IScopedDbConnectionProvider` gives every DbContext in a DI scope the same `DbConnection` — the only way EF Core can enlist a second context in a transaction another one opened, since Npgsql has no distributed-transaction promotion. Connections are handed over unopened and un-owned, so EF keeps its usual open/close behaviour and pooling is unaffected.

`BaseDbContext.OnConfiguring` routes tenant connection strings through the same provider; missing that would have made per-tenant databases the one topology that silently lost atomicity. `AmbientDbTransactionRegistry` exists because `DbConnection` cannot be asked whether a transaction is open on it — it is an `IDbTransactionInterceptor` on every Hero context. `AddAsync` joins the ambient transaction when there is one and behaves exactly as before when there isn't.

**This changes connection lifetime for every context in the application**, so the real gate was the whole integration suite, not the five new tests. It went green on the first run.

## Phase 5 — seven of eight direct bus publishes moved onto the outbox

`eventing.md` has claimed since it was written that the outbox is the only way to publish; eight call sites published straight to `IEventBus`, so those events were neither durable nor transactional. Billing invoice issuance (×2), Files finalize-upload, Multitenancy create/renew/expiry-notice and Identity user-registered are now outbox-backed.

**Chat mentions deliberately stay on the bus**, with the reason at the call site. The Notifications handler writes the row *and* pushes it over SignalR; a mention landing in the bell a dispatch cycle after the message appears in the channel reads as broken, and durability matters least there — the message itself is persisted and visible, so a lost notification costs a badge, not data. Phase 5 sanctions a documented exception; this is the only one.

Modules can't reference the eventing runtime (`IOutboxStore` lives there and would drag EF Core into every module), so **`IOutboxWriter`** is new in `Eventing.Abstractions` as the publish-side contract, with `IOutboxStore` extending it. A module depends on abstractions only, exactly as it did with `IEventBus`.

### Behaviour change worth reading

These seven flows are now **asynchronous** — the consumer runs on the next dispatch cycle, not inside the request. Creating a tenant returns before its subscription and invoice exist. Tune `OutboxDispatchIntervalSeconds` (default 10) if that window matters.

Six integration tests encoded the old synchronous timing and now drain explicitly via a new `OutboxDrain.DrainAsync`, which loops until a pass makes no progress: one cycle claims at most `OutboxBatchSize`, the suite shares one database so unrelated tests' rows sit ahead in `CreatedOnUtc` order, and `TenantSubscribed → InvoiceIssued` needs a cycle each. A single `DispatchAsync` passed in isolation and failed in the full suite — worth knowing before writing the next outbox-dependent test.

## Phase 6 — docs

`.agents/rules/eventing.md`, `add-module`, `add-integration-event` and the `code-reviewer` workflow updated: inject `IOutboxWriter`, publishing needs no module registration, delivery is asynchronous, and the Chat exception is named. The docs-site repo has a matching commit (eventing building block, modular-monolith page, five changelog entries) — **committed locally, not pushed**, per the plan.

## Tests

New: 3 dispatcher-loop tests (including one unreachable target), 2 drain-target provider tests, 1 claim-index model test, 4 claim integration tests against real Postgres (concurrent claims never overlap and together take all 50 rows; a live lease hides rows; an expired lease is reclaimable; completing releases), 5 atomicity integration tests (shared connection; rollback takes the outbox row; commit keeps both; no-transaction still commits; a later write is not blocked by the stale handle).

**Green:** build 0 warnings · **1053 unit** · **747 integration** (1 pre-existing skip).

## Not done

`EventingOptions.OutboxClaimLeaseSeconds = 300` is the plan's guess, not a measured value — if a batch of 100 events can take longer than five minutes to publish, raise it or a second instance re-claims rows still in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
