### PR TITLE
feat(localization): request localization, localized errors and user locale (1/4)

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -81,8 +81,9 @@ In `src/BuildingBlocks/Web/Extensions.cs` (`UseHeroPlatform`):
 2. **CORS before HTTPS redirect** (so OPTIONS preflight isn't 307-redirected)
 3. HttpsRedirection → SecurityHeaders → static files → Routing
 4. **`UseAuthentication`**
-5. **`UseModuleMiddlewares`** — each module's `ConfigureMiddleware`, runs **after** auth
-6. RateLimiting → Quotas → `UseAuthorization` → `MapModules`
+5. **`UseHeroLocalization`** — request localization, sits **between `UseAuthentication` and `UseAuthorization`** so the user-`locale`-claim culture provider can read `HttpContext.User`
+6. **`UseModuleMiddlewares`** — each module's `ConfigureMiddleware`, runs **after** auth
+7. RateLimiting → Quotas → `UseAuthorization` → `MapModules`
 
 `app.UseHeroMultiTenantDatabases()` (Finbuckle `UseMultiTenant()`) runs in `Program.cs` **before** `UseHeroPlatform`, i.e. **before `UseAuthentication`** — so tenant resolution is header-driven, not claim-driven. See `modules/multitenancy.md`.
 

--- a/.agents/rules/localization.md
+++ b/.agents/rules/localization.md
@@ -1,0 +1,77 @@
+# Localization (i18n)
+
+`src/BuildingBlocks/Core/Localization/` + per-module `Localization/` folders. Read before adding any user-facing message (exception, validation, API error). **The client's culture decides which words the client reads; it never decides how the API formats numbers or dates.**
+
+## Culture negotiation (already wired — don't re-add)
+
+`AddHeroLocalization()` / `UseHeroLocalization()` (`BuildingBlocks/Web/Localization/`) negotiate the request **UI** culture in this order: `?culture=` query → `locale` JWT claim (`UserLocaleRequestCultureProvider`) → `Accept-Language` → configured default → `en-US`. Supported tags live in `SupportedCultures.Tags`. The culture is set before endpoints and the exception handler run, so any `IStringLocalizer` resolved downstream picks up the request culture automatically.
+
+**`CultureInfo.CurrentUICulture` only — `CurrentCulture` stays invariant.** An API that emits JSON must not shift `ToString()`, `Parse()` or interpolation per request; both React apps format at the presentation layer. `RequestLocalizationMiddleware` assigns both cultures unconditionally, so the culture half is pinned rather than left alone: `DefaultRequestCulture` carries `(InvariantCulture, configured default)` and `SupportedCultures` is `null` so the middleware skips culture filtering. Do **not** "fix" this by adding `AddSupportedCultures(...)`; `Formatting_culture_stays_invariant_while_ui_culture_negotiates` fails if you do.
+
+`SupportedCultures.Tags` is **specific tags only**, no neutrals. A request asking for a bare `pt`, or for an unsupported variant like `pt-PT`, resolves to the configured default rather than being served a language it was not translated into. The React apps canonicalize variants onto supported tags (`CANON` in `clients/*/src/i18n.ts`) before calling the API, so app traffic is unaffected; a hand-rolled client sending bare `pt` gets the default. Adding a language means: add its specific tag to `Tags`, add a `*.{tag}.resx` per catalog, add its JSON catalogs to both apps, and remove it from `CANON` if it was being folded into another tag.
+
+## Catalogs — hybrid, one marker per catalog
+
+- **Core (`SharedResources`)** — generic / cross-cutting messages: ProblemDetails titles (`Error.*`), cross-module errors (`Error.TenantContextRequired`, `Error.NoCurrentUser`, …), and shared validation (`Validation.*`).
+- **Per module (`<Module>Resources`)** — domain-specific messages owned by the module: `src/Modules/<Module>/Modules.<Module>/Localization/<Module>Resources.cs` (marker `public sealed class <Module>Resources;`) + co-located `<Module>Resources.resx` (neutral / en-US) + `<Module>Resources.pt-BR.resx`. `ResourcesPath = ""` (co-located), so the resx manifest name must equal the marker's full type name.
+
+Catalogs are named for **specific** cultures (`.pt-BR`, never a neutral `.pt`), matching the front-end catalog folders. The neutral, un-suffixed `.resx` is the en-US / ultimate-fallback catalog.
+
+Key naming: `Error.<Module>.<Case>` for domain messages (`Catalog.ProductNotFound`), `Error.<CrossCutting>` / `Validation.<Case>` for Core. PascalCase. Placeholders are `{0}`, `{1}` (`string.Format` via the localizer) — **not** the frontend's `{{name}}`.
+
+**Placeholder arguments must be culture-insensitive.** The localizer's indexer calls `string.Format` under `CurrentCulture`, which is invariant (above). Pass `int`/`long`/`string`/enum — never a `double`, `decimal`, `DateTime` or `TimeSpan.TotalX`, which would render with an invariant separator instead of the reader's. Where a count is conceptually whole, expose it as an `int` at the source rather than converting at the call site (see `GetAuditsQueryHandler.MaxWindowDays` next to `MaxWindow`). Money and dates belong in structured response fields formatted by the client, not interpolated into a message.
+
+## Exceptions — localize at the boundary, log stays English
+
+Throw with the **English message** as `Exception.Message` (used for logs and fallback) plus the resource key metadata. **Never** pre-localize the message at the throw site.
+
+```csharp
+// domain message -> module catalog
+throw new NotFoundException($"Product {id} not found.")
+{
+    MessageKey = "Catalog.ProductNotFound",
+    MessageArgs = [id],
+    ResourceSource = typeof(CatalogResources),
+};
+
+// cross-cutting message -> Core catalog (ResourceSource omitted = SharedResources)
+throw new UnauthorizedException("Tenant context is required.")
+{
+    MessageKey = "Error.TenantContextRequired",
+};
+```
+
+`GlobalExceptionHandler` resolves `Title` (by status) and `Detail` (via `MessageKey` + `ResourceSource`) under the request culture, and falls back to `Exception.Message` when the key is missing (`ResourceNotFound`) or malformed (`FormatException`). Migration is therefore incremental: an un-migrated `throw new NotFoundException("...")` still renders its English literal.
+
+**Do NOT** set `ProblemDetails` from a localized string in logs — the handler logs `Exception.Message` (English) and the type name, never the translated body.
+
+## Validators — inject the localizer, defer resolution
+
+```csharp
+public sealed class XCommandValidator : AbstractValidator<XCommand>
+{
+    public XCommandValidator(IStringLocalizer<SharedResources> localizer)
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage(_ => localizer["Validation.NameRequired"]);
+    }
+}
+```
+
+Always the `.WithMessage(_ => localizer["Key"])` lambda (resolution is deferred to `Validate()`, under the request culture) — never `.WithMessage(localizer["Key"])`. **Catalog choice:** inject `IStringLocalizer<SharedResources>` for genuinely shared/generic validation (`Validation.*` already in Core, reuse them), or `IStringLocalizer<<Module>Resources>` for module-specific validation messages kept in the module's own catalog. DI provides the localizer automatically (`AddValidatorsFromAssembly` + `AddHeroLocalization` + the module's own `AddLocalization`); nested validators (`Include(new PagedQueryValidator<T>(localizer))`) receive it from the parent.
+
+## Known behaviour (documented, not bugs)
+
+- **The `locale` claim lags a language switch by one token.** The culture provider reads the JWT `locale` claim, so a switch does not reach the API until the next token issue. The front-end persists the choice to the profile and re-mints, so it converges; in the window between, the shell can be in the new language while an API error still comes back in the old one. Deliberate: the alternative is a per-request DB read on every authenticated call.
+- **Impersonation carries the operator's language, not the target's.** `StartImpersonationCommandHandler` strips the target's `locale` claim so the operator keeps reading in their own language, and the cross-app handoff URL carries `locale` because the dashboard is normally on a different origin and cannot read admin's `i18nextLng`. During impersonation the switcher is client-side only — it must not PUT onto the impersonated user's profile.
+- **SignalR does not carry the app locale.** The hub client builds its own requests instead of going through `apiFetch`, so `Accept-Language` on the negotiate is the browser's. Applies to every session. `handoff-locale.spec.ts` names the exception explicitly so any *other* channel that stops carrying the locale fails the test.
+
+## Tests (required with every catalog change)
+
+- **Parity** — every key present in both the neutral and the `pt-BR` catalog, for Core and every `<Module>Resources`. Per-catalog tests live in each module's test project; `CatalogParityTests` in `Architecture.Tests` enumerates every module catalog generically, so a **new** module catalog is covered without adding a test.
+- **Code → resx guard** — every referenced key (`MessageKey`, `localizer["…"]`) must exist in its catalog, or the build fails. This is what catches a forgotten/typo `ResourceSource` (which would otherwise fall back silently).
+- Build validators/handlers with a real localizer from the embedded catalog via `SharedResourcesLocalizerFactory.Create()` (test-project `Support/` helper), not a stub.
+
+## Emails / background handlers
+
+Integration-event handlers run without an HTTP request, so there is no negotiated culture. Localizing outbound emails needs the recipient's stored locale propagated to the handler — **not yet implemented** (tracked for a future PR); email bodies stay English for now.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Single long-lived branch: **`main`** (the default) — there is **no `develop`**
 | CORS, security headers, rate limiting, idempotency, quotas | `security.md` |
 | SignalR / SSE backend | `realtime.md` |
 | Logging, correlation, OpenTelemetry | `logging.md` |
+| Localization (i18n), request culture, resource catalogs, localized exceptions | `localization.md` |
 | Unit test conventions, NetArchTest | `testing.md` |
 | Integration tests (Testcontainers harness + gotchas) | `integration-testing.md` |
 | **Modifying `src/BuildingBlocks`** (read first — it's protected) | `buildingblocks-protection.md` |

--- a/src/BuildingBlocks/Core/Core.csproj
+++ b/src/BuildingBlocks/Core/Core.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
 	    <RootNamespace>FSH.Framework.Core</RootNamespace>
 	    <AssemblyName>FSH.Framework.Core</AssemblyName>
+	    <!-- SharedResources is an intentional empty localizer marker (see Localization/SharedResources.cs). -->
+	    <NoWarn>$(NoWarn);S2094</NoWarn>
     </PropertyGroup>
 
 	<ItemGroup>

--- a/src/BuildingBlocks/Core/Exceptions/CustomException.cs
+++ b/src/BuildingBlocks/Core/Exceptions/CustomException.cs
@@ -7,7 +7,7 @@ namespace FSH.Framework.Core.Exceptions;
 /// FullStackHero exception used for consistent error handling across the stack.
 /// Includes HTTP status codes and optional detailed error messages.
 /// </summary>
-public class CustomException : Exception
+public class CustomException : Exception, ILocalizableMessage
 {
     /// <summary>
     /// A list of error messages (e.g., validation errors, business rules).
@@ -18,6 +18,24 @@ public class CustomException : Exception
     /// The HTTP status code associated with this exception.
     /// </summary>
     public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Optional resource key resolved against <see cref="ResourceSource"/> to localize the
+    /// response body under the request culture. When null, the literal <see cref="Exception.Message"/>
+    /// is used. The message itself always stays the (English) fallback for logs.
+    /// </summary>
+    public string? MessageKey { get; init; }
+
+    /// <summary>
+    /// Format arguments applied to the localized message ({0}, {1}, …).
+    /// </summary>
+    public IReadOnlyList<object> MessageArgs { get; init; } = [];
+
+    /// <summary>
+    /// Marker type identifying the resource catalog for <see cref="MessageKey"/>. When null,
+    /// the shared (Core) catalog is used; module-specific keys point it at the module's own catalog.
+    /// </summary>
+    public Type? ResourceSource { get; init; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomException"/> class with default message and internal server error status.

--- a/src/BuildingBlocks/Core/Exceptions/ForbiddenException.cs
+++ b/src/BuildingBlocks/Core/Exceptions/ForbiddenException.cs
@@ -12,6 +12,7 @@ public class ForbiddenException : CustomException
     public ForbiddenException()
         : base("Unauthorized access.", Array.Empty<string>(), HttpStatusCode.Forbidden)
     {
+        MessageKey = "Error.ForbiddenAccess";
     }
 
     /// <summary>

--- a/src/BuildingBlocks/Core/Exceptions/ILocalizableMessage.cs
+++ b/src/BuildingBlocks/Core/Exceptions/ILocalizableMessage.cs
@@ -1,0 +1,20 @@
+namespace FSH.Framework.Core.Exceptions;
+
+/// <summary>
+/// Implemented by exceptions whose response Detail can be localized from a resource key.
+/// Lets <c>GlobalExceptionHandler</c> translate the body under the request culture while the
+/// exception type stays intact — needed for BCL types the audit severity classifier keys off
+/// (e.g. <see cref="UnauthorizedAccessException"/>, <see cref="KeyNotFoundException"/>).
+/// The <see cref="Exception.Message"/> stays the English fallback for logs and unresolved keys.
+/// </summary>
+public interface ILocalizableMessage
+{
+    /// <summary>Resource key resolved against <see cref="ResourceSource"/>; null keeps the literal message.</summary>
+    string? MessageKey { get; }
+
+    /// <summary>Format arguments applied to the localized message ({0}, {1}, …).</summary>
+    IReadOnlyList<object> MessageArgs { get; }
+
+    /// <summary>Marker type identifying the resource catalog; null uses the shared (Core) catalog.</summary>
+    Type? ResourceSource { get; }
+}

--- a/src/BuildingBlocks/Core/Exceptions/LocalizedKeyNotFoundException.cs
+++ b/src/BuildingBlocks/Core/Exceptions/LocalizedKeyNotFoundException.cs
@@ -1,0 +1,28 @@
+namespace FSH.Framework.Core.Exceptions;
+
+/// <summary>
+/// <see cref="KeyNotFoundException"/> whose 404 response Detail is localized via <see cref="MessageKey"/>.
+/// Subclasses the BCL type on purpose so audit exception-type fixtures and severity classification that
+/// key off <see cref="KeyNotFoundException"/> keep working, while the body still translates under the
+/// request culture. The base message stays the English log fallback.
+/// </summary>
+public sealed class LocalizedKeyNotFoundException : KeyNotFoundException, ILocalizableMessage
+{
+    public string? MessageKey { get; init; }
+    public IReadOnlyList<object> MessageArgs { get; init; } = [];
+    public Type? ResourceSource { get; init; }
+
+    public LocalizedKeyNotFoundException()
+    {
+    }
+
+    public LocalizedKeyNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public LocalizedKeyNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/BuildingBlocks/Core/Exceptions/LocalizedUnauthorizedAccessException.cs
+++ b/src/BuildingBlocks/Core/Exceptions/LocalizedUnauthorizedAccessException.cs
@@ -1,0 +1,28 @@
+namespace FSH.Framework.Core.Exceptions;
+
+/// <summary>
+/// <see cref="UnauthorizedAccessException"/> whose 401 response Detail is localized via
+/// <see cref="MessageKey"/>. Subclasses the BCL type on purpose so the audit severity classifier
+/// (which maps <see cref="UnauthorizedAccessException"/> to Warning) keeps working, while the body
+/// still translates under the request culture. The base message stays the English log fallback.
+/// </summary>
+public sealed class LocalizedUnauthorizedAccessException : UnauthorizedAccessException, ILocalizableMessage
+{
+    public string? MessageKey { get; init; }
+    public IReadOnlyList<object> MessageArgs { get; init; } = [];
+    public Type? ResourceSource { get; init; }
+
+    public LocalizedUnauthorizedAccessException()
+    {
+    }
+
+    public LocalizedUnauthorizedAccessException(string message)
+        : base(message)
+    {
+    }
+
+    public LocalizedUnauthorizedAccessException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/BuildingBlocks/Core/Exceptions/UnauthorizedException.cs
+++ b/src/BuildingBlocks/Core/Exceptions/UnauthorizedException.cs
@@ -12,6 +12,7 @@ public class UnauthorizedException : CustomException
     public UnauthorizedException()
         : base("Authentication failed.", Array.Empty<string>(), HttpStatusCode.Unauthorized)
     {
+        MessageKey = "Error.AuthenticationFailed";
     }
 
     /// <summary>

--- a/src/BuildingBlocks/Core/Localization/SharedResources.cs
+++ b/src/BuildingBlocks/Core/Localization/SharedResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Framework.Core.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;SharedResources&gt;</c> to the shared resx catalog.</summary>
+public sealed class SharedResources;

--- a/src/BuildingBlocks/Core/Localization/SharedResources.pt-BR.resx
+++ b/src/BuildingBlocks/Core/Localization/SharedResources.pt-BR.resx
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.Validation" xml:space="preserve">
+    <value>Ocorreram um ou mais erros de validação.</value>
+  </data>
+  <data name="Error.Validation.Detail" xml:space="preserve">
+    <value>Ocorreram um ou mais erros de validação.</value>
+  </data>
+  <data name="Error.Unauthorized" xml:space="preserve">
+    <value>Não autorizado</value>
+  </data>
+  <data name="Error.NotFound" xml:space="preserve">
+    <value>Não encontrado</value>
+  </data>
+  <data name="Error.BadRequest" xml:space="preserve">
+    <value>Requisição inválida</value>
+  </data>
+  <data name="Error.Conflict" xml:space="preserve">
+    <value>Conflito</value>
+  </data>
+  <data name="Error.Forbidden" xml:space="preserve">
+    <value>Acesso negado</value>
+  </data>
+  <data name="Error.NoCurrentUser" xml:space="preserve">
+    <value>Nenhum usuário autenticado.</value>
+  </data>
+  <data name="Error.InvalidTenant" xml:space="preserve">
+    <value>Tenant inválido ou ausente.</value>
+  </data>
+  <data name="Error.TenantContextRequired" xml:space="preserve">
+    <value>O contexto do tenant é obrigatório.</value>
+  </data>
+  <data name="Error.Unexpected" xml:space="preserve">
+    <value>Ocorreu um erro inesperado</value>
+  </data>
+  <data name="Error.Unexpected.Detail" xml:space="preserve">
+    <value>Ocorreu um erro inesperado. Tente novamente mais tarde.</value>
+  </data>
+  <data name="Error.AppBoundary" xml:space="preserve">
+    <value>Limite de aplicação</value>
+  </data>
+  <data name="Error.AppBoundary.Detail" xml:space="preserve">
+    <value>Contas de superadministrador devem usar o aplicativo de administração. Entre por lá, não pelo painel da organização.</value>
+  </data>
+  <data name="Error.AuthenticationFailed" xml:space="preserve">
+    <value>Falha na autenticação.</value>
+  </data>
+  <data name="Error.ForbiddenAccess" xml:space="preserve">
+    <value>Acesso não autorizado.</value>
+  </data>
+  <data name="Storage.QuotaExceeded" xml:space="preserve">
+    <value>Cota de armazenamento excedida ({0}/{1} bytes).</value>
+  </data>
+  <data name="Validation.ImpersonationTakeRange" xml:space="preserve">
+    <value>O valor de Take deve estar entre 1 e {0}.</value>
+  </data>
+  <data name="Validation.ImpersonationDurationRange" xml:space="preserve">
+    <value>A duração deve estar entre 1 e {0} minutos.</value>
+  </data>
+  <data name="Validation.AllowedExtensions" xml:space="preserve">
+    <value>Somente estas extensões são permitidas: {0}</value>
+  </data>
+  <data name="Validation.MaxFileSize" xml:space="preserve">
+    <value>O arquivo deve ter no máximo {0} MB.</value>
+  </data>
+  <data name="Jobs.DatabaseOptionsNotFound" xml:space="preserve">
+    <value>Opções de banco de dados não encontradas.</value>
+  </data>
+  <data name="Jobs.UnsupportedStorageProvider" xml:space="preserve">
+    <value>O provedor de armazenamento {0} do Hangfire não é suportado.</value>
+  </data>
+  <data name="Validation.UserIdRequired" xml:space="preserve">
+    <value>O ID do usuário é obrigatório.</value>
+  </data>
+  <data name="Validation.ImageUploadDeleteConflict" xml:space="preserve">
+    <value>Você não pode enviar uma nova imagem e excluir a atual ao mesmo tempo.</value>
+  </data>
+  <data name="Validation.UnsupportedLocale" xml:space="preserve">
+    <value>Idioma não suportado.</value>
+  </data>
+  <data name="Validation.GroupIdRequired" xml:space="preserve">
+    <value>O ID do grupo é obrigatório.</value>
+  </data>
+  <data name="Validation.AtLeastOneUserIdRequired" xml:space="preserve">
+    <value>É necessário pelo menos um ID de usuário.</value>
+  </data>
+  <data name="Validation.UserIdsNotEmptyOrWhitespace" xml:space="preserve">
+    <value>Os IDs de usuário não podem ser vazios ou conter apenas espaços.</value>
+  </data>
+  <data name="Validation.GroupNameRequired" xml:space="preserve">
+    <value>O nome do grupo é obrigatório.</value>
+  </data>
+  <data name="Validation.GroupNameMaxLength" xml:space="preserve">
+    <value>O nome do grupo não pode exceder 256 caracteres.</value>
+  </data>
+  <data name="Validation.DescriptionMaxLength" xml:space="preserve">
+    <value>A descrição não pode exceder 1024 caracteres.</value>
+  </data>
+  <data name="Validation.RoleIdRequired" xml:space="preserve">
+    <value>O ID da função é obrigatório.</value>
+  </data>
+  <data name="Validation.RoleNameRequired" xml:space="preserve">
+    <value>O nome da função é obrigatório.</value>
+  </data>
+  <data name="Validation.PageNumberMinimum" xml:space="preserve">
+    <value>O número da página deve ser maior ou igual a 1.</value>
+  </data>
+  <data name="Validation.PageSizeMinimum" xml:space="preserve">
+    <value>O tamanho da página deve ser maior ou igual a 1.</value>
+  </data>
+  <data name="Validation.PageSizeRange" xml:space="preserve">
+    <value>O tamanho da página deve estar entre 1 e 100.</value>
+  </data>
+  <data name="Validation.SortMaxLength" xml:space="preserve">
+    <value>A expressão de ordenação não pode exceder 200 caracteres.</value>
+  </data>
+  <data name="Validation.SessionIdRequired" xml:space="preserve">
+    <value>O ID da sessão é obrigatório.</value>
+  </data>
+  <data name="Validation.ReasonMaxLength" xml:space="preserve">
+    <value>O motivo não pode exceder 500 caracteres.</value>
+  </data>
+  <data name="Validation.UserRolesRequired" xml:space="preserve">
+    <value>A lista de funções do usuário é obrigatória.</value>
+  </data>
+  <data name="Validation.ConfirmationCodeRequired" xml:space="preserve">
+    <value>O código de confirmação é obrigatório.</value>
+  </data>
+  <data name="Validation.TenantRequired" xml:space="preserve">
+    <value>A organização é obrigatória.</value>
+  </data>
+  <data name="Validation.CurrentPasswordRequired" xml:space="preserve">
+    <value>A senha atual é obrigatória.</value>
+  </data>
+  <data name="Validation.NewPasswordRequired" xml:space="preserve">
+    <value>A nova senha é obrigatória.</value>
+  </data>
+  <data name="Validation.NewPasswordMustDiffer" xml:space="preserve">
+    <value>A nova senha deve ser diferente da senha atual.</value>
+  </data>
+  <data name="Validation.PasswordRecentlyUsed" xml:space="preserve">
+    <value>Esta senha foi usada recentemente. Escolha uma senha diferente.</value>
+  </data>
+  <data name="Validation.PasswordsDoNotMatch" xml:space="preserve">
+    <value>As senhas não coincidem.</value>
+  </data>
+  <data name="Validation.FirstNameRequired" xml:space="preserve">
+    <value>O nome é obrigatório.</value>
+  </data>
+  <data name="Validation.FirstNameMaxLength" xml:space="preserve">
+    <value>O nome não pode exceder 100 caracteres.</value>
+  </data>
+  <data name="Validation.LastNameRequired" xml:space="preserve">
+    <value>O sobrenome é obrigatório.</value>
+  </data>
+  <data name="Validation.LastNameMaxLength" xml:space="preserve">
+    <value>O sobrenome não pode exceder 100 caracteres.</value>
+  </data>
+  <data name="Validation.EmailRequired" xml:space="preserve">
+    <value>O e-mail é obrigatório.</value>
+  </data>
+  <data name="Validation.EmailInvalid" xml:space="preserve">
+    <value>É necessário um endereço de e-mail válido.</value>
+  </data>
+  <data name="Validation.UsernameRequired" xml:space="preserve">
+    <value>O nome de usuário é obrigatório.</value>
+  </data>
+  <data name="Validation.UsernameMinLength" xml:space="preserve">
+    <value>O nome de usuário deve ter pelo menos 3 caracteres.</value>
+  </data>
+  <data name="Validation.UsernameMaxLength" xml:space="preserve">
+    <value>O nome de usuário não pode exceder 50 caracteres.</value>
+  </data>
+  <data name="Validation.PasswordRequired" xml:space="preserve">
+    <value>A senha é obrigatória.</value>
+  </data>
+  <data name="Validation.PasswordMinLength" xml:space="preserve">
+    <value>A senha deve ter pelo menos 6 caracteres.</value>
+  </data>
+  <data name="Validation.PasswordConfirmationRequired" xml:space="preserve">
+    <value>A confirmação de senha é obrigatória.</value>
+  </data>
+  <data name="Validation.PhoneNumberMaxLength" xml:space="preserve">
+    <value>O número de telefone não pode exceder 20 caracteres.</value>
+  </data>
+</root>

--- a/src/BuildingBlocks/Core/Localization/SharedResources.resx
+++ b/src/BuildingBlocks/Core/Localization/SharedResources.resx
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.Validation" xml:space="preserve">
+    <value>One or more validation errors occurred.</value>
+  </data>
+  <data name="Error.Validation.Detail" xml:space="preserve">
+    <value>One or more validation errors occurred.</value>
+  </data>
+  <data name="Error.Unauthorized" xml:space="preserve">
+    <value>Unauthorized</value>
+  </data>
+  <data name="Error.NotFound" xml:space="preserve">
+    <value>Not Found</value>
+  </data>
+  <data name="Error.BadRequest" xml:space="preserve">
+    <value>Bad Request</value>
+  </data>
+  <data name="Error.Conflict" xml:space="preserve">
+    <value>Conflict</value>
+  </data>
+  <data name="Error.Forbidden" xml:space="preserve">
+    <value>Forbidden</value>
+  </data>
+  <data name="Error.NoCurrentUser" xml:space="preserve">
+    <value>No authenticated user.</value>
+  </data>
+  <data name="Error.InvalidTenant" xml:space="preserve">
+    <value>Invalid or missing tenant.</value>
+  </data>
+  <data name="Error.TenantContextRequired" xml:space="preserve">
+    <value>Tenant context is required.</value>
+  </data>
+  <data name="Error.Unexpected" xml:space="preserve">
+    <value>An unexpected error occurred</value>
+  </data>
+  <data name="Error.Unexpected.Detail" xml:space="preserve">
+    <value>An unexpected error occurred. Please try again later.</value>
+  </data>
+  <data name="Error.AppBoundary" xml:space="preserve">
+    <value>App boundary</value>
+  </data>
+  <data name="Error.AppBoundary.Detail" xml:space="preserve">
+    <value>SuperAdmin accounts must use the admin app. Sign in there instead of the tenant dashboard.</value>
+  </data>
+  <data name="Error.AuthenticationFailed" xml:space="preserve">
+    <value>Authentication failed.</value>
+  </data>
+  <data name="Error.ForbiddenAccess" xml:space="preserve">
+    <value>Unauthorized access.</value>
+  </data>
+  <data name="Storage.QuotaExceeded" xml:space="preserve">
+    <value>Storage quota exceeded ({0}/{1} bytes).</value>
+  </data>
+  <data name="Validation.ImpersonationTakeRange" xml:space="preserve">
+    <value>Take must be between 1 and {0}.</value>
+  </data>
+  <data name="Validation.ImpersonationDurationRange" xml:space="preserve">
+    <value>Duration must be between 1 and {0} minutes.</value>
+  </data>
+  <data name="Validation.AllowedExtensions" xml:space="preserve">
+    <value>Only these extensions are allowed: {0}</value>
+  </data>
+  <data name="Validation.MaxFileSize" xml:space="preserve">
+    <value>File must be &lt;= {0} MB.</value>
+  </data>
+  <data name="Jobs.DatabaseOptionsNotFound" xml:space="preserve">
+    <value>Database options not found.</value>
+  </data>
+  <data name="Jobs.UnsupportedStorageProvider" xml:space="preserve">
+    <value>Hangfire storage provider {0} is not supported.</value>
+  </data>
+  <data name="Validation.UserIdRequired" xml:space="preserve">
+    <value>User ID is required.</value>
+  </data>
+  <data name="Validation.ImageUploadDeleteConflict" xml:space="preserve">
+    <value>You cannot upload a new image and delete the current one simultaneously.</value>
+  </data>
+  <data name="Validation.UnsupportedLocale" xml:space="preserve">
+    <value>Unsupported locale.</value>
+  </data>
+  <data name="Validation.GroupIdRequired" xml:space="preserve">
+    <value>Group ID is required.</value>
+  </data>
+  <data name="Validation.AtLeastOneUserIdRequired" xml:space="preserve">
+    <value>At least one user ID is required.</value>
+  </data>
+  <data name="Validation.UserIdsNotEmptyOrWhitespace" xml:space="preserve">
+    <value>User IDs cannot be empty or whitespace.</value>
+  </data>
+  <data name="Validation.GroupNameRequired" xml:space="preserve">
+    <value>Group name is required.</value>
+  </data>
+  <data name="Validation.GroupNameMaxLength" xml:space="preserve">
+    <value>Group name must not exceed 256 characters.</value>
+  </data>
+  <data name="Validation.DescriptionMaxLength" xml:space="preserve">
+    <value>Description must not exceed 1024 characters.</value>
+  </data>
+  <data name="Validation.RoleIdRequired" xml:space="preserve">
+    <value>Role ID is required.</value>
+  </data>
+  <data name="Validation.RoleNameRequired" xml:space="preserve">
+    <value>Role name is required.</value>
+  </data>
+  <data name="Validation.PageNumberMinimum" xml:space="preserve">
+    <value>Page number must be greater than or equal to 1.</value>
+  </data>
+  <data name="Validation.PageSizeMinimum" xml:space="preserve">
+    <value>Page size must be greater than or equal to 1.</value>
+  </data>
+  <data name="Validation.PageSizeRange" xml:space="preserve">
+    <value>Page size must be between 1 and 100.</value>
+  </data>
+  <data name="Validation.SortMaxLength" xml:space="preserve">
+    <value>Sort expression must not exceed 200 characters.</value>
+  </data>
+  <data name="Validation.SessionIdRequired" xml:space="preserve">
+    <value>Session ID is required.</value>
+  </data>
+  <data name="Validation.ReasonMaxLength" xml:space="preserve">
+    <value>Reason must not exceed 500 characters.</value>
+  </data>
+  <data name="Validation.UserRolesRequired" xml:space="preserve">
+    <value>User roles list is required.</value>
+  </data>
+  <data name="Validation.ConfirmationCodeRequired" xml:space="preserve">
+    <value>Confirmation code is required.</value>
+  </data>
+  <data name="Validation.TenantRequired" xml:space="preserve">
+    <value>Tenant is required.</value>
+  </data>
+  <data name="Validation.CurrentPasswordRequired" xml:space="preserve">
+    <value>Current password is required.</value>
+  </data>
+  <data name="Validation.NewPasswordRequired" xml:space="preserve">
+    <value>New password is required.</value>
+  </data>
+  <data name="Validation.NewPasswordMustDiffer" xml:space="preserve">
+    <value>New password must be different from the current password.</value>
+  </data>
+  <data name="Validation.PasswordRecentlyUsed" xml:space="preserve">
+    <value>This password has been used recently. Please choose a different password.</value>
+  </data>
+  <data name="Validation.PasswordsDoNotMatch" xml:space="preserve">
+    <value>Passwords do not match.</value>
+  </data>
+  <data name="Validation.FirstNameRequired" xml:space="preserve">
+    <value>First name is required.</value>
+  </data>
+  <data name="Validation.FirstNameMaxLength" xml:space="preserve">
+    <value>First name must not exceed 100 characters.</value>
+  </data>
+  <data name="Validation.LastNameRequired" xml:space="preserve">
+    <value>Last name is required.</value>
+  </data>
+  <data name="Validation.LastNameMaxLength" xml:space="preserve">
+    <value>Last name must not exceed 100 characters.</value>
+  </data>
+  <data name="Validation.EmailRequired" xml:space="preserve">
+    <value>Email is required.</value>
+  </data>
+  <data name="Validation.EmailInvalid" xml:space="preserve">
+    <value>A valid email address is required.</value>
+  </data>
+  <data name="Validation.UsernameRequired" xml:space="preserve">
+    <value>Username is required.</value>
+  </data>
+  <data name="Validation.UsernameMinLength" xml:space="preserve">
+    <value>Username must be at least 3 characters.</value>
+  </data>
+  <data name="Validation.UsernameMaxLength" xml:space="preserve">
+    <value>Username must not exceed 50 characters.</value>
+  </data>
+  <data name="Validation.PasswordRequired" xml:space="preserve">
+    <value>Password is required.</value>
+  </data>
+  <data name="Validation.PasswordMinLength" xml:space="preserve">
+    <value>Password must be at least 6 characters.</value>
+  </data>
+  <data name="Validation.PasswordConfirmationRequired" xml:space="preserve">
+    <value>Password confirmation is required.</value>
+  </data>
+  <data name="Validation.PhoneNumberMaxLength" xml:space="preserve">
+    <value>Phone number must not exceed 20 characters.</value>
+  </data>
+</root>

--- a/src/BuildingBlocks/Core/Localization/SupportedCultures.cs
+++ b/src/BuildingBlocks/Core/Localization/SupportedCultures.cs
@@ -1,0 +1,18 @@
+namespace FSH.Framework.Core.Localization;
+
+/// <summary>Canonical set of cultures the platform supports for user-facing localization.</summary>
+public static class SupportedCultures
+{
+    /// <summary>Guaranteed ultimate fallback culture, served by the neutral (un-suffixed) catalog.</summary>
+    public const string Default = "en-US";
+
+    /// <summary>
+    /// Specific tags a user may persist, the switcher offers, and Accept-Language is matched against.
+    /// Deliberately specific-only, with no neutral entries: every catalog is named for a specific
+    /// culture (<c>*.pt-BR.resx</c>), matching the front-end catalogs. A request asking for a bare
+    /// <c>pt</c>, or for an unsupported variant like <c>pt-PT</c>, therefore resolves to
+    /// <see cref="Default"/> rather than being silently served Brazilian strings. Adding a language
+    /// means adding its specific tag here plus a <c>*.{tag}.resx</c> per catalog.
+    /// </summary>
+    public static readonly string[] Tags = ["en-US", "pt-BR"];
+}

--- a/src/BuildingBlocks/Jobs/Extensions.cs
+++ b/src/BuildingBlocks/Jobs/Extensions.cs
@@ -32,7 +32,10 @@ public static class Extensions
         {
             var configuration = provider.GetRequiredService<IConfiguration>();
             var dbOptions = configuration.GetSection(nameof(DatabaseOptions)).Get<DatabaseOptions>()
-                ?? throw new CustomException("Database options not found");
+                ?? throw new CustomException("Database options not found")
+                {
+                    MessageKey = "Jobs.DatabaseOptionsNotFound",
+                };
 
             switch (dbOptions.Provider.ToUpperInvariant())
             {
@@ -48,7 +51,11 @@ public static class Extensions
                     break;
 
                 default:
-                    throw new CustomException($"Hangfire storage provider {dbOptions.Provider} is not supported");
+                    throw new CustomException($"Hangfire storage provider {dbOptions.Provider} is not supported")
+                    {
+                        MessageKey = "Jobs.UnsupportedStorageProvider",
+                        MessageArgs = [dbOptions.Provider],
+                    };
             }
 
             config.UseActivator(new FshJobActivator(provider.GetRequiredService<IServiceScopeFactory>()));

--- a/src/BuildingBlocks/Storage/QuotaMeteredStorageService.cs
+++ b/src/BuildingBlocks/Storage/QuotaMeteredStorageService.cs
@@ -69,7 +69,11 @@ internal sealed class QuotaMeteredStorageService : IStorageService
             throw new CustomException(
                 $"Storage quota exceeded ({check.CurrentUsage}/{check.Limit} bytes).",
                 errors: null,
-                HttpStatusCode.InsufficientStorage);
+                HttpStatusCode.InsufficientStorage)
+            {
+                MessageKey = "Storage.QuotaExceeded",
+                MessageArgs = [check.CurrentUsage, check.Limit],
+            };
         }
 
         try

--- a/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
+++ b/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
 using System;
+using System.Globalization;
 using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Core.Localization;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -73,11 +75,44 @@ public class GlobalExceptionHandler(
         }
     }
 
+    // UseExceptionHandler sits ABOVE UseHeroLocalization in the pipeline, and
+    // RequestLocalizationMiddleware assigns CultureInfo.CurrentUICulture inside its own async frame —
+    // an assignment that belongs to that frame's ExecutionContext and is already gone by the time an
+    // exception unwinds up to this handler. Every localizer below would therefore resolve under the
+    // culture of the host process (the invariant one in a container with no LANG), and answer from the
+    // neutral resx no matter what the client asked for. The negotiated culture survives on the request
+    // itself, so take it from there and restore the ambient one afterwards.
+    //
+    // CurrentUICulture only: AddHeroLocalization pins CurrentCulture to invariant on purpose, so that
+    // no request can shift numeric or date formatting anywhere in the pipeline.
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
         ArgumentNullException.ThrowIfNull(exception);
 
+        var requestUiCulture = httpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.UICulture;
+
+        // No feature means the exception escaped before localization ran (CORS, security headers,
+        // forwarded headers). Nothing was negotiated, so the ambient culture is all there is.
+        if (requestUiCulture is null)
+        {
+            return await WriteProblemDetailsAsync(httpContext, exception, requestUiCulture: null, cancellationToken).ConfigureAwait(false);
+        }
+
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentUICulture = requestUiCulture;
+        try
+        {
+            return await WriteProblemDetailsAsync(httpContext, exception, requestUiCulture, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+
+    private async ValueTask<bool> WriteProblemDetailsAsync(HttpContext httpContext, Exception exception, CultureInfo? requestUiCulture, CancellationToken cancellationToken)
+    {
         var problemDetails = new ProblemDetails
         {
             Instance = httpContext.Request.Path
@@ -164,6 +199,15 @@ public class GlobalExceptionHandler(
         }
 
         httpContext.Response.StatusCode = statusCode;
+
+        // ExceptionHandlerMiddleware clears the response before re-executing, which drops the
+        // Content-Language RequestLocalizationMiddleware had already written. Put it back, so a client
+        // can tell which culture the prose in this body is in. The invariant culture has an empty name
+        // and is not a valid header value.
+        if (requestUiCulture is not null && requestUiCulture.Name.Length > 0)
+        {
+            httpContext.Response.Headers.ContentLanguage = requestUiCulture.Name;
+        }
 
         // Surface trace and correlation IDs so clients/support can correlate errors to traces
         var traceId = Activity.Current?.TraceId.ToString() ?? httpContext.TraceIdentifier;

--- a/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
+++ b/src/BuildingBlocks/Web/Exceptions/GlobalExceptionHandler.cs
@@ -1,16 +1,78 @@
 using System.Diagnostics;
 using System;
+using System.Net;
 using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Core.Localization;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
 
 namespace FSH.Framework.Web.Exceptions;
 
-public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
+public class GlobalExceptionHandler(
+    ILogger<GlobalExceptionHandler> logger,
+    IStringLocalizer<SharedResources> localizer,
+    IStringLocalizerFactory localizerFactory) : IExceptionHandler
 {
+    // Returns null for a status with no title of its own. Deliberately NOT a catch-all
+    // "Error.Unexpected": that key exists, so ResourceNotFound would be false and a 409 would
+    // report "An unexpected error occurred" alongside Status 409 and a Detail describing a
+    // perfectly ordinary business-rule conflict — a title contradicting its own status code.
+    // A null key keeps the pre-localization behaviour (the exception type name) for every
+    // status not translated here, which is at least status-consistent.
+    private static string? TitleKeyFor(HttpStatusCode statusCode) => statusCode switch
+    {
+        HttpStatusCode.NotFound => "Error.NotFound",
+        HttpStatusCode.Unauthorized => "Error.Unauthorized",
+        HttpStatusCode.Forbidden => "Error.Forbidden",
+        HttpStatusCode.BadRequest => "Error.BadRequest",
+        HttpStatusCode.Conflict => "Error.Conflict",
+        _ => null,
+    };
+
+    // Resolves the localized Detail for an exception carrying a MessageKey, under the request culture.
+    // The [key, args] indexer runs string.Format; a stray '{' in the resx would throw FormatException
+    // from inside the handler, so fall back to the (English) message on a format error or a missing key.
+    // A null key keeps the literal message. Shared by the CustomException, Unauthorized and NotFound
+    // branches so a localized BCL subclass (ILocalizableMessage) translates the same way.
+    private string LocalizeDetail(ILocalizableMessage localizable, string fallbackMessage)
+    {
+        if (localizable.MessageKey is null)
+        {
+            return fallbackMessage;
+        }
+
+        var moduleLocalizer = localizerFactory.Create(localizable.ResourceSource ?? typeof(SharedResources));
+        try
+        {
+            var message = localizable.MessageArgs.Count == 0
+                ? moduleLocalizer[localizable.MessageKey]
+                : moduleLocalizer[localizable.MessageKey, localizable.MessageArgs.ToArray()];
+            return message.ResourceNotFound ? fallbackMessage : message.Value;
+        }
+        catch (FormatException)
+        {
+            return fallbackMessage;
+        }
+    }
+
+    // Writes the localized Detail and, when the exception carries a MessageKey, surfaces that key as a
+    // stable machine-readable "code". Detail is prose under the request culture, so a client that needs
+    // to branch on a specific error (a terminal state, a dedicated screen, a retry) keys off the code
+    // instead of matching text that changes with Accept-Language.
+    private void ApplyLocalizedDetail(ProblemDetails problemDetails, ILocalizableMessage localizable, string fallbackMessage)
+    {
+        problemDetails.Detail = LocalizeDetail(localizable, fallbackMessage);
+
+        if (localizable.MessageKey is not null)
+        {
+            problemDetails.Extensions["code"] = localizable.MessageKey;
+        }
+    }
+
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
@@ -28,8 +90,8 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
             statusCode = StatusCodes.Status400BadRequest;
 
             problemDetails.Status = statusCode;
-            problemDetails.Title = "Validation error";
-            problemDetails.Detail = "One or more validation errors occurred.";
+            problemDetails.Title = localizer["Error.Validation"];
+            problemDetails.Detail = localizer["Error.Validation.Detail"];
             problemDetails.Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1";
 
             var errors = fluentException.Errors
@@ -43,10 +105,13 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
         else if (exception is CustomException e)
         {
             statusCode = (int)e.StatusCode;
-
             problemDetails.Status = statusCode;
-            problemDetails.Title = e.GetType().Name;
-            problemDetails.Detail = e.Message;
+
+            var titleKey = TitleKeyFor(e.StatusCode);
+            var title = titleKey is null ? null : localizer[titleKey];
+            problemDetails.Title = title is null || title.ResourceNotFound ? e.GetType().Name : title.Value;
+
+            ApplyLocalizedDetail(problemDetails, e, e.Message);
 
             if (e.ErrorMessages is { Count: > 0 })
             {
@@ -57,15 +122,29 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
         {
             statusCode = StatusCodes.Status401Unauthorized;
             problemDetails.Status = statusCode;
-            problemDetails.Title = "Unauthorized";
-            problemDetails.Detail = exception.Message;
+            problemDetails.Title = localizer["Error.Unauthorized"];
+            if (exception is ILocalizableMessage unauthorizedLoc)
+            {
+                ApplyLocalizedDetail(problemDetails, unauthorizedLoc, exception.Message);
+            }
+            else
+            {
+                problemDetails.Detail = exception.Message;
+            }
         }
         else if (exception is KeyNotFoundException)
         {
             statusCode = StatusCodes.Status404NotFound;
             problemDetails.Status = statusCode;
-            problemDetails.Title = "Not Found";
-            problemDetails.Detail = exception.Message;
+            problemDetails.Title = localizer["Error.NotFound"];
+            if (exception is ILocalizableMessage notFoundLoc)
+            {
+                ApplyLocalizedDetail(problemDetails, notFoundLoc, exception.Message);
+            }
+            else
+            {
+                problemDetails.Detail = exception.Message;
+            }
         }
         else if (exception is BadHttpRequestException badRequest)
         {
@@ -73,15 +152,15 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
             // Client error carrying the correct status (usually 400) — honour it instead of falling through to a generic 500.
             statusCode = badRequest.StatusCode;
             problemDetails.Status = statusCode;
-            problemDetails.Title = "Bad Request";
+            problemDetails.Title = localizer["Error.BadRequest"];
             problemDetails.Detail = badRequest.Message;
         }
         else
         {
             statusCode = StatusCodes.Status500InternalServerError;
             problemDetails.Status = statusCode;
-            problemDetails.Title = "An unexpected error occurred";
-            problemDetails.Detail = "An unexpected error occurred. Please try again later.";
+            problemDetails.Title = localizer["Error.Unexpected"];
+            problemDetails.Detail = localizer["Error.Unexpected.Detail"];
         }
 
         httpContext.Response.StatusCode = statusCode;
@@ -94,12 +173,18 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
             ?? httpContext.TraceIdentifier;
         problemDetails.Extensions["correlationId"] = correlationId;
 
-        LogContext.PushProperty("exception_title", problemDetails.Title);
-        LogContext.PushProperty("exception_detail", problemDetails.Detail);
-        LogContext.PushProperty("exception_statusCode", problemDetails.Status);
-        LogContext.PushProperty("exception_stackTrace", exception.StackTrace);
-
-        logger.LogError("Exception at {Path} - {StatusCode} {Title}", httpContext.Request.Path.Value?.Replace(Environment.NewLine, string.Empty), statusCode, problemDetails.Title);
+        // Log the raw (English) exception message and type, never the localized ProblemDetails body,
+        // so log entries stay culture-independent regardless of the request's negotiated culture.
+        // PushProperty returns an IDisposable that pops the property on dispose; scope it to the LogError
+        // call so it does not leak onto every subsequent log entry of the request (AsyncLocal contamination).
+        var logPath = httpContext.Request.Path.Value?.Replace(Environment.NewLine, string.Empty);
+        using (LogContext.PushProperty("exception_type", exception.GetType().Name))
+        using (LogContext.PushProperty("exception_detail", exception.Message))
+        using (LogContext.PushProperty("exception_statusCode", statusCode))
+        using (LogContext.PushProperty("exception_stackTrace", exception.StackTrace))
+        {
+            logger.LogError("Exception at {Path} - {StatusCode} {Type}", logPath, statusCode, exception.GetType().Name);
+        }
 
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken).ConfigureAwait(false);
         return true;

--- a/src/BuildingBlocks/Web/Extensions.cs
+++ b/src/BuildingBlocks/Web/Extensions.cs
@@ -9,6 +9,7 @@ using FSH.Framework.Web.Cors;
 using FSH.Framework.Web.Exceptions;
 using FSH.Framework.Web.FeatureFlags;
 using FSH.Framework.Web.Idempotency;
+using FSH.Framework.Web.Localization;
 using FSH.Framework.Web.Sse;
 using FSH.Framework.Web.Health;
 using FSH.Framework.Web.Mediator.Behaviors;
@@ -129,6 +130,7 @@ public static class Extensions
             builder.Services.AddHeroQuotas(builder.Configuration);
         }
 
+        builder.Services.AddHeroLocalization(builder.Configuration);
         builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
         builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
         builder.Services.AddProblemDetails();
@@ -184,6 +186,10 @@ public static class Extensions
         }
 
         app.UseAuthentication();
+
+        // Must run after UseAuthentication so the user-locale-claim provider sees HttpContext.User,
+        // and before UseAuthorization/endpoints so the request culture is set for the handlers.
+        app.UseHeroLocalization();
 
         // Let each module register its own middleware (e.g. Auditing registers AuditHttpMiddleware)
         app.UseModuleMiddlewares();

--- a/src/BuildingBlocks/Web/Localization/LocalizationExtensions.cs
+++ b/src/BuildingBlocks/Web/Localization/LocalizationExtensions.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using FSH.Framework.Core.Localization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FSH.Framework.Web.Localization;
+
+public static class LocalizationExtensions
+{
+    /// <summary>
+    /// Registers request localization: resx-backed <c>IStringLocalizer</c> and a UI-culture-provider
+    /// chain of Query → user <c>locale</c> claim → Accept-Language → configured default → en-US.
+    /// The per-deployment default is read from <c>LocalizationOptions:DefaultCulture</c> and validated
+    /// against the whitelist, so garbage config falls back to the guaranteed default culture.
+    /// Negotiation drives <see cref="CultureInfo.CurrentUICulture"/> only —
+    /// <see cref="CultureInfo.CurrentCulture"/> stays invariant, so no request can shift numeric,
+    /// date or string formatting anywhere in the pipeline.
+    /// </summary>
+    public static IServiceCollection AddHeroLocalization(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configured = configuration["LocalizationOptions:DefaultCulture"];
+        var defaultCulture = SupportedCultures.Tags.Contains(configured!) ? configured! : SupportedCultures.Default;
+
+        // ResourcesPath = "" because SharedResources and its resx live in the same folder/namespace
+        // (co-located). A non-empty path would double the prefix and IStringLocalizer would silently
+        // fall back to the raw key. The resx-resolution test guards this value.
+        services.AddLocalization(o => o.ResourcesPath = "");
+
+        services.Configure<RequestLocalizationOptions>(o =>
+        {
+            // UI-culture-only. RequestLocalizationMiddleware.SetCurrentThreadCulture assigns BOTH
+            // CurrentCulture and CurrentUICulture unconditionally, so there is no "leave formatting
+            // alone" switch: the culture half has to be pinned instead. Two things make that work.
+            //   1. DefaultRequestCulture carries the pair, and the middleware resolves the culture half
+            //      as `cultureInfo ??= DefaultRequestCulture.Culture`. Pinning that half to invariant
+            //      makes invariant the only value CurrentCulture can ever take.
+            //   2. SupportedCultures = null makes the middleware skip culture filtering entirely.
+            //      A one-element [InvariantCulture] list would behave the same but log
+            //      `UnsupportedCultures` on EVERY request: the middleware's parent-culture walk bails
+            //      out at the empty culture name, so invariant is unmatchable by design.
+            // An API that emits JSON has no business shifting ToString()/Parse() per request; both
+            // React apps already format at the presentation layer. See #1344 review.
+            o.DefaultRequestCulture = new RequestCulture(CultureInfo.InvariantCulture, new CultureInfo(defaultCulture));
+            o.SupportedCultures = null;
+            o.AddSupportedUICultures(SupportedCultures.Tags);
+            o.ApplyCurrentCultureToResponseHeaders = true;
+
+            // Default order is [Query(0), Cookie(1), AcceptLanguage(2)]. Drop the cookie provider by
+            // type (order-independent, so a framework reshuffle of the defaults can't silently remove
+            // the wrong provider) and insert the user-claim provider right after query, so the final
+            // chain is Query → UserLocaleClaim → AcceptLanguage → configured default → en-US neutral resx.
+            var cookieProvider = o.RequestCultureProviders
+                .FirstOrDefault(p => p is CookieRequestCultureProvider);
+            if (cookieProvider is not null)
+            {
+                o.RequestCultureProviders.Remove(cookieProvider);
+            }
+
+            o.RequestCultureProviders.Insert(1, new UserLocaleRequestCultureProvider());
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseHeroLocalization(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        return app.UseRequestLocalization();
+    }
+}

--- a/src/BuildingBlocks/Web/Localization/UserLocaleRequestCultureProvider.cs
+++ b/src/BuildingBlocks/Web/Localization/UserLocaleRequestCultureProvider.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using FSH.Framework.Core.Localization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+
+namespace FSH.Framework.Web.Localization;
+
+/// <summary>
+/// Resolves the request culture from the authenticated user's <c>locale</c> claim
+/// (mirrors the persisted <c>User.Locale</c>). Sits after the query-string provider and before
+/// the Accept-Language provider: a supported claim wins over the browser header, an unsupported
+/// or absent claim falls through to the next provider.
+/// </summary>
+public sealed class UserLocaleRequestCultureProvider : RequestCultureProvider
+{
+    public override Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var claim = httpContext.User.FindFirstValue("locale");
+        if (IsSupported(claim))
+        {
+            return Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(claim!));
+        }
+
+        return NullProviderCultureResult;
+    }
+
+    private static bool IsSupported(string? tag) =>
+        !string.IsNullOrWhiteSpace(tag) && SupportedCultures.Tags.Contains(tag);
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -143,5 +143,12 @@
          AccessViolation). Transitive pinning is enabled, so this entry alone bumps it.
          Remove once the SignalR backplane package depends on a patched version itself. -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <!-- Pulled transitively by the Testcontainers packages; versions up to 2025.1.0 fail
+         NuGet audit (NU1903, GHSA-q939-rpr3-3284 / CVE-2026-48798: ScpClient recursive
+         download writes outside the target directory), which breaks restore for the whole
+         solution under TreatWarningsAsErrors. Testcontainers 4.11.0 and 4.13.0 both depend
+         on 2025.1.0, so bumping Testcontainers does not help; 2026.0.0 is the first patched
+         release. Remove once Testcontainers depends on a patched version itself. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260720062947_AddUserLocale.Designer.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260720062947_AddUserLocale.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.Modules.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FSH.Starter.Migrations.PostgreSQL.Identity
 {
     [DbContext(typeof(IdentityDbContext))]
-    partial class IdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720062947_AddUserLocale")]
+    partial class AddUserLocale
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,6 +24,78 @@ namespace FSH.Starter.Migrations.PostgreSQL.Identity
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            modelBuilder.Entity("FSH.Framework.Eventing.Inbox.InboxMessage", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("HandlerName")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<DateTime>("ProcessedOnUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("TenantId")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.HasKey("Id", "HandlerName");
+
+                    b.ToTable("InboxMessages", "identity");
+                });
+
+            modelBuilder.Entity("FSH.Framework.Eventing.Outbox.OutboxMessage", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("CorrelationId")
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.Property<DateTime>("CreatedOnUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsDead")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("LastError")
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("NextRetryAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Payload")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("ProcessedOnUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("RetryCount")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TenantId")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("OutboxMessages", "identity");
+                });
 
             modelBuilder.Entity("FSH.Modules.Identity.Domain.FshRole", b =>
                 {

--- a/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260720062947_AddUserLocale.cs
+++ b/src/Host/FSH.Starter.Migrations.PostgreSQL/Identity/20260720062947_AddUserLocale.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FSH.Starter.Migrations.PostgreSQL.Identity
+{
+    /// <inheritdoc />
+    public partial class AddUserLocale : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Locale",
+                schema: "identity",
+                table: "Users",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Locale",
+                schema: "identity",
+                table: "Users");
+        }
+    }
+}

--- a/src/Modules/Identity/Modules.Identity.Contracts/DTOs/UserDto.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/DTOs/UserDto.cs
@@ -22,4 +22,7 @@ public class UserDto
 
     /// <summary>Whether the user has enrolled in TOTP-based two-factor authentication.</summary>
     public bool TwoFactorEnabled { get; set; }
+
+    /// <summary>BCP 47 UI language tag (e.g. "pt-BR"); null resolves to the default culture.</summary>
+    public string? Locale { get; set; }
 }

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserProfileService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserProfileService.cs
@@ -26,7 +26,7 @@ public interface IUserProfileService
     /// <summary>
     /// Updates a user's profile.
     /// </summary>
-    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default);
+    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, string? locale, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets the profile image URL directly (no upload). Used by the presigned-upload flow:

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
@@ -15,7 +15,7 @@ public interface IUserService
     Task ToggleStatusAsync(bool activateUser, string userId, CancellationToken cancellationToken);
     Task<string> GetOrCreateFromPrincipalAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default);
     Task<string> RegisterAsync(string firstName, string lastName, string email, string userName, string password, string confirmPassword, string phoneNumber, string origin, CancellationToken cancellationToken);
-    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default);
+    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, string? locale, CancellationToken cancellationToken = default);
     Task DeleteAsync(string userId, CancellationToken cancellationToken = default);
     Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken);
     Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default);

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/UpdateUser/UpdateUserCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/UpdateUser/UpdateUserCommand.cs
@@ -12,4 +12,5 @@ public class UpdateUserCommand : ICommand<Unit>
     public string? Email { get; set; }
     public FileUploadRequest? Image { get; set; }
     public bool DeleteCurrentImage { get; set; }
+    public string? Locale { get; set; }
 }

--- a/src/Modules/Identity/Modules.Identity/Data/IdentityConfigurations.cs
+++ b/src/Modules/Identity/Modules.Identity/Data/IdentityConfigurations.cs
@@ -19,6 +19,13 @@ public class ApplicationUserConfig : IEntityTypeConfiguration<FshUser>
         builder
             .Property(u => u.ObjectId)
                 .HasMaxLength(256);
+
+        // A BCP-47 tag is short and bounded; 10 covers language-script-region (zh-Hant-TW). Writes are
+        // additionally constrained to SupportedCultures.Tags by UpdateUserCommandValidator, so this is
+        // the storage-level backstop, not the validation.
+        builder
+            .Property(u => u.Locale)
+                .HasMaxLength(10);
     }
 }
 

--- a/src/Modules/Identity/Modules.Identity/Domain/FshUser.cs
+++ b/src/Modules/Identity/Modules.Identity/Domain/FshUser.cs
@@ -15,6 +15,9 @@ public class FshUser : IdentityUser, IHasDomainEvents
     public string? RefreshToken { get; set; }
     public DateTime RefreshTokenExpiryTime { get; set; }
 
+    /// <summary>BCP 47 UI language tag (e.g. "pt-BR"); null resolves to the default culture.</summary>
+    public string? Locale { get; set; }
+
     public string? ObjectId { get; set; }
 
     /// <summary>Timestamp when the user last changed their password</summary>

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandHandler.cs
@@ -6,6 +6,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Impersonation;
 using FSH.Modules.Identity.Contracts.v1.Impersonation.StartImpersonation;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.Extensions.Logging;
 using System.IdentityModel.Tokens.Jwt;
@@ -58,7 +59,10 @@ public sealed class StartImpersonationCommandHandler
 
         var actorUserId = _currentUser.GetUserId().ToString();
         var actorTenantId = _currentUser.GetTenant()
-            ?? throw new UnauthorizedException("missing tenant context");
+            ?? throw new UnauthorizedException("missing tenant context")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         var actorUserName = _currentUser.Name;
 
         // Cross-tenant impersonation requires the actor to be in the root tenant. Tenant admins
@@ -66,7 +70,11 @@ public sealed class StartImpersonationCommandHandler
         if (!string.Equals(actorTenantId, MultitenancyConstants.Root.Id, StringComparison.Ordinal)
             && !string.Equals(actorTenantId, request.TargetTenantId, StringComparison.Ordinal))
         {
-            throw new ForbiddenException("cross-tenant impersonation is restricted to platform operators");
+            throw new ForbiddenException("cross-tenant impersonation is restricted to platform operators")
+            {
+                MessageKey = "Identity.CrossTenantImpersonationRestricted",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Prevent self-impersonation (pointless, confuses the audit trail). Caller error → explicit 4xx,
@@ -74,7 +82,11 @@ public sealed class StartImpersonationCommandHandler
         if (string.Equals(actorUserId, request.TargetUserId, StringComparison.Ordinal)
             && string.Equals(actorTenantId, request.TargetTenantId, StringComparison.Ordinal))
         {
-            throw new CustomException("cannot impersonate yourself", errors: null, System.Net.HttpStatusCode.BadRequest);
+            throw new CustomException("cannot impersonate yourself", errors: null, System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.CannotImpersonateYourself",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Prevent nesting: if the caller is already impersonating, require end-impersonation first.
@@ -85,7 +97,11 @@ public sealed class StartImpersonationCommandHandler
             throw new CustomException(
                 "end current impersonation before starting a new one",
                 errors: null,
-                System.Net.HttpStatusCode.BadRequest);
+                System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.EndImpersonationFirst",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var targetClaimsResult = await _identityService
@@ -93,7 +109,11 @@ public sealed class StartImpersonationCommandHandler
 
         if (targetClaimsResult is null)
         {
-            throw new NotFoundException("target user not found");
+            throw new NotFoundException("target user not found")
+            {
+                MessageKey = "Identity.TargetUserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var (subject, claims) = targetClaimsResult.Value;
@@ -104,7 +124,9 @@ public sealed class StartImpersonationCommandHandler
         // ImpersonationGrant row and the issued JWT share the same jti.
         var jti = Guid.NewGuid().ToString("N");
         var impersonationClaims = claims
-            .Where(c => c.Type != JwtRegisteredClaimNames.Jti)
+            // Drop the target's locale: language is a presentation concern, so the operator reads in
+            // THEIR own language (falls through to Accept-Language), not the impersonated user's.
+            .Where(c => c.Type != JwtRegisteredClaimNames.Jti && c.Type != "locale")
             .Concat(
             [
                 new Claim(JwtRegisteredClaimNames.Jti, jti),

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandHandler.cs
@@ -24,6 +24,7 @@ public sealed class UpdateUserCommandHandler : ICommandHandler<UpdateUserCommand
             command.PhoneNumber ?? string.Empty,
             command.Image!,
             command.DeleteCurrentImage,
+            command.Locale,
             cancellationToken).ConfigureAwait(false);
 
         return Unit.Value;

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandValidator.cs
@@ -1,16 +1,18 @@
-﻿using FluentValidation;
+using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Storage;
 using FSH.Modules.Identity.Contracts.v1.Users.UpdateUser;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.UpdateUser;
 
 public sealed class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
 {
-    public UpdateUserCommandValidator()
+    public UpdateUserCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Id)
             .NotEmpty()
-            .WithMessage("User ID is required.");
+            .WithMessage(_ => localizer["Validation.UserIdRequired"]);
 
         RuleFor(x => x.FirstName)
             .MaximumLength(50)
@@ -31,12 +33,17 @@ public sealed class UpdateUserCommandValidator : AbstractValidator<UpdateUserCom
         When(x => x.Image is not null, () =>
         {
             RuleFor(x => x.Image!)
-                .SetValidator(new UserImageValidator(FileType.Image));
+                .SetValidator(new UserImageValidator(FileType.Image, localizer));
         });
 
         // Prevent deleting and uploading image at the same time
         RuleFor(x => x)
             .Must(x => !(x.DeleteCurrentImage && x.Image is not null))
-            .WithMessage("You cannot upload a new image and delete the current one simultaneously.");
+            .WithMessage(_ => localizer["Validation.ImageUploadDeleteConflict"]);
+
+        RuleFor(x => x.Locale)
+            .Must(l => SupportedCultures.Tags.Contains(l!))
+            .When(x => !string.IsNullOrWhiteSpace(x.Locale))
+            .WithMessage(_ => localizer["Validation.UnsupportedLocale"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/UserImageValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/UserImageValidator.cs
@@ -1,24 +1,26 @@
 ﻿using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Shared.Storage;
 using FSH.Framework.Storage;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users;
 
 public sealed class UserImageValidator : AbstractValidator<FileUploadRequest>
 {
-    public UserImageValidator() : this(FileType.Image) { }
-    public UserImageValidator(FileType fileType)
+    public UserImageValidator(IStringLocalizer<SharedResources> localizer) : this(FileType.Image, localizer) { }
+    public UserImageValidator(FileType fileType, IStringLocalizer<SharedResources> localizer)
     {
         var rules = FileTypeMetadata.GetRules(fileType);
 
         RuleFor(x => x.FileName)
             .NotEmpty()
             .Must(file => rules.AllowedExtensions.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
-            .WithMessage($"Only these extensions are allowed: {string.Join(", ", rules.AllowedExtensions)}");
+            .WithMessage(_ => localizer["Validation.AllowedExtensions", string.Join(", ", rules.AllowedExtensions)]);
 
         RuleFor(x => x.Data)
             .NotEmpty()
             .Must(data => data.Count <= rules.MaxSizeInMB * 1024 * 1024)
-            .WithMessage($"File must be <= {rules.MaxSizeInMB} MB.");
+            .WithMessage(_ => localizer["Validation.MaxFileSize", rules.MaxSizeInMB]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.cs
+++ b/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Identity.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;IdentityResources&gt;</c> to the Identity resx catalog.</summary>
+public sealed class IdentityResources;

--- a/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.pt-BR.resx
+++ b/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.pt-BR.resx
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Identity.GroupNotFound" xml:space="preserve">
+    <value>Grupo com ID '{0}' não encontrado.</value>
+  </data>
+  <data name="Identity.UsersNotFound" xml:space="preserve">
+    <value>Usuários não encontrados: {0}</value>
+  </data>
+  <data name="Identity.GroupNameAlreadyExists" xml:space="preserve">
+    <value>Já existe um grupo com o nome '{0}'.</value>
+  </data>
+  <data name="Identity.RolesNotFoundWithIds" xml:space="preserve">
+    <value>Funções não encontradas: {0}</value>
+  </data>
+  <data name="Identity.SystemGroupsCannotBeDeleted" xml:space="preserve">
+    <value>Grupos do sistema não podem ser excluídos.</value>
+  </data>
+  <data name="Identity.UserNotMemberOfGroup" xml:space="preserve">
+    <value>O usuário '{0}' não é membro do grupo '{1}'.</value>
+  </data>
+  <data name="Identity.CannotRemoveFromDefaultGroup" xml:space="preserve">
+    <value>Usuários não podem ser removidos de um grupo padrão.</value>
+  </data>
+  <data name="Identity.SystemGroupsCannotBeModified" xml:space="preserve">
+    <value>Grupos do sistema não podem ser modificados.</value>
+  </data>
+  <data name="Identity.RoleNotFound" xml:space="preserve">
+    <value>Função não encontrada.</value>
+  </data>
+  <data name="Identity.RolesNotFound" xml:space="preserve">
+    <value>Funções não encontradas.</value>
+  </data>
+  <data name="Identity.SystemRoleCannotBeModified" xml:space="preserve">
+    <value>Funções do sistema não podem ser modificadas.</value>
+  </data>
+  <data name="Identity.CannotRenameToSystemRole" xml:space="preserve">
+    <value>Não é possível renomear uma função para o nome de uma função do sistema.</value>
+  </data>
+  <data name="Identity.CannotCreateWithSystemRoleName" xml:space="preserve">
+    <value>Não é possível criar uma função usando o nome de uma função do sistema.</value>
+  </data>
+  <data name="Identity.SystemRolesCannotBeDeleted" xml:space="preserve">
+    <value>Funções do sistema não podem ser excluídas.</value>
+  </data>
+  <data name="Identity.SystemRolePermissionsManaged" xml:space="preserve">
+    <value>As permissões de funções do sistema são gerenciadas pelo framework e não podem ser modificadas.</value>
+  </data>
+  <data name="Identity.OperationFailed" xml:space="preserve">
+    <value>A operação falhou.</value>
+  </data>
+  <data name="Identity.NotAnImpersonationSession" xml:space="preserve">
+    <value>A sessão atual não é uma sessão de personificação.</value>
+  </data>
+  <data name="Identity.OriginalActorNotFound" xml:space="preserve">
+    <value>Ator original não encontrado.</value>
+  </data>
+  <data name="Identity.ImpersonationGrantNotFound" xml:space="preserve">
+    <value>Concessão de personificação não encontrada.</value>
+  </data>
+  <data name="Identity.CrossTenantImpersonationRestricted" xml:space="preserve">
+    <value>A personificação entre tenants é restrita a operadores da plataforma.</value>
+  </data>
+  <data name="Identity.CannotImpersonateYourself" xml:space="preserve">
+    <value>Não é possível personificar a si mesmo.</value>
+  </data>
+  <data name="Identity.EndImpersonationFirst" xml:space="preserve">
+    <value>Encerre a personificação atual antes de iniciar uma nova.</value>
+  </data>
+  <data name="Identity.TargetUserNotFound" xml:space="preserve">
+    <value>Usuário alvo não encontrado.</value>
+  </data>
+  <data name="Identity.UserNotFound" xml:space="preserve">
+    <value>Usuário não encontrado.</value>
+  </data>
+  <data name="Identity.UserNotFoundById" xml:space="preserve">
+    <value>Usuário {0} não encontrado.</value>
+  </data>
+  <data name="Identity.CurrentPasswordIncorrect" xml:space="preserve">
+    <value>A senha atual está incorreta.</value>
+  </data>
+  <data name="Identity.FailedToGenerateAuthenticatorKey" xml:space="preserve">
+    <value>Falha ao gerar a chave do autenticador.</value>
+  </data>
+  <data name="Identity.AuthenticatorCodeInvalid" xml:space="preserve">
+    <value>O código do autenticador é inválido.</value>
+  </data>
+  <data name="Identity.InvalidRefreshToken" xml:space="preserve">
+    <value>Token de atualização inválido.</value>
+  </data>
+  <data name="Identity.SessionRevoked" xml:space="preserve">
+    <value>A sessão foi revogada.</value>
+  </data>
+  <data name="Identity.AccessTokenSubjectMismatch" xml:space="preserve">
+    <value>O assunto do token de acesso não corresponde.</value>
+  </data>
+  <data name="Identity.TwoFactorRequired" xml:space="preserve">
+    <value>two_factor_required: É necessário um código de autenticador para concluir o login.</value>
+  </data>
+  <data name="Identity.TwoFactorInvalid" xml:space="preserve">
+    <value>two_factor_invalid: O código do autenticador é inválido ou expirou.</value>
+  </data>
+  <data name="Identity.AccountLocked" xml:space="preserve">
+    <value>A conta está temporariamente bloqueada devido a muitas tentativas de login malsucedidas. Tente novamente mais tarde.</value>
+  </data>
+  <data name="Identity.RefreshTokenInvalidOrExpired" xml:space="preserve">
+    <value>O token de atualização é inválido ou expirou.</value>
+  </data>
+  <data name="Identity.UserDeactivated" xml:space="preserve">
+    <value>O usuário está desativado.</value>
+  </data>
+  <data name="Identity.EmailNotConfirmed" xml:space="preserve">
+    <value>E-mail não confirmado.</value>
+  </data>
+  <data name="Identity.TenantDeactivated" xml:space="preserve">
+    <value>O tenant {0} está desativado.</value>
+  </data>
+  <data name="Identity.TenantValidityExpired" xml:space="preserve">
+    <value>A validade do tenant {0} expirou.</value>
+  </data>
+  <data name="Identity.ErrorResettingPassword" xml:space="preserve">
+    <value>Erro ao redefinir a senha.</value>
+  </data>
+  <data name="Identity.FailedToChangePassword" xml:space="preserve">
+    <value>Falha ao alterar a senha.</value>
+  </data>
+  <data name="Identity.UpdateProfileFailed" xml:space="preserve">
+    <value>Falha ao atualizar o perfil.</value>
+  </data>
+  <data name="Identity.UpdateProfileImageFailed" xml:space="preserve">
+    <value>Falha ao atualizar a imagem do perfil.</value>
+  </data>
+  <data name="Identity.EmailConfirmationError" xml:space="preserve">
+    <value>Ocorreu um erro ao confirmar o e-mail.</value>
+  </data>
+  <data name="Identity.EmailConfirmationFailedFor" xml:space="preserve">
+    <value>Ocorreu um erro ao confirmar {0}.</value>
+  </data>
+  <data name="Identity.EmailConfirmationFailedWithErrors" xml:space="preserve">
+    <value>Ocorreu um erro ao confirmar o e-mail de {0}: {1}</value>
+  </data>
+  <data name="Identity.EmailAlreadyConfirmed" xml:space="preserve">
+    <value>O e-mail de {0} já está confirmado.</value>
+  </data>
+  <data name="Identity.PhoneConfirmationError" xml:space="preserve">
+    <value>Ocorreu um erro ao confirmar o número de telefone.</value>
+  </data>
+  <data name="Identity.PhoneConfirmationFailedFor" xml:space="preserve">
+    <value>Ocorreu um erro ao confirmar o número de telefone {0}.</value>
+  </data>
+  <data name="Identity.EmailClaimRequired" xml:space="preserve">
+    <value>A claim de e-mail é obrigatória para autenticação externa.</value>
+  </data>
+  <data name="Identity.FailedToCreateUserFromPrincipal" xml:space="preserve">
+    <value>Falha ao criar o usuário a partir do principal externo.</value>
+  </data>
+  <data name="Identity.PasswordsDoNotMatch" xml:space="preserve">
+    <value>As senhas não coincidem.</value>
+  </data>
+  <data name="Identity.UnableToRegisterUser" xml:space="preserve">
+    <value>Não foi possível registrar o usuário.</value>
+  </data>
+  <data name="Identity.AdminCannotRemoveOwnRole" xml:space="preserve">
+    <value>Administradores não podem remover a própria função de administrador.</value>
+  </data>
+  <data name="Identity.RootAdminCannotBeDemoted" xml:space="preserve">
+    <value>O administrador do tenant raiz não pode ser rebaixado.</value>
+  </data>
+  <data name="Identity.TenantMustRetainOneAdmin" xml:space="preserve">
+    <value>O tenant deve manter pelo menos um administrador.</value>
+  </data>
+  <data name="Identity.OnlyAdminsCanChangeStatus" xml:space="preserve">
+    <value>Apenas administradores podem alterar o status do usuário.</value>
+  </data>
+  <data name="Identity.CannotDeactivateSelf" xml:space="preserve">
+    <value>Usuários não podem desativar a si mesmos.</value>
+  </data>
+  <data name="Identity.AdminsCannotBeDeactivated" xml:space="preserve">
+    <value>Administradores não podem ser desativados.</value>
+  </data>
+  <data name="Identity.TenantMustHaveActiveAdmin" xml:space="preserve">
+    <value>O tenant deve ter pelo menos um administrador ativo.</value>
+  </data>
+  <data name="Identity.ToggleStatusFailed" xml:space="preserve">
+    <value>Falha ao alternar o status.</value>
+  </data>
+  <data name="Identity.InvalidCredentials" xml:space="preserve">
+    <value>Credenciais inválidas.</value>
+  </data>
+  <data name="Identity.CannotViewOthersSessions" xml:space="preserve">
+    <value>Não é possível visualizar sessões de outro usuário</value>
+  </data>
+  <data name="Identity.CannotRevokeOthersSession" xml:space="preserve">
+    <value>Não é possível revogar a sessão de outro usuário</value>
+  </data>
+  <data name="Identity.CannotRevokeOthersSessions" xml:space="preserve">
+    <value>Não é possível revogar sessões de outro usuário</value>
+  </data>
+  <data name="Identity.RoleManagerNotResolved" xml:space="preserve">
+    <value>RoleManager&lt;FshRole&gt; não resolvido. Verifique o registro do Identity.</value>
+  </data>
+  <data name="Identity.RoleStoreNotConfigured" xml:space="preserve">
+    <value>Repositório de funções não configurado. Garanta .AddRoles&lt;FshRole&gt;() e os stores do EF.</value>
+  </data>
+  <data name="Identity.InScopeInitializationOnly" xml:space="preserve">
+    <value>Método reservado para inicialização em escopo.</value>
+  </data>
+</root>

--- a/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.resx
+++ b/src/Modules/Identity/Modules.Identity/Localization/IdentityResources.resx
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Identity.GroupNotFound" xml:space="preserve">
+    <value>Group with ID '{0}' not found.</value>
+  </data>
+  <data name="Identity.UsersNotFound" xml:space="preserve">
+    <value>Users not found: {0}</value>
+  </data>
+  <data name="Identity.GroupNameAlreadyExists" xml:space="preserve">
+    <value>Group with name '{0}' already exists.</value>
+  </data>
+  <data name="Identity.RolesNotFoundWithIds" xml:space="preserve">
+    <value>Roles not found: {0}</value>
+  </data>
+  <data name="Identity.SystemGroupsCannotBeDeleted" xml:space="preserve">
+    <value>System groups cannot be deleted.</value>
+  </data>
+  <data name="Identity.UserNotMemberOfGroup" xml:space="preserve">
+    <value>User '{0}' is not a member of group '{1}'.</value>
+  </data>
+  <data name="Identity.CannotRemoveFromDefaultGroup" xml:space="preserve">
+    <value>Users cannot be removed from a default group.</value>
+  </data>
+  <data name="Identity.SystemGroupsCannotBeModified" xml:space="preserve">
+    <value>System groups cannot be modified.</value>
+  </data>
+  <data name="Identity.RoleNotFound" xml:space="preserve">
+    <value>Role not found.</value>
+  </data>
+  <data name="Identity.RolesNotFound" xml:space="preserve">
+    <value>Roles not found.</value>
+  </data>
+  <data name="Identity.SystemRoleCannotBeModified" xml:space="preserve">
+    <value>System roles cannot be modified.</value>
+  </data>
+  <data name="Identity.CannotRenameToSystemRole" xml:space="preserve">
+    <value>Cannot rename a role to a system role's name.</value>
+  </data>
+  <data name="Identity.CannotCreateWithSystemRoleName" xml:space="preserve">
+    <value>Cannot create a role using a system role's name.</value>
+  </data>
+  <data name="Identity.SystemRolesCannotBeDeleted" xml:space="preserve">
+    <value>System roles cannot be deleted.</value>
+  </data>
+  <data name="Identity.SystemRolePermissionsManaged" xml:space="preserve">
+    <value>System role permissions are managed by the framework and cannot be modified.</value>
+  </data>
+  <data name="Identity.OperationFailed" xml:space="preserve">
+    <value>Operation failed.</value>
+  </data>
+  <data name="Identity.NotAnImpersonationSession" xml:space="preserve">
+    <value>Current session is not an impersonation session.</value>
+  </data>
+  <data name="Identity.OriginalActorNotFound" xml:space="preserve">
+    <value>Original actor not found.</value>
+  </data>
+  <data name="Identity.ImpersonationGrantNotFound" xml:space="preserve">
+    <value>Impersonation grant not found.</value>
+  </data>
+  <data name="Identity.CrossTenantImpersonationRestricted" xml:space="preserve">
+    <value>Cross-tenant impersonation is restricted to platform operators.</value>
+  </data>
+  <data name="Identity.CannotImpersonateYourself" xml:space="preserve">
+    <value>Cannot impersonate yourself.</value>
+  </data>
+  <data name="Identity.EndImpersonationFirst" xml:space="preserve">
+    <value>End current impersonation before starting a new one.</value>
+  </data>
+  <data name="Identity.TargetUserNotFound" xml:space="preserve">
+    <value>Target user not found.</value>
+  </data>
+  <data name="Identity.UserNotFound" xml:space="preserve">
+    <value>User not found.</value>
+  </data>
+  <data name="Identity.UserNotFoundById" xml:space="preserve">
+    <value>User {0} not found.</value>
+  </data>
+  <data name="Identity.CurrentPasswordIncorrect" xml:space="preserve">
+    <value>Current password is incorrect.</value>
+  </data>
+  <data name="Identity.FailedToGenerateAuthenticatorKey" xml:space="preserve">
+    <value>Failed to generate authenticator key.</value>
+  </data>
+  <data name="Identity.AuthenticatorCodeInvalid" xml:space="preserve">
+    <value>The authenticator code is invalid.</value>
+  </data>
+  <data name="Identity.InvalidRefreshToken" xml:space="preserve">
+    <value>Invalid refresh token.</value>
+  </data>
+  <data name="Identity.SessionRevoked" xml:space="preserve">
+    <value>Session has been revoked.</value>
+  </data>
+  <data name="Identity.AccessTokenSubjectMismatch" xml:space="preserve">
+    <value>Access token subject mismatch.</value>
+  </data>
+  <data name="Identity.TwoFactorRequired" xml:space="preserve">
+    <value>two_factor_required: An authenticator code is required to complete sign-in.</value>
+  </data>
+  <data name="Identity.TwoFactorInvalid" xml:space="preserve">
+    <value>two_factor_invalid: The authenticator code is invalid or expired.</value>
+  </data>
+  <data name="Identity.AccountLocked" xml:space="preserve">
+    <value>Account is temporarily locked due to too many failed login attempts. Try again later.</value>
+  </data>
+  <data name="Identity.RefreshTokenInvalidOrExpired" xml:space="preserve">
+    <value>Refresh token is invalid or expired.</value>
+  </data>
+  <data name="Identity.UserDeactivated" xml:space="preserve">
+    <value>User is deactivated.</value>
+  </data>
+  <data name="Identity.EmailNotConfirmed" xml:space="preserve">
+    <value>Email not confirmed.</value>
+  </data>
+  <data name="Identity.TenantDeactivated" xml:space="preserve">
+    <value>Tenant {0} is deactivated.</value>
+  </data>
+  <data name="Identity.TenantValidityExpired" xml:space="preserve">
+    <value>Tenant {0} validity has expired.</value>
+  </data>
+  <data name="Identity.ErrorResettingPassword" xml:space="preserve">
+    <value>Error resetting password.</value>
+  </data>
+  <data name="Identity.FailedToChangePassword" xml:space="preserve">
+    <value>Failed to change password.</value>
+  </data>
+  <data name="Identity.UpdateProfileFailed" xml:space="preserve">
+    <value>Update profile failed.</value>
+  </data>
+  <data name="Identity.UpdateProfileImageFailed" xml:space="preserve">
+    <value>Update profile image failed.</value>
+  </data>
+  <data name="Identity.EmailConfirmationError" xml:space="preserve">
+    <value>An error occurred while confirming E-Mail.</value>
+  </data>
+  <data name="Identity.EmailConfirmationFailedFor" xml:space="preserve">
+    <value>An error occurred while confirming {0}.</value>
+  </data>
+  <data name="Identity.EmailConfirmationFailedWithErrors" xml:space="preserve">
+    <value>An error occurred while confirming the email for {0}: {1}</value>
+  </data>
+  <data name="Identity.EmailAlreadyConfirmed" xml:space="preserve">
+    <value>The email for {0} is already confirmed.</value>
+  </data>
+  <data name="Identity.PhoneConfirmationError" xml:space="preserve">
+    <value>An error occurred while confirming phone number.</value>
+  </data>
+  <data name="Identity.PhoneConfirmationFailedFor" xml:space="preserve">
+    <value>An error occurred while confirming phone number {0}.</value>
+  </data>
+  <data name="Identity.EmailClaimRequired" xml:space="preserve">
+    <value>Email claim is required for external authentication.</value>
+  </data>
+  <data name="Identity.FailedToCreateUserFromPrincipal" xml:space="preserve">
+    <value>Failed to create user from external principal.</value>
+  </data>
+  <data name="Identity.PasswordsDoNotMatch" xml:space="preserve">
+    <value>Passwords do not match.</value>
+  </data>
+  <data name="Identity.UnableToRegisterUser" xml:space="preserve">
+    <value>Unable to register the user.</value>
+  </data>
+  <data name="Identity.AdminCannotRemoveOwnRole" xml:space="preserve">
+    <value>Administrators cannot remove their own admin role.</value>
+  </data>
+  <data name="Identity.RootAdminCannotBeDemoted" xml:space="preserve">
+    <value>The root tenant administrator cannot be demoted.</value>
+  </data>
+  <data name="Identity.TenantMustRetainOneAdmin" xml:space="preserve">
+    <value>Tenant must retain at least one administrator.</value>
+  </data>
+  <data name="Identity.OnlyAdminsCanChangeStatus" xml:space="preserve">
+    <value>Only administrators can change user status.</value>
+  </data>
+  <data name="Identity.CannotDeactivateSelf" xml:space="preserve">
+    <value>Users cannot deactivate themselves.</value>
+  </data>
+  <data name="Identity.AdminsCannotBeDeactivated" xml:space="preserve">
+    <value>Administrators cannot be deactivated.</value>
+  </data>
+  <data name="Identity.TenantMustHaveActiveAdmin" xml:space="preserve">
+    <value>Tenant must have at least one active administrator.</value>
+  </data>
+  <data name="Identity.ToggleStatusFailed" xml:space="preserve">
+    <value>Toggle status failed.</value>
+  </data>
+  <data name="Identity.InvalidCredentials" xml:space="preserve">
+    <value>Invalid credentials.</value>
+  </data>
+  <data name="Identity.CannotViewOthersSessions" xml:space="preserve">
+    <value>Cannot view sessions for another user</value>
+  </data>
+  <data name="Identity.CannotRevokeOthersSession" xml:space="preserve">
+    <value>Cannot revoke session for another user</value>
+  </data>
+  <data name="Identity.CannotRevokeOthersSessions" xml:space="preserve">
+    <value>Cannot revoke sessions for another user</value>
+  </data>
+  <data name="Identity.RoleManagerNotResolved" xml:space="preserve">
+    <value>RoleManager&lt;FshRole&gt; not resolved. Check Identity registration.</value>
+  </data>
+  <data name="Identity.RoleStoreNotConfigured" xml:space="preserve">
+    <value>Role store not configured. Ensure .AddRoles&lt;FshRole&gt;() and EF stores.</value>
+  </data>
+  <data name="Identity.InScopeInitializationOnly" xml:space="preserve">
+    <value>Method reserved for in-scope initialization</value>
+  </data>
+</root>

--- a/src/Modules/Identity/Modules.Identity/Modules.Identity.csproj
+++ b/src/Modules/Identity/Modules.Identity/Modules.Identity.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Identity</RootNamespace>
 		<AssemblyName>FSH.Modules.Identity</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1812;CA2208;S3267;S3928;CA1062;CA1304;CA1308;CA1311;CA1862;CA2227</NoWarn>
+		<NoWarn>$(NoWarn);CA1031;CA1812;CA2208;S3267;S3928;CA1062;CA1304;CA1308;CA1311;CA1862;CA2227;S2094</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Modules/Identity/Modules.Identity/Services/IdentityService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/IdentityService.cs
@@ -5,6 +5,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -72,7 +73,11 @@ public sealed class IdentityService : IIdentityService
             throw new CustomException(
                 "two_factor_required: An authenticator code is required to complete sign-in.",
                 errors: null,
-                HttpStatusCode.Unauthorized);
+                HttpStatusCode.Unauthorized)
+            {
+                MessageKey = "Identity.TwoFactorRequired",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var valid = await _userManager.VerifyTwoFactorTokenAsync(
@@ -83,7 +88,11 @@ public sealed class IdentityService : IIdentityService
         if (!valid)
         {
             _logger.LogWarning("Invalid two-factor code for user {UserId}", user.Id);
-            throw new UnauthorizedException("two_factor_invalid: The authenticator code is invalid or expired.");
+            throw new UnauthorizedException("two_factor_invalid: The authenticator code is invalid or expired.")
+            {
+                MessageKey = "Identity.TwoFactorInvalid",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -116,7 +125,11 @@ public sealed class IdentityService : IIdentityService
 
         if (updated == 0)
         {
-            throw new UnauthorizedException("user not found");
+            throw new UnauthorizedException("user not found")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -199,7 +212,11 @@ public sealed class IdentityService : IIdentityService
             throw new CustomException(
                 "Account is temporarily locked due to too many failed login attempts. Try again later.",
                 errors: null,
-                HttpStatusCode.Locked);
+                HttpStatusCode.Locked)
+            {
+                MessageKey = "Identity.AccountLocked",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!await _userManager.CheckPasswordAsync(user, password))
@@ -243,7 +260,11 @@ public sealed class IdentityService : IIdentityService
         if (user is null)
         {
             _logger.LogWarning("No user found with matching refresh token hash for tenant {TenantId}", tenantId);
-            throw new UnauthorizedException("refresh token is invalid or expired");
+            throw new UnauthorizedException("refresh token is invalid or expired")
+            {
+                MessageKey = "Identity.RefreshTokenInvalidOrExpired",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         return user;
@@ -257,7 +278,11 @@ public sealed class IdentityService : IIdentityService
             _logger.LogWarning(
                 "Refresh token expired for user {UserId}. Expired at: {ExpiryTime}, Current time: {CurrentTime}",
                 user.Id, user.RefreshTokenExpiryTime, now);
-            throw new UnauthorizedException("refresh token is invalid or expired");
+            throw new UnauthorizedException("refresh token is invalid or expired")
+            {
+                MessageKey = "Identity.RefreshTokenInvalidOrExpired",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -265,12 +290,20 @@ public sealed class IdentityService : IIdentityService
     {
         if (!user.IsActive)
         {
-            throw new UnauthorizedException("user is deactivated");
+            throw new UnauthorizedException("user is deactivated")
+            {
+                MessageKey = "Identity.UserDeactivated",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!user.EmailConfirmed)
         {
-            throw new UnauthorizedException("email not confirmed");
+            throw new UnauthorizedException("email not confirmed")
+            {
+                MessageKey = "Identity.EmailNotConfirmed",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -283,14 +316,24 @@ public sealed class IdentityService : IIdentityService
 
         if (!tenant.IsActive)
         {
-            throw new UnauthorizedException($"tenant {tenant.Id} is deactivated");
+            throw new UnauthorizedException($"tenant {tenant.Id} is deactivated")
+            {
+                MessageKey = "Identity.TenantDeactivated",
+                MessageArgs = [tenant.Id],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Honor the billing grace period: a lapsed tenant can still authenticate until
         // ValidUpto + grace (matching the request-time guard in MultitenancyModule).
         if (_timeProvider.GetUtcNow().UtcDateTime > tenant.ValidUpto.AddDays(_gracePeriodDays))
         {
-            throw new UnauthorizedException($"tenant {tenant.Id} validity has expired");
+            throw new UnauthorizedException($"tenant {tenant.Id} validity has expired")
+            {
+                MessageKey = "Identity.TenantValidityExpired",
+                MessageArgs = [tenant.Id],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -301,11 +344,11 @@ public sealed class IdentityService : IIdentityService
         return claims;
     }
 
-    private static List<Claim> CreateBasicClaims(FshUser user, string tenantId)
+    internal static List<Claim> CreateBasicClaims(FshUser user, string tenantId)
     {
         var fullName = $"{user.FirstName} {user.LastName}".Trim();
-        return
-        [
+        var claims = new List<Claim>
+        {
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             // RFC 7519 short-form sub/name/email emitted alongside legacy ClaimTypes.* so JWT consumers read them per spec.
             // `name` is published explicitly because the default outbound map turns ClaimTypes.Name into `unique_name`, not `name`.
@@ -320,7 +363,17 @@ public sealed class IdentityService : IIdentityService
             new(ClaimTypes.Surname, user.LastName ?? string.Empty),
             new(ClaimConstants.Tenant, tenantId),
             new(ClaimConstants.ImageUrl, user.ImageUrl?.ToString() ?? string.Empty)
-        ];
+        };
+
+        // OIDC-standard `locale` claim, emitted ONLY when the user explicitly chose a language.
+        // A null/blank Locale emits no claim so the culture-resolution chain falls to Accept-Language
+        // rather than forcing the deployment default onto users who never picked one.
+        if (!string.IsNullOrWhiteSpace(user.Locale))
+        {
+            claims.Add(new Claim("locale", user.Locale));
+        }
+
+        return claims;
     }
 
     private async Task AddRoleClaimsAsync(List<Claim> claims, FshUser user, CancellationToken ct)

--- a/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
@@ -8,6 +8,7 @@ using FSH.Framework.Web.Origin;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -34,7 +35,11 @@ internal sealed class UserProfileService(
             .Where(u => u.Id == userId)
             .FirstOrDefaultAsync(cancellationToken);
 
-        _ = user ?? throw new NotFoundException("user not found");
+        _ = user ?? throw new NotFoundException("user not found")
+        {
+            MessageKey = "Identity.UserNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         return new UserDto
         {
@@ -48,6 +53,7 @@ internal sealed class UserProfileService(
             EmailConfirmed = user.EmailConfirmed,
             PhoneNumber = user.PhoneNumber,
             TwoFactorEnabled = user.TwoFactorEnabled,
+            Locale = user.Locale,
         };
     }
 
@@ -75,11 +81,15 @@ internal sealed class UserProfileService(
         return result;
     }
 
-    public async Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default)
+    public async Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, string? locale, CancellationToken cancellationToken = default)
     {
         var user = await userManager.FindByIdAsync(userId);
 
-        _ = user ?? throw new NotFoundException("user not found");
+        _ = user ?? throw new NotFoundException("user not found")
+        {
+            MessageKey = "Identity.UserNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         Uri imageUri = user.ImageUrl ?? null!;
         // image is optional: text-only edits forward a null FileUploadRequest, so guard before
@@ -101,6 +111,13 @@ internal sealed class UserProfileService(
 
         user.FirstName = firstName;
         user.LastName = lastName;
+        // Null locale means "not provided by this update" — preserve the existing value so a
+        // text-only profile edit never clears a language the user already chose.
+        if (locale is not null)
+        {
+            user.Locale = locale;
+        }
+
         string? currentPhoneNumber = await userManager.GetPhoneNumberAsync(user);
         if (phoneNumber != currentPhoneNumber)
         {
@@ -112,7 +129,11 @@ internal sealed class UserProfileService(
 
         if (!result.Succeeded)
         {
-            throw new CustomException("Update profile failed");
+            throw new CustomException("Update profile failed")
+            {
+                MessageKey = "Identity.UpdateProfileFailed",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -120,7 +141,11 @@ internal sealed class UserProfileService(
     {
         EnsureValidTenant();
         var user = await userManager.FindByIdAsync(userId)
-            ?? throw new NotFoundException("user not found");
+            ?? throw new NotFoundException("user not found")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         user.ImageUrl = string.IsNullOrWhiteSpace(imageUrl)
             ? null
@@ -129,7 +154,11 @@ internal sealed class UserProfileService(
         var result = await userManager.UpdateAsync(user);
         if (!result.Succeeded)
         {
-            throw new CustomException("Update profile image failed");
+            throw new CustomException("Update profile image failed")
+            {
+                MessageKey = "Identity.UpdateProfileImageFailed",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await signInManager.RefreshSignInAsync(user);
@@ -157,7 +186,10 @@ internal sealed class UserProfileService(
     {
         if (string.IsNullOrWhiteSpace(multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id))
         {
-            throw new UnauthorizedException("invalid tenant");
+            throw new UnauthorizedException("invalid tenant")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         }
     }
 

--- a/src/Modules/Identity/Modules.Identity/Services/UserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserService.cs
@@ -55,8 +55,8 @@ internal sealed class UserService(
     public Task<int> GetCountAsync(CancellationToken cancellationToken)
         => profileService.GetCountAsync(cancellationToken);
 
-    public Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default)
-        => profileService.UpdateAsync(userId, firstName, lastName, phoneNumber, image, deleteCurrentImage, cancellationToken);
+    public Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, string? locale, CancellationToken cancellationToken = default)
+        => profileService.UpdateAsync(userId, firstName, lastName, phoneNumber, image, deleteCurrentImage, locale, cancellationToken);
 
     public Task<bool> ExistsWithEmailAsync(string email, string? exceptId = null, CancellationToken cancellationToken = default)
         => profileService.ExistsWithEmailAsync(email, exceptId, cancellationToken);

--- a/src/Tests/Auditing.Tests/Contracts/ExceptionSeverityClassifierTests.cs
+++ b/src/Tests/Auditing.Tests/Contracts/ExceptionSeverityClassifierTests.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Auditing.Contracts;
 
 namespace Auditing.Tests.Contracts;
@@ -138,6 +139,45 @@ public sealed class ExceptionSeverityClassifierTests
 
         // Assert
         result.ShouldBe(AuditSeverity.Information);
+    }
+
+    // The localization work introduced LocalizedUnauthorizedAccessException specifically so that
+    // subclassing the BCL type — rather than swapping it for a CustomException — keeps this
+    // classifier mapping unauthorized access to Warning. That intent lived only in a code
+    // comment: changing the base type would silently reclassify every unauthorized access as
+    // Error and no test would have noticed. This is the test that notices.
+    [Fact]
+    public void Classify_Should_ReturnWarning_For_LocalizedUnauthorizedAccessException()
+    {
+        // Arrange
+        var exception = new LocalizedUnauthorizedAccessException("Authentication failed.")
+        {
+            MessageKey = "Error.AuthenticationFailed",
+        };
+
+        // Act
+        var result = ExceptionSeverityClassifier.Classify(exception);
+
+        // Assert
+        result.ShouldBe(AuditSeverity.Warning);
+    }
+
+    // The KeyNotFound counterpart lands on Error either way; pinned so the classification is
+    // stated rather than left to be derived from the switch's default arm.
+    [Fact]
+    public void Classify_Should_ReturnError_For_LocalizedKeyNotFoundException()
+    {
+        // Arrange
+        var exception = new LocalizedKeyNotFoundException("Not found.")
+        {
+            MessageKey = "Error.NotFound",
+        };
+
+        // Act
+        var result = ExceptionSeverityClassifier.Classify(exception);
+
+        // Assert
+        result.ShouldBe(AuditSeverity.Error);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Test-only exception class")]

--- a/src/Tests/Framework.Tests/Localization/SharedResourcesKeyParityTests.cs
+++ b/src/Tests/Framework.Tests/Localization/SharedResourcesKeyParityTests.cs
@@ -1,0 +1,40 @@
+using System.Globalization;
+using System.Linq;
+
+namespace Framework.Tests.Localization;
+
+// Guards against an English key missing from the .pt-BR catalog (a silent English fallback shipped as
+// "translated"). Enumerates each culture's own embedded resx (includeParentCultures: false) and
+// asserts identical key sets.
+public sealed class SharedResourcesKeyParityTests
+{
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = SharedResourcesLocalizerFactory.Create();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // SharedResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // SharedResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+}

--- a/src/Tests/Framework.Tests/Localization/SharedResourcesLocalizationTests.cs
+++ b/src/Tests/Framework.Tests/Localization/SharedResourcesLocalizationTests.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using FSH.Framework.Core.Localization;
+using FSH.Framework.Web.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Framework.Tests.Localization;
+
+// Proves the whole resx wiring: SharedResources marker + co-located resx + ResourcesPath="" in
+// AddHeroLocalization resolve to the embedded catalog under the current UI culture. If the manifest
+// name or ResourcesPath is wrong, ResourceNotFound flips true and IStringLocalizer leaks the raw key.
+public sealed class SharedResourcesLocalizationTests
+{
+    private static IStringLocalizer<SharedResources> BuildLocalizer()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHeroLocalization(configuration);
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<SharedResources>>();
+    }
+
+    // Catalogs are named for specific cultures (SharedResources.pt-BR.resx), matching the front-end.
+    // The consequence is deliberate and pinned here: only pt-BR is served Portuguese. A bare `pt` or
+    // an unsupported variant like pt-PT walks its parent chain, finds no catalog of its own and lands
+    // on the neutral (English) one, rather than being silently handed Brazilian strings.
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]   // specific pt-BR resolves directly
+    [InlineData("pt", "Not Found")]           // bare pt has no catalog -> neutral English
+    [InlineData("pt-PT", "Not Found")]         // unsupported variant -> neutral English, NOT pt-BR
+    [InlineData("en-US", "Not Found")]        // en-US falls back to the neutral (default) catalog
+    public void Localizer_resolves_error_key_per_culture(string culture, string expected)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo(culture);
+            var localized = localizer["Error.NotFound"];
+
+            localized.ResourceNotFound.ShouldBeFalse(
+                $"resx for '{culture}' did not resolve 'Error.NotFound' — check ResourcesPath/resx manifest name.");
+            localized.Value.ShouldBe(expected);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Framework.Tests/Localization/SharedResourcesLocalizerFactory.cs
+++ b/src/Tests/Framework.Tests/Localization/SharedResourcesLocalizerFactory.cs
@@ -1,0 +1,27 @@
+using FSH.Framework.Core.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Framework.Tests.Localization;
+
+// Builds a REAL IStringLocalizer<SharedResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx). Shared by the handler and validator tests
+// so they exercise the actual catalog resolution rather than a stub.
+internal static class SharedResourcesLocalizerFactory
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider();
+    }
+
+    public static IStringLocalizer<SharedResources> Create() =>
+        BuildProvider().GetRequiredService<IStringLocalizer<SharedResources>>();
+
+    // The GlobalExceptionHandler resolves module-catalog keys through IStringLocalizerFactory
+    // (via CustomException.ResourceSource); tests build a real factory bound to the same setup.
+    public static IStringLocalizerFactory CreateFactory() =>
+        BuildProvider().GetRequiredService<IStringLocalizerFactory>();
+}

--- a/src/Tests/Framework.Tests/Localization/UserLocaleRequestCultureProviderTests.cs
+++ b/src/Tests/Framework.Tests/Localization/UserLocaleRequestCultureProviderTests.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using System.Security.Claims;
+using FSH.Framework.Web.Localization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Framework.Tests.Localization;
+
+public sealed class UserLocaleRequestCultureProviderTests
+{
+    private static IOptions<RequestLocalizationOptions> BuildOptions()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var services = new ServiceCollection();
+        services.AddHeroLocalization(configuration);
+        return services.BuildServiceProvider().GetRequiredService<IOptions<RequestLocalizationOptions>>();
+    }
+
+    private static DefaultHttpContext BuildContext(string? claim, string? header, string? query)
+    {
+        var context = new DefaultHttpContext();
+        if (claim is not null)
+        {
+            context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("locale", claim)], "test"));
+        }
+
+        if (header is not null)
+        {
+            context.Request.Headers.AcceptLanguage = header;
+        }
+
+        if (query is not null)
+        {
+            context.Request.QueryString = new QueryString($"?culture={query}");
+        }
+
+        return context;
+    }
+
+    // Full culture-provider chain: Query -> user locale claim -> Accept-Language -> configured default -> en-US.
+    [Theory]
+    [InlineData("pt-BR", "en-US", null, "pt-BR")]    // supported claim wins over the header
+    [InlineData(null, "pt-BR", null, "pt-BR")]       // header used when there is no claim
+    [InlineData(null, null, null, "en-US")]          // nothing set -> default fallback
+    [InlineData("xx-YY", "pt-BR", null, "pt-BR")]    // unsupported claim ignored -> falls to header
+    [InlineData(null, "pt-BR", "en-US", "en-US")]    // explicit query override wins over everything
+    [InlineData(null, "pt", null, "en-US")]          // bare pt is not a supported tag -> default
+    [InlineData(null, "pt-PT", null, "en-US")]       // unsupported variant -> default, never pt-BR
+    public async Task Resolves_expected_culture_through_chain(string? claim, string? header, string? query, string expected)
+    {
+        var options = BuildOptions();
+        var context = BuildContext(claim, header, query);
+
+        string? resolved = null;
+        var middleware = new RequestLocalizationMiddleware(
+            _ => { resolved = CultureInfo.CurrentUICulture.Name; return Task.CompletedTask; },
+            options,
+            NullLoggerFactory.Instance);
+
+        var previous = (CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+        try
+        {
+            await middleware.Invoke(context);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous.Item1;
+            CultureInfo.CurrentUICulture = previous.Item2;
+        }
+
+        resolved.ShouldBe(expected);
+    }
+
+    // Localization negotiates the UI culture ONLY. CurrentCulture must stay invariant no matter what
+    // the request asks for, so no endpoint's ToString()/Parse()/interpolation shifts per request. Runs
+    // the real RequestLocalizationMiddleware, because this property comes out of the interaction
+    // between DefaultRequestCulture and a null SupportedCultures, not out of our provider.
+    [Theory]
+    [InlineData("pt-BR", null, null, "pt-BR")]       // claim
+    [InlineData(null, "pt-BR", null, "pt-BR")]       // header
+    [InlineData(null, null, "pt-BR", "pt-BR")]       // query override
+    [InlineData(null, null, null, "en-US")]          // nothing set
+    public async Task Formatting_culture_stays_invariant_while_ui_culture_negotiates(
+        string? claim, string? header, string? query, string expectedUiCulture)
+    {
+        var options = BuildOptions();
+        var context = BuildContext(claim, header, query);
+
+        string? formattingCulture = null;
+        string? uiCulture = null;
+        var middleware = new RequestLocalizationMiddleware(
+            _ =>
+            {
+                formattingCulture = CultureInfo.CurrentCulture.Name;
+                uiCulture = CultureInfo.CurrentUICulture.Name;
+                return Task.CompletedTask;
+            },
+            options,
+            NullLoggerFactory.Instance);
+
+        var previous = (CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("pt-BR");
+            await middleware.Invoke(context);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous.Item1;
+            CultureInfo.CurrentUICulture = previous.Item2;
+        }
+
+        uiCulture.ShouldBe(expectedUiCulture);
+        formattingCulture.ShouldBe(
+            string.Empty,
+            "CurrentCulture must be the invariant culture; a negotiated formatting culture would shift "
+                + "number and date rendering for every endpoint in the request.");
+    }
+
+    // The custom provider in isolation: emit the claim only when supported, otherwise fall through (null).
+    [Theory]
+    [InlineData("pt-BR", "pt-BR")]
+    [InlineData("en-US", "en-US")]
+    [InlineData("xx-YY", null)]
+    [InlineData(null, null)]
+    public async Task Provider_returns_claim_only_when_supported(string? claim, string? expected)
+    {
+        var context = BuildContext(claim, header: null, query: null);
+        var result = await new UserLocaleRequestCultureProvider().DetermineProviderCultureResult(context);
+        (result?.Cultures[0].Value).ShouldBe(expected);
+    }
+}

--- a/src/Tests/Framework.Tests/Web/ExceptionLocalizationPipelineTests.cs
+++ b/src/Tests/Framework.Tests/Web/ExceptionLocalizationPipelineTests.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Web.Exceptions;
+using FSH.Framework.Web.Localization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Framework.Tests.Web;
+
+// Pipeline-level counterpart to GlobalExceptionHandlerLocalizationTests. Those tests assign
+// CultureInfo.CurrentUICulture by hand and call the handler directly, so they never exercise the one
+// thing production depends on: that the culture RequestLocalizationMiddleware negotiates is still
+// visible to the handler, which UseExceptionHandler runs from ABOVE that middleware. It is not — the
+// assignment lives in the middleware own async frame — so the handler has to read the negotiated
+// culture off the request instead.
+//
+// The ambient culture is pinned to invariant for the duration of each case, which is what a container
+// with no LANG gives the API. Without the pin the developer machine culture decides the outcome and a
+// pt-BR machine reports a false pass.
+public sealed class ExceptionLocalizationPipelineTests
+{
+    private sealed record Outcome(string? Title, string? Detail, string? Code, string? NegotiatedUiCulture, string? ContentLanguage);
+
+    // The production order: UseExceptionHandler at the top of the pipeline, localization further in.
+    private static Task<Outcome> InvokeAsync(string acceptLanguage, Exception exception) =>
+        RunAsync(app => app.UseHeroLocalization(), acceptLanguage, exception);
+
+    // A pipeline with no localization at all, standing in for the middleware registered between
+    // UseExceptionHandler and UseHeroLocalization: nothing negotiates a culture, so no feature exists.
+    private static Task<Outcome> InvokeWithoutLocalizationAsync(string acceptLanguage, Exception exception) =>
+        RunAsync(_ => { }, acceptLanguage, exception);
+
+    private static async Task<Outcome> RunAsync(Action<IApplicationBuilder> configure, string acceptLanguage, Exception exception)
+    {
+        var previousCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        try
+        {
+            var configuration = new ConfigurationBuilder().Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddMetrics();
+
+            // ExceptionHandlerMiddlewareImpl is activated from DI and takes a DiagnosticListener;
+            // the real host gets it from WebApplicationBuilder, so a bare ServiceCollection must supply it.
+            services.AddSingleton(_ => new DiagnosticListener("Microsoft.AspNetCore"));
+            services.AddSingleton<DiagnosticSource>(sp => sp.GetRequiredService<DiagnosticListener>());
+
+            services.AddHeroLocalization(configuration);
+            services.AddExceptionHandler<GlobalExceptionHandler>();
+            services.AddProblemDetails();
+
+            await using var provider = services.BuildServiceProvider();
+
+            var app = new ApplicationBuilder(provider);
+            app.UseExceptionHandler();
+            configure(app);
+            app.Run(_ => throw exception);
+            var pipeline = app.Build();
+
+            using var scope = provider.CreateScope();
+            var context = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+            context.Request.Path = "/api/v1/test";
+            context.Request.Headers.AcceptLanguage = acceptLanguage;
+            using var body = new MemoryStream();
+            context.Response.Body = body;
+
+            await pipeline(context);
+
+            using var doc = JsonDocument.Parse(Encoding.UTF8.GetString(body.ToArray()));
+            var root = doc.RootElement;
+            var contentLanguage = context.Response.Headers.ContentLanguage.ToString();
+            return new Outcome(
+                root.TryGetProperty("title", out var t) ? t.GetString() : null,
+                root.TryGetProperty("detail", out var d) ? d.GetString() : null,
+                root.TryGetProperty("code", out var c) ? c.GetString() : null,
+                context.Features.Get<IRequestCultureFeature>()?.RequestCulture.UICulture.Name,
+                string.IsNullOrEmpty(contentLanguage) ? null : contentLanguage);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousCulture;
+        }
+    }
+
+    // Baseline: the middleware DOES negotiate the requested UI culture. If this fails, the gap is in
+    // negotiation and the assertions below say nothing about the handler.
+    [Theory]
+    [InlineData("pt-BR")]
+    [InlineData("en-US")]
+    public async Task Request_culture_is_negotiated_from_the_accept_language_header(string acceptLanguage)
+    {
+        var exception = new NotFoundException("English fallback") { MessageKey = "Error.NotFound" };
+
+        var outcome = await InvokeAsync(acceptLanguage, exception);
+
+        outcome.NegotiatedUiCulture.ShouldBe(acceptLanguage);
+    }
+
+    // The production symptom: a localized exception answered in English despite Accept-Language: pt-BR.
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]
+    [InlineData("en-US", "Not Found")]
+    public async Task Detail_is_localized_from_the_negotiated_request_culture(string acceptLanguage, string expected)
+    {
+        var exception = new NotFoundException("English fallback") { MessageKey = "Error.NotFound" };
+
+        var outcome = await InvokeAsync(acceptLanguage, exception);
+
+        outcome.Code.ShouldBe("Error.NotFound");
+        outcome.Detail.ShouldBe(expected);
+    }
+
+    // Title comes from the status-mapped catalog key through the injected IStringLocalizer, a separate
+    // resolution path from Detail IStringLocalizerFactory. Both read the ambient culture, so both broke.
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]
+    [InlineData("en-US", "Not Found")]
+    public async Task Title_is_localized_from_the_negotiated_request_culture(string acceptLanguage, string expected)
+    {
+        var outcome = await InvokeAsync(acceptLanguage, new NotFoundException("English fallback"));
+
+        outcome.Title.ShouldBe(expected);
+    }
+
+    // A raw exception takes the 500 branch, whose Title and Detail come straight off the injected
+    // localizer with no MessageKey involved.
+    [Theory]
+    [InlineData("pt-BR", "Ocorreu um erro inesperado")]
+    [InlineData("en-US", "An unexpected error occurred")]
+    public async Task Unexpected_error_is_localized_from_the_negotiated_request_culture(string acceptLanguage, string expected)
+    {
+        var outcome = await InvokeAsync(acceptLanguage, new InvalidOperationException("boom"));
+
+        outcome.Title.ShouldBe(expected);
+    }
+
+    // ExceptionHandlerMiddleware clears the response before re-executing, dropping the Content-Language
+    // the localization middleware had written. The handler restores it so the body culture is declared.
+    [Theory]
+    [InlineData("pt-BR")]
+    [InlineData("en-US")]
+    public async Task Content_language_declares_the_culture_the_body_was_written_in(string acceptLanguage)
+    {
+        var exception = new NotFoundException("English fallback") { MessageKey = "Error.NotFound" };
+
+        var outcome = await InvokeAsync(acceptLanguage, exception);
+
+        outcome.ContentLanguage.ShouldBe(acceptLanguage);
+    }
+
+    // No localization in the pipeline: the handler must still answer, from the ambient culture, and
+    // must not claim a Content-Language it never negotiated.
+    [Fact]
+    public async Task Handler_still_answers_when_no_culture_was_negotiated()
+    {
+        var exception = new NotFoundException("English fallback") { MessageKey = "Error.NotFound" };
+
+        var outcome = await InvokeWithoutLocalizationAsync("pt-BR", exception);
+
+        outcome.NegotiatedUiCulture.ShouldBeNull();
+        outcome.ContentLanguage.ShouldBeNull();
+        outcome.Code.ShouldBe("Error.NotFound");
+        outcome.Detail.ShouldBe("Not Found");
+        outcome.Title.ShouldBe("Not Found");
+    }
+
+    // The ambient culture is restored on the way out, so the handler cannot leak the request culture
+    // onto whatever else runs on this thread afterwards.
+    [Fact]
+    public async Task Ambient_culture_is_restored_after_handling()
+    {
+        var exception = new NotFoundException("English fallback") { MessageKey = "Error.NotFound" };
+        var before = CultureInfo.CurrentUICulture;
+
+        await InvokeAsync("pt-BR", exception);
+
+        CultureInfo.CurrentUICulture.ShouldBe(before);
+    }
+}

--- a/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerLocalizationTests.cs
+++ b/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerLocalizationTests.cs
@@ -1,0 +1,241 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Web.Exceptions;
+using Framework.Tests.Localization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Framework.Tests.Web;
+
+// Handler-level (Docker-free) proof that GlobalExceptionHandler localizes the ProblemDetails body
+// from the shared resx under the ambient UI culture. Covers both the framework branches (raw
+// KeyNotFoundException/InvalidOperationException) and the CustomException branch, whose Title now
+// comes from the status-mapped catalog key and whose Detail is resolved from MessageKey (falling
+// back to the English Message when no key is set).
+public sealed class GlobalExceptionHandlerLocalizationTests
+{
+    private static async Task<(string? Title, string? Detail)> HandleAsync(Exception exception, string culture)
+    {
+        var (title, detail, _) = await HandleWithCodeAsync(exception, culture);
+        return (title, detail);
+    }
+
+    private static async Task<(string? Title, string? Detail, string? Code)> HandleWithCodeAsync(Exception exception, string culture)
+    {
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo(culture);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/api/v1/test";
+            using var body = new MemoryStream();
+            context.Response.Body = body;
+
+            var handler = new GlobalExceptionHandler(
+                NullLogger<GlobalExceptionHandler>.Instance,
+                SharedResourcesLocalizerFactory.Create(),
+                SharedResourcesLocalizerFactory.CreateFactory());
+            await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+            var json = Encoding.UTF8.GetString(body.ToArray());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var title = root.TryGetProperty("title", out var t) ? t.GetString() : null;
+            var detail = root.TryGetProperty("detail", out var d) ? d.GetString() : null;
+            var code = root.TryGetProperty("code", out var c) ? c.GetString() : null;
+            return (title, detail, code);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]
+    [InlineData("en-US", "Not Found")]
+    public async Task NotFound_title_is_localized(string culture, string expected)
+    {
+        var (title, _) = await HandleAsync(new KeyNotFoundException("missing"), culture);
+        title.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("pt-BR", "Ocorreu um erro inesperado")]
+    [InlineData("en-US", "An unexpected error occurred")]
+    public async Task Unexpected_title_is_localized(string culture, string expected)
+    {
+        var (title, _) = await HandleAsync(new InvalidOperationException("boom"), culture);
+        title.ShouldBe(expected);
+    }
+
+    // CustomException Title is now the status-mapped catalog key (404 -> Error.NotFound), localized.
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]
+    [InlineData("en-US", "Not Found")]
+    public async Task CustomException_title_is_localized_by_status(string culture, string expected)
+    {
+        var (title, _) = await HandleAsync(new NotFoundException("some entity was not found"), culture);
+        title.ShouldBe(expected);
+    }
+
+    // Detail resolves from MessageKey under the request culture (using an existing Core key).
+    [Theory]
+    [InlineData("pt-BR", "Não autorizado")]
+    [InlineData("en-US", "Unauthorized")]
+    public async Task CustomException_detail_is_localized_from_key(string culture, string expected)
+    {
+        var exception = new UnauthorizedException("english fallback") { MessageKey = "Error.Unauthorized" };
+        var (_, detail) = await HandleAsync(exception, culture);
+        detail.ShouldBe(expected);
+    }
+
+    // No MessageKey: Detail falls back to the literal (English) Message regardless of culture (non-breaking).
+    [Theory]
+    [InlineData("pt-BR")]
+    [InlineData("en-US")]
+    public async Task CustomException_detail_falls_back_to_message_without_key(string culture)
+    {
+        var (_, detail) = await HandleAsync(new NotFoundException("Plain English detail."), culture);
+        detail.ShouldBe("Plain English detail.");
+    }
+
+    // Parameterless UnauthorizedException carries Error.AuthenticationFailed, so generic auth failures
+    // localize their Detail without any call-site key (English fallback stays "Authentication failed.").
+    [Theory]
+    [InlineData("pt-BR", "Falha na autenticação.")]
+    [InlineData("en-US", "Authentication failed.")]
+    public async Task Parameterless_unauthorized_detail_is_localized(string culture, string expected)
+    {
+        var (_, detail) = await HandleAsync(new UnauthorizedException(), culture);
+        detail.ShouldBe(expected);
+    }
+
+    // Unknown MessageKey: ResourceNotFound path falls back to the English Message, never leaks the raw key.
+    [Fact]
+    public async Task CustomException_detail_falls_back_when_key_missing()
+    {
+        var exception = new NotFoundException("English fallback detail.") { MessageKey = "Does.Not.Exist" };
+        var (_, detail) = await HandleAsync(exception, "pt-BR");
+        detail.ShouldBe("English fallback detail.");
+    }
+
+    // BCL-subclass exceptions (kept as their base type so audit severity classification is unaffected)
+    // still localize their Detail from MessageKey through the shared handler path.
+    [Theory]
+    [InlineData("pt-BR", "Falha na autenticação.")]
+    [InlineData("en-US", "Authentication failed.")]
+    public async Task LocalizedUnauthorizedAccess_detail_is_localized(string culture, string expected)
+    {
+        var exception = new LocalizedUnauthorizedAccessException("english fallback")
+        {
+            MessageKey = "Error.AuthenticationFailed",
+        };
+        var (_, detail) = await HandleAsync(exception, culture);
+        detail.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("pt-BR", "Não encontrado")]
+    [InlineData("en-US", "Not Found")]
+    public async Task LocalizedKeyNotFound_detail_is_localized(string culture, string expected)
+    {
+        var exception = new LocalizedKeyNotFoundException("english fallback")
+        {
+            MessageKey = "Error.NotFound",
+        };
+        var (_, detail) = await HandleAsync(exception, culture);
+        detail.ShouldBe(expected);
+    }
+
+    // No MessageKey on a localized subclass → Detail falls back to the literal (English) message.
+    [Fact]
+    public async Task LocalizedUnauthorizedAccess_without_key_falls_back_to_message()
+    {
+        var (_, detail) = await HandleAsync(new LocalizedUnauthorizedAccessException("Plain English."), "pt-BR");
+        detail.ShouldBe("Plain English.");
+    }
+
+    // Detail is prose under the request culture, so the MessageKey travels as a stable "code" extension:
+    // clients branch on the code instead of matching localized text. Same key in every culture.
+    [Theory]
+    [InlineData("pt-BR")]
+    [InlineData("en-US")]
+    public async Task CustomException_surfaces_the_message_key_as_code(string culture)
+    {
+        var exception = new UnauthorizedException("english fallback") { MessageKey = "Error.Unauthorized" };
+        var (_, _, code) = await HandleWithCodeAsync(exception, culture);
+        code.ShouldBe("Error.Unauthorized");
+    }
+
+    // A localized BCL subclass carries its key through the same path.
+    [Fact]
+    public async Task LocalizedKeyNotFound_surfaces_the_message_key_as_code()
+    {
+        var exception = new LocalizedKeyNotFoundException("english fallback") { MessageKey = "Error.NotFound" };
+        var (_, _, code) = await HandleWithCodeAsync(exception, "pt-BR");
+        code.ShouldBe("Error.NotFound");
+    }
+
+    // No key → no code property at all, rather than a null or an invented one.
+    [Fact]
+    public async Task Exception_without_key_omits_the_code()
+    {
+        var (_, _, code) = await HandleWithCodeAsync(new NotFoundException("Plain English detail."), "pt-BR");
+        code.ShouldBeNull();
+    }
+
+    // An unknown key still travels as the code even though Detail fell back to English: the code is the
+    // contract, the resx lookup is presentation.
+    [Fact]
+    public async Task Unknown_key_still_surfaces_as_code()
+    {
+        var exception = new NotFoundException("English fallback detail.") { MessageKey = "Does.Not.Exist" };
+        var (_, detail, code) = await HandleWithCodeAsync(exception, "pt-BR");
+        detail.ShouldBe("English fallback detail.");
+        code.ShouldBe("Does.Not.Exist");
+    }
+
+    // A raw BCL exception (no ILocalizableMessage) keeps its message and gets no code.
+    [Fact]
+    public async Task Raw_key_not_found_has_no_code()
+    {
+        var (_, detail, code) = await HandleWithCodeAsync(new KeyNotFoundException("missing"), "pt-BR");
+        detail.ShouldBe("missing");
+        code.ShouldBeNull();
+    }
+
+    // A 409 must not be titled "an unexpected error occurred". Before Error.Conflict existed the
+    // status-to-key map fell through to Error.Unexpected — which RESOLVES, so the type-name fallback
+    // never fired and every conflict in the API reported a title contradicting its own status and its
+    // own detail. There are 41 Conflict throw sites across Billing and Catalog.
+    [Theory]
+    [InlineData("en-US", "Conflict")]
+    [InlineData("pt-BR", "Conflito")]
+    public async Task Conflict_is_titled_as_a_conflict_not_as_unexpected(string culture, string expected)
+    {
+        var exception = new CustomException("Brand name already taken.", [], HttpStatusCode.Conflict);
+
+        var (title, _) = await HandleAsync(exception, culture);
+
+        title.ShouldBe(expected);
+    }
+
+    // A status with no title of its own keeps the pre-localization behaviour — the exception type
+    // name — instead of claiming the error was unexpected. Status-consistent beats confidently wrong.
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("pt-BR")]
+    public async Task Untranslated_status_falls_back_to_the_exception_type_name(string culture)
+    {
+        var exception = new CustomException("Mailbox is locked.", [], HttpStatusCode.Locked);
+
+        var (title, _) = await HandleAsync(exception, culture);
+
+        title.ShouldBe(nameof(CustomException));
+    }
+}

--- a/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
+++ b/src/Tests/Framework.Tests/Web/GlobalExceptionHandlerTests.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Web.Exceptions;
+using Framework.Tests.Localization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Net;
@@ -14,7 +15,10 @@ public sealed class GlobalExceptionHandlerTests
         context.Request.Path = "/api/v1/identity/forgot-password";
         context.Response.Body = new MemoryStream();
 
-        var handler = new GlobalExceptionHandler(NullLogger<GlobalExceptionHandler>.Instance);
+        var handler = new GlobalExceptionHandler(
+            NullLogger<GlobalExceptionHandler>.Instance,
+            SharedResourcesLocalizerFactory.Create(),
+            SharedResourcesLocalizerFactory.CreateFactory());
         await handler.TryHandleAsync(context, exception, CancellationToken.None);
         return context;
     }

--- a/src/Tests/Identity.Tests/Data/IdentityDbContextModelTests.cs
+++ b/src/Tests/Identity.Tests/Data/IdentityDbContextModelTests.cs
@@ -1,0 +1,56 @@
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Framework.Shared.Persistence;
+using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Identity.Tests.Data;
+
+public class IdentityDbContextModelTests
+{
+    private static IdentityDbContext CreateContext()
+    {
+        var accessor = Substitute.For<IMultiTenantContextAccessor<AppTenantInfo>>();
+        accessor.MultiTenantContext.Returns(new MultiTenantContext<AppTenantInfo>(new AppTenantInfo()));
+
+        var options = new DbContextOptionsBuilder<IdentityDbContext>()
+            .UseNpgsql("Host=arch;Database=arch;Username=arch;Password=arch")
+            .Options;
+
+        var settings = Options.Create(new DatabaseOptions
+        {
+            Provider = "postgresql",
+            ConnectionString = string.Empty,
+            MigrationsAssembly = "FSH.Starter.Migrations.PostgreSQL",
+        });
+
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns("Production");
+
+        return new IdentityDbContext(accessor, options, settings, environment);
+    }
+
+    // User.Locale holds a BCP-47 tag, which is short and bounded. Unbounded `text`
+    // invites arbitrary input at the storage layer for a value the write boundary
+    // already restricts to SupportedCultures.Tags. 10 covers the longest form the
+    // platform could offer (language-script-region, e.g. zh-Hant-TW).
+    [Fact]
+    public void User_Locale_Is_Bounded_To_A_Bcp47_Tag_Length()
+    {
+        using var context = CreateContext();
+
+        var locale = context.Model.FindEntityType(typeof(FshUser))?.FindProperty(nameof(FshUser.Locale));
+
+        locale.ShouldNotBeNull();
+        locale!.GetMaxLength().ShouldBe(
+            10,
+            "an unbounded locale column accepts arbitrary input for a value that is always a short BCP-47 tag");
+    }
+}

--- a/src/Tests/Identity.Tests/Handlers/StartImpersonationCommandHandlerTests.cs
+++ b/src/Tests/Identity.Tests/Handlers/StartImpersonationCommandHandlerTests.cs
@@ -1,0 +1,100 @@
+using System.Security.Claims;
+using FSH.Framework.Core.Context;
+using FSH.Framework.Shared.Constants;
+using FSH.Modules.Auditing.Contracts;
+using FSH.Modules.Identity.Contracts.Services;
+using FSH.Modules.Identity.Contracts.v1.Impersonation;
+using FSH.Modules.Identity.Contracts.v1.Impersonation.StartImpersonation;
+using FSH.Modules.Identity.Features.v1.Impersonation.StartImpersonation;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace Identity.Tests.Handlers;
+
+/// <summary>
+/// The impersonation token must NOT carry the target user's `locale` claim — language is a
+/// presentation concern, so the operator keeps reading in their own language.
+/// </summary>
+public sealed class StartImpersonationCommandHandlerTests
+{
+    private const string TenantId = "codefi";
+    private const string TargetUserId = "target-user";
+
+    private readonly IIdentityService _identityService = Substitute.For<IIdentityService>();
+    private readonly ITokenService _tokenService = Substitute.For<ITokenService>();
+    private readonly ISecurityAudit _securityAudit = Substitute.For<ISecurityAudit>();
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+    private readonly IRequestContext _requestContext = Substitute.For<IRequestContext>();
+    private readonly IImpersonationGrantService _grantService = Substitute.For<IImpersonationGrantService>();
+
+    private StartImpersonationCommandHandler CreateSut() =>
+        new(_identityService, _tokenService, _securityAudit, _currentUser, _requestContext,
+            _grantService, TimeProvider.System, Substitute.For<ILogger<StartImpersonationCommandHandler>>());
+
+    [Fact]
+    public async Task Handle_strips_locale_but_preserves_identity_claims_and_injects_actor()
+    {
+        // Arrange — an authenticated operator in the same tenant as the target.
+        var actorUserId = Guid.NewGuid();
+        _currentUser.IsAuthenticated().Returns(true);
+        _currentUser.GetUserId().Returns(actorUserId);
+        _currentUser.GetTenant().Returns(TenantId);
+        _currentUser.Name.Returns("operator");
+        _currentUser.GetUserClaims().Returns(new List<Claim>());
+
+        // A realistic target claim set: the persisted `locale` must be dropped, but every other
+        // identity claim (name, role, subject, tenant) must survive into the impersonation token.
+        var targetClaims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Jti, "orig-jti"),
+            new(JwtRegisteredClaimNames.Sub, TargetUserId),
+            new(ClaimConstants.Tenant, TenantId),
+            new(ClaimTypes.Name, "Target User"),
+            new(ClaimTypes.Role, "Admin"),
+            new("locale", "pt-BR"),
+        };
+        _identityService
+            .BuildClaimsForUserAsync(TargetUserId, TenantId, Arg.Any<CancellationToken>())
+            .Returns(((string, IEnumerable<Claim>)?)(TargetUserId, targetClaims));
+
+        IEnumerable<Claim>? issuedClaims = null;
+        _tokenService
+            .IssueAccessOnlyAsync(
+                Arg.Any<string>(),
+                Arg.Do<IEnumerable<Claim>>(c => issuedClaims = c),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(("access-token", DateTime.UtcNow.AddMinutes(15)));
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(new StartImpersonationCommand(TargetUserId, TenantId, "reason", 15), CancellationToken.None);
+
+        // Assert
+        issuedClaims.ShouldNotBeNull();
+        var issued = issuedClaims.ToList();
+
+        // (a) locale is stripped — the operator keeps reading in their own language.
+        issued.ShouldNotContain(c => c.Type == "locale");
+
+        // (b) every NON-locale identity claim survives — a mutation that over-strips (e.g. drops Name,
+        //     role, sub or tenant) must fail here.
+        issued.ShouldContain(c => c.Type == ClaimTypes.Name && c.Value == "Target User");
+        issued.ShouldContain(c => c.Type == ClaimTypes.Role && c.Value == "Admin");
+        issued.ShouldContain(c => c.Type == JwtRegisteredClaimNames.Sub && c.Value == TargetUserId);
+        issued.ShouldContain(c => c.Type == ClaimConstants.Tenant && c.Value == TenantId);
+
+        // (c) RFC 8693 actor claims are injected so the token records who is acting.
+        issued.ShouldContain(c => c.Type == ClaimConstants.ActorSubject && c.Value == actorUserId.ToString());
+        issued.ShouldContain(c => c.Type == ClaimConstants.ActorTenant && c.Value == TenantId);
+
+        // (d) the jti is swapped: the target's original jti is gone and exactly one fresh, non-empty
+        //     jti is present (so the persisted grant row and the JWT share a new identifier).
+        issued.ShouldNotContain(c => c.Type == JwtRegisteredClaimNames.Jti && c.Value == "orig-jti");
+        var jti = issued.Single(c => c.Type == JwtRegisteredClaimNames.Jti);
+        jti.Value.ShouldNotBe("orig-jti");
+        jti.Value.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/Tests/Identity.Tests/Handlers/UpdateUserCommandHandlerTests.cs
+++ b/src/Tests/Identity.Tests/Handlers/UpdateUserCommandHandlerTests.cs
@@ -39,7 +39,8 @@ public sealed class UpdateUserCommandHandlerTests
             command.LastName ?? string.Empty,
             command.PhoneNumber ?? string.Empty,
             command.Image!,
-            command.DeleteCurrentImage);
+            command.DeleteCurrentImage,
+            command.Locale);
     }
 
     [Fact]
@@ -66,7 +67,8 @@ public sealed class UpdateUserCommandHandlerTests
             string.Empty,
             string.Empty,
             null!,
-            true);
+            true,
+            command.Locale);
     }
 
     [Fact]
@@ -83,7 +85,7 @@ public sealed class UpdateUserCommandHandlerTests
         // Arrange
         var command = _fixture.Create<UpdateUserCommand>();
         var expectedExceptionMessage = "Update failed";
-        _userService.UpdateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<FSH.Framework.Shared.Storage.FileUploadRequest>(), Arg.Any<bool>())
+        _userService.UpdateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<FSH.Framework.Shared.Storage.FileUploadRequest>(), Arg.Any<bool>(), Arg.Any<string?>())
             .Returns(x => throw new InvalidOperationException(expectedExceptionMessage));
 
         // Act & Assert

--- a/src/Tests/Identity.Tests/Services/CreateBasicClaimsTests.cs
+++ b/src/Tests/Identity.Tests/Services/CreateBasicClaimsTests.cs
@@ -1,0 +1,38 @@
+using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Services;
+
+namespace Identity.Tests.Services;
+
+/// <summary>
+/// The JWT carries the OIDC-standard `locale` claim only when the user explicitly chose a language;
+/// an unset locale emits no claim so culture resolution can fall through to Accept-Language.
+/// </summary>
+public sealed class CreateBasicClaimsTests
+{
+    private static FshUser User(string? locale) =>
+        new() { Id = "u1", Email = "u@codefi.com.br", UserName = "u", FirstName = "First", LastName = "Last", Locale = locale };
+
+    [Fact]
+    public void Emits_locale_claim_when_user_locale_is_set()
+    {
+        var claims = IdentityService.CreateBasicClaims(User("pt-BR"), "codefi");
+
+        claims.Single(c => c.Type == "locale").Value.ShouldBe("pt-BR");
+    }
+
+    [Fact]
+    public void Omits_locale_claim_when_user_locale_is_null()
+    {
+        var claims = IdentityService.CreateBasicClaims(User(null), "codefi");
+
+        claims.Any(c => c.Type == "locale").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Omits_locale_claim_when_user_locale_is_whitespace()
+    {
+        var claims = IdentityService.CreateBasicClaims(User("   "), "codefi");
+
+        claims.Any(c => c.Type == "locale").ShouldBeFalse();
+    }
+}

--- a/src/Tests/Identity.Tests/Services/UserLocaleTests.cs
+++ b/src/Tests/Identity.Tests/Services/UserLocaleTests.cs
@@ -1,0 +1,95 @@
+using Finbuckle.MultiTenant.Abstractions;
+using FSH.Framework.Shared.Multitenancy;
+using FSH.Framework.Storage.Services;
+using FSH.Framework.Web.Origin;
+using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Services;
+using Identity.Tests.Support;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Identity.Tests.Services;
+
+/// <summary>
+/// Covers the User.Locale foundation: UpdateAsync persists the locale onto the entity and
+/// GetAsync projects it back onto the DTO.
+/// </summary>
+public sealed class UserLocaleTests
+{
+    private readonly UserManager<FshUser> _userManager;
+    private readonly SignInManager<FshUser> _signInManager;
+    private readonly IStorageService _storageService;
+    private readonly IMultiTenantContextAccessor<AppTenantInfo> _tenantAccessor;
+
+    public UserLocaleTests()
+    {
+        _userManager = Substitute.For<UserManager<FshUser>>(
+            Substitute.For<IUserStore<FshUser>>(), null, null, null, null, null, null, null, null);
+        _signInManager = Substitute.For<SignInManager<FshUser>>(
+            _userManager,
+            Substitute.For<IHttpContextAccessor>(),
+            Substitute.For<IUserClaimsPrincipalFactory<FshUser>>(),
+            Options.Create(new IdentityOptions()),
+            Substitute.For<ILogger<SignInManager<FshUser>>>(),
+            Substitute.For<IAuthenticationSchemeProvider>(),
+            Substitute.For<IUserConfirmation<FshUser>>());
+        _signInManager.RefreshSignInAsync(Arg.Any<FshUser>()).Returns(Task.CompletedTask);
+        _storageService = Substitute.For<IStorageService>();
+        _tenantAccessor = Substitute.For<IMultiTenantContextAccessor<AppTenantInfo>>();
+    }
+
+    private UserProfileService CreateSut() =>
+        new(_userManager, _signInManager, _storageService, _tenantAccessor,
+            Options.Create(new OriginOptions()), Substitute.For<IHttpContextAccessor>());
+
+    [Fact]
+    public async Task UpdateAsync_persists_the_supplied_locale_onto_the_user()
+    {
+        // Arrange
+        var user = new FshUser { Id = "u1", Email = "u@codefi.com.br", UserName = "u" };
+        _userManager.FindByIdAsync("u1").Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        var sut = CreateSut();
+
+        // Act
+        await sut.UpdateAsync("u1", "First", "Last", string.Empty, null!, false, "pt-BR", CancellationToken.None);
+
+        // Assert
+        user.Locale.ShouldBe("pt-BR");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_with_null_locale_preserves_the_existing_value()
+    {
+        // Arrange — a text-only edit forwards a null locale; the user already chose en-US.
+        var user = new FshUser { Id = "u1", Email = "u@codefi.com.br", UserName = "u", Locale = "en-US" };
+        _userManager.FindByIdAsync("u1").Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        var sut = CreateSut();
+
+        // Act
+        await sut.UpdateAsync("u1", "First", "Last", string.Empty, null!, false, null, CancellationToken.None);
+
+        // Assert
+        user.Locale.ShouldBe("en-US");
+    }
+
+    [Fact]
+    public async Task GetAsync_projects_the_persisted_locale_onto_the_dto()
+    {
+        // Arrange
+        var user = new FshUser { Id = "u1", Email = "u@codefi.com.br", UserName = "u", Locale = "pt-BR" };
+        _userManager.Users.Returns(new[] { user }.AsAsyncQueryable());
+        var sut = CreateSut();
+
+        // Act
+        var dto = await sut.GetAsync("u1", CancellationToken.None);
+
+        // Assert
+        dto.Locale.ShouldBe("pt-BR");
+    }
+}

--- a/src/Tests/Identity.Tests/Support/SharedResourcesLocalizerFactory.cs
+++ b/src/Tests/Identity.Tests/Support/SharedResourcesLocalizerFactory.cs
@@ -1,0 +1,18 @@
+using FSH.Framework.Core.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Identity.Tests.Support;
+
+// Builds a REAL IStringLocalizer<SharedResources> bound to the embedded resx catalog so validator
+// tests exercise the actual catalog under the ambient UI culture (default culture -> neutral English).
+internal static class SharedResourcesLocalizerFactory
+{
+    public static IStringLocalizer<SharedResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<SharedResources>>();
+    }
+}

--- a/src/Tests/Identity.Tests/Support/TestAsyncQueryable.cs
+++ b/src/Tests/Identity.Tests/Support/TestAsyncQueryable.cs
@@ -1,0 +1,68 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Identity.Tests.Support;
+
+/// <summary>
+/// Minimal in-memory async queryable so services that call EF's <c>FirstOrDefaultAsync</c>
+/// (e.g. <c>UserManager.Users.Where(...).FirstOrDefaultAsync</c>) can be unit tested against a
+/// mocked <c>UserManager.Users</c> without a database. Standard EF unit-testing scaffold.
+/// </summary>
+internal static class TestAsyncQueryable
+{
+    public static IQueryable<T> AsAsyncQueryable<T>(this IEnumerable<T> source) =>
+        new TestAsyncEnumerable<T>(source);
+}
+
+internal sealed class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+{
+    private readonly IQueryProvider _inner;
+
+    internal TestAsyncQueryProvider(IQueryProvider inner) => _inner = inner;
+
+    public IQueryable CreateQuery(Expression expression) => new TestAsyncEnumerable<TEntity>(expression);
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression expression) => new TestAsyncEnumerable<TElement>(expression);
+
+    public object? Execute(Expression expression) => _inner.Execute(expression);
+
+    public TResult Execute<TResult>(Expression expression) => _inner.Execute<TResult>(expression);
+
+    public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)
+    {
+        // TResult is Task<T>; run the query synchronously through the base provider and wrap the result.
+        var resultType = typeof(TResult).GetGenericArguments()[0];
+        var executionResult = _inner.Execute(expression);
+        var fromResult = typeof(Task).GetMethod(nameof(Task.FromResult))!.MakeGenericMethod(resultType);
+        return (TResult)fromResult.Invoke(null, new[] { executionResult })!;
+    }
+}
+
+internal sealed class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+{
+    public TestAsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable) { }
+
+    public TestAsyncEnumerable(Expression expression) : base(expression) { }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+        new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+
+    IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+}
+
+internal sealed class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+    private readonly IEnumerator<T> _inner;
+
+    public TestAsyncEnumerator(IEnumerator<T> inner) => _inner = inner;
+
+    public T Current => _inner.Current;
+
+    public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(_inner.MoveNext());
+
+    public ValueTask DisposeAsync()
+    {
+        _inner.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Tests/Identity.Tests/Validators/UpdateUserCommandValidatorTests.cs
+++ b/src/Tests/Identity.Tests/Validators/UpdateUserCommandValidatorTests.cs
@@ -1,5 +1,8 @@
+using System.Globalization;
+using System.Linq;
 using FSH.Modules.Identity.Contracts.v1.Users.UpdateUser;
 using FSH.Modules.Identity.Features.v1.Users.UpdateUser;
+using Identity.Tests.Support;
 using Shouldly;
 using Xunit;
 
@@ -7,7 +10,21 @@ namespace Identity.Tests.Validators;
 
 public sealed class UpdateUserCommandValidatorTests
 {
-    private readonly UpdateUserCommandValidator _sut = new();
+    private readonly UpdateUserCommandValidator _sut = new(SharedResourcesLocalizerFactory.Create());
+
+    private static TResult WithCulture<TResult>(string culture, Func<TResult> action)
+    {
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo(culture);
+            return action();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
 
     [Fact]
     public void Validate_Should_Pass_When_ValidMinimalCommand()
@@ -40,10 +57,10 @@ public sealed class UpdateUserCommandValidatorTests
     public void Validate_Should_Fail_When_FirstNameExceedsMaxLength()
     {
         // Arrange
-        var command = new UpdateUserCommand 
-        { 
-            Id = "user-123", 
-            FirstName = new string('a', 51) 
+        var command = new UpdateUserCommand
+        {
+            Id = "user-123",
+            FirstName = new string('a', 51)
         };
 
         // Act
@@ -58,10 +75,10 @@ public sealed class UpdateUserCommandValidatorTests
     public void Validate_Should_Fail_When_EmailIsInvalid()
     {
         // Arrange
-        var command = new UpdateUserCommand 
-        { 
-            Id = "user-123", 
-            Email = "not-an-email" 
+        var command = new UpdateUserCommand
+        {
+            Id = "user-123",
+            Email = "not-an-email"
         };
 
         // Act
@@ -76,18 +93,69 @@ public sealed class UpdateUserCommandValidatorTests
     public void Validate_Should_Fail_When_DeleteImageAndUploadImage_Simultaneously()
     {
         // Arrange
-        var command = new UpdateUserCommand 
-        { 
-            Id = "user-123", 
-            DeleteCurrentImage = true, 
-            Image = new FSH.Framework.Shared.Storage.FileUploadRequest { FileName = "test.png", Data = [0] } 
+        var command = new UpdateUserCommand
+        {
+            Id = "user-123",
+            DeleteCurrentImage = true,
+            Image = new FSH.Framework.Shared.Storage.FileUploadRequest { FileName = "test.png", Data = [0] }
         };
+
+        // Act — pin en-US so the localized message resolves to the neutral (English) catalog.
+        var result = WithCulture("en-US", () => _sut.Validate(command));
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.ErrorMessage == "You cannot upload a new image and delete the current one simultaneously.");
+    }
+
+    [Theory]
+    [InlineData("pt-BR", true)]
+    [InlineData("en-US", true)]
+    [InlineData(null, true)]
+    // Empty/whitespace is treated as "not provided": the .When(!IsNullOrWhiteSpace) guard skips the
+    // rule, so an empty locale is valid (the caller simply isn't changing it).
+    [InlineData("", true)]
+    // Case matters: SupportedCultures.Tags.Contains is ordinal, so a wrong-case tag is rejected —
+    // pins the ordinal comparison against an accidental case-insensitive refactor.
+    [InlineData("pt-br", false)]
+    [InlineData("PT-BR", false)]
+    [InlineData("xx-YY", false)]
+    [InlineData("notaculture", false)]
+    public void Locale_Must_Be_Supported_Or_Null(string? locale, bool expectedValid)
+    {
+        // Arrange
+        var command = new UpdateUserCommand { Id = "user-123", Locale = locale };
 
         // Act
         var result = _sut.Validate(command);
 
         // Assert
-        result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain(e => e.ErrorMessage == "You cannot upload a new image and delete the current one simultaneously.");
+        result.Errors.Any(e => e.PropertyName == nameof(UpdateUserCommand.Locale)).ShouldBe(!expectedValid);
+    }
+
+    [Fact]
+    public void UserId_required_message_is_localized_under_ptBR()
+    {
+        // Act
+        var result = WithCulture("pt-BR", () => _sut.Validate(new UpdateUserCommand { Id = "" }));
+
+        // Assert — custom WithMessage resolves from the .pt-BR catalog.
+        result.Errors.Single(e => e.PropertyName == "Id").ErrorMessage
+            .ShouldBe("O ID do usuário é obrigatório.");
+    }
+
+    [Fact]
+    public void Builtin_validation_message_is_localized_under_ptBR()
+    {
+        // Act — FluentValidation resolves built-in messages via CurrentUICulture (ships a pt catalog).
+        var result = WithCulture("pt-BR", () =>
+            _sut.Validate(new UpdateUserCommand { Id = "user-123", Email = "not-an-email" }));
+
+        // Assert — pin the actual Portuguese text, not merely the absence of the English one.
+        // "does not contain the English sentence" is satisfied by a blank message, by a raw
+        // resource key leaking through, and by any wrong-but-non-English string, so it stayed
+        // green through exactly the failures it existed to catch.
+        var message = result.Errors.Single(e => e.PropertyName == "Email").ErrorMessage;
+        message.ShouldBe("'Email' é um endereço de email inválido.");
     }
 }


### PR DESCRIPTION
Framework slice of the i18n work, split out of [#1344](https://github.com/fullstackhero/dotnet-starter-kit/pull/1344) as you asked. This is the one that needs real scrutiny; **56 files**.

The split is four PRs rather than three. Your three were framework / `clients/admin` / `clients/dashboard`, but the ~220 files of module-level localization fit none of them, and folding them into the framework PR would put it back at ~285 files and defeat the point. So the module catalogs and their handler/validator wiring live in their own PR.

| Slice | Files | PR |
|---|---|---|
| **Framework** | 56 | this one |
| Module catalogs and wiring | 229 | [#1361](https://github.com/fullstackhero/dotnet-starter-kit/pull/1361) — depends on this one |
| `clients/admin` | 111 | [#1362](https://github.com/fullstackhero/dotnet-starter-kit/pull/1362) — independent |
| `clients/dashboard` | 134 | [#1363](https://github.com/fullstackhero/dotnet-starter-kit/pull/1363) — independent |

The union of the four is byte-identical to `#1344`'s tree, with empty pairwise intersection apart from the one shared `src/Directory.Packages.props` hunk. That is asserted by a script, not by eye: for each slice, `git diff --quiet feat/i18n <slice> -- <its paths>` and `git diff --name-only main <slice>` equal to its declared path set.

The two front-end PRs depend on nothing here and can be reviewed in parallel. The module PR does not compile without this one — verified, not assumed: `src/Modules/**` applied alone on `main` fails with 862 compile errors, all rooted in `FSH.Framework.Core.Localization` not existing.

## ⚠️ Touches protected `src/BuildingBlocks` (Golden Rule #4)

Seventeen files here, needing maintainer sign-off:

**`Core`** — `Core.csproj`; `Exceptions/` (`CustomException`, `ForbiddenException`, `UnauthorizedException`, and the new `ILocalizableMessage`, `LocalizedKeyNotFoundException`, `LocalizedUnauthorizedAccessException`); `Localization/` (new `SharedResources` marker + `SupportedCultures` + the two shared catalogs).

**`Web`** — `Extensions.cs` (registers and orders the localization middleware, +6 lines); `Exceptions/GlobalExceptionHandler.cs`; new `Localization/` (`LocalizationExtensions`, `UserLocaleRequestCultureProvider`).

**`Jobs`** — `Extensions.cs`, one exception message. **`Storage`** — `QuotaMeteredStorageService.cs`, one exception message.

**One eighteenth `BuildingBlocks` file is in the module PR instead**, and I want to be upfront about it: `Web/Validation/PagedQueryValidator.cs`. Its constructor now takes `IStringLocalizer<SharedResources>`, and all three subclasses (`GetAuditsQueryValidator`, `GetTenantsQueryValidator`, `SearchUsersQueryValidator`) live in modules. Keeping the base class here would either break this PR's build or drag the Auditing catalog and handler in with it; sending it with its three callers keeps both PRs compiling on their own and puts the change in front of the code it affects. It is declared under Golden Rule #4 there too.

No existing behaviour of other building blocks is altered. `src/Directory.Packages.props` carries one addition, the `SSH.NET` pin discussed at the end.

## `UseRequestLocalization` sets the UI culture only

You asked whether UI-culture-only was considered. It is what ships.

`main` has no request localization at all, so pinning the formatting culture is *less* change than negotiating it: `CultureInfo.CurrentCulture` behaves exactly as it does on `main` today, and only resource lookup follows the request. For an API whose output is JSON that is the safer default, and it makes the CA1305 question moot rather than merely bounded.

It is not one switch. `RequestLocalizationMiddleware.SetCurrentThreadCulture` assigns both cultures unconditionally, so the culture half has to be pinned:

- `DefaultRequestCulture` carries `(InvariantCulture, configured default)`. The middleware resolves the culture half as `cultureInfo ??= DefaultRequestCulture.Culture`, making invariant the only reachable value.
- `SupportedCultures` is `null`, so the middleware skips culture filtering entirely. A one-element `[InvariantCulture]` list behaves identically but logs `UnsupportedCultures` on **every** request — the middleware's parent-culture walk bails at the empty culture name, so invariant is unmatchable by design.

With formatting out of the negotiation, the neutral `pt`/`en` entries in `RequestMatch` bought nothing and are gone; `SupportedCultures.Tags` is the single, specific-only list. A request asking for a bare `pt` or an unsupported variant resolves to the configured default. Both React apps canonicalise variants onto supported tags before calling the API, so app traffic is unaffected; a hand-rolled client sending bare `pt` gets the default.

**Message arguments are culture-insensitive too.** The localizer formats with `string.Format` under `CurrentCulture`, so a `double` or `DateTime` in a message would render with an invariant separator. Every `MessageArgs` site and every `localizer["…", …]` call site was enumerated: all `int`, `long`, `string` or enum, except `MaxWindow.TotalDays` in the two audit-window validators, which is now an `int` at the source (that change travels with the module PR).

## Catalogs are named for specific cultures

`SharedResources.pt-BR.resx` here, and the same convention for the ten module catalogs in the module PR. Renames only, no string changed.

The asymmetry with the front-end is gone, and so is the trap behind it: a future `pt-PT` is no longer served Brazilian strings by parent fallback. The documented consequence is that a bare `pt` or an unsupported variant lands on the neutral English catalog rather than on Portuguese. Adding a language is: add the specific tag to `SupportedCultures.Tags`, add a `*.{tag}.resx` per catalog, add the JSON catalogs to both apps, and drop it from the front-end `CANON` map if it was being folded into another tag. `.agents/rules/localization.md` records all of this.

## The `Locale` column

The original summary was wrong: there is no DB default. The column is nullable with **`en-US` as a code-level fallback**, and it is `character varying(10)` rather than unbounded `text` — 10 covers language-script-region (`zh-Hant-TW`). `AddUserLocale` was edited in place rather than stacked with an `ALTER`, since it has never shipped in a release.

Confirmed as you asked: `Validation.UnsupportedLocale` is wired at the write boundary. `UpdateUserCommandValidator` restricts `Locale` to `SupportedCultures.Tags`, on `PUT /identity/profile`, via the Mediator `ValidationBehavior`. The column constraint is the storage-level backstop, not the validation.

Because whole files cannot be split across PRs, three Identity files carry both the `Locale` plumbing and their `IdentityResources` wiring in the same diff (`IdentityService`, `UserProfileService`, `StartImpersonationCommandHandler`). They ship here, which is why `IdentityResources` and its two catalogs ride along in this PR rather than in the module one.

## Known behaviour (documented, not bugs)

- **The `locale` claim lags a language switch by one token.** The provider reads the JWT claim, so a switch reaches the API at the next token issue. The front-end persists to the profile and re-mints, so it converges; in between, the shell can be in the new language while an API error is still in the old one. The alternative is a per-request DB read on every authenticated call.
- **SignalR does not carry the app locale.** The hub client builds its own requests instead of going through `apiFetch`, so `Accept-Language` on the negotiate is the browser's. Applies to every session, not just impersonation. Named explicitly in the front-end `handoff-locale.spec.ts` so any *other* channel that stops carrying the locale fails the test.
- **Middleware registered before localization renders its errors in the default language.** `UseExceptionHandler()` sits ahead of `UseHeroLocalization()`, which in turn has to sit after `UseAuthentication()` because the culture provider reads the `locale` claim off `HttpContext.User`. An exception thrown by anything in between — HTTPS redirection, CORS, static files, routing — is therefore rendered in the configured default culture rather than the caller's. Endpoint handlers, where every localized exception in this codebase is actually thrown, are unaffected. Moving the exception handler below localization would leave those middlewares with no `ProblemDetails` at all, which is the worse trade, so this stays as documented behaviour rather than being papered over.

## Also in this slice, from the last review round

- **`LogContext.PushProperty` is scoped in `using` blocks.** Pre-existing AsyncLocal leak that contaminated every subsequent log entry in the request; unrelated to i18n, fixed here because the same lines were being touched.
- **Unmapped status codes are no longer titled "an unexpected error occurred".** `TitleKeyFor` sent everything outside four statuses to `Error.Unexpected`; the type-name fallback beside it only fires on `ResourceNotFound`, and that key resolves, so it never fired. `#1344` regressed this — before it, `Title` was the exception type name. Unmapped statuses fall back to the type name again, and `Conflict` gets a real localized title. The 41 `Conflict` throw sites this affected are in Billing and Catalog, so the visible half of that fix lands with the module PR.
- **`ExceptionSeverityClassifier` is now exercised with the `Localized*` subclasses.** They subclass the BCL types precisely so audit severity classification keeps working; changing a base type would have silently reclassified every unauthorized access with the suite green.

## The `SSH.NET` pin is carried from #1333

`NU1903` / `GHSA-q939-rpr3-3284` on `SSH.NET` 2025.1.0, pulled transitively by Testcontainers, fails `restore` for the whole solution under `TreatWarningsAsErrors` — on `main` too: `dotnet restore src/FSH.Starter.slnx` at `3f2959e6` fails identically, re-verified today. It is not introduced here, and the fix properly belongs to [#1333](https://github.com/fullstackhero/dotnet-starter-kit/pull/1333).

Rather than leave this red on someone else's advisory, the pin is carried **byte-identical** to #1333's version of the file, comment included. That keeps both mergeable in either order: `git merge-tree` on both orderings yields a clean tree holding a single `SSH.NET` entry, and the merged file is identical to what #1333 alone produces. The byte identity is what buys that — the same pin under a reworded comment conflicts. If #1333's pin changes during review this copy should be matched rather than allowed to drift, and once #1333 lands first it can simply be dropped. All four slices carry it, including the two front-end ones: `template-smoke.yml` runs on `clients/**` and builds the scaffolded solution, which includes `src/Tests/**`.

## Testing

Every number below is this slice on its own, at `main` plus these 56 files.

- `dotnet restore src/FSH.Starter.slnx` with the audit **on**: exit 0, no `NU1903`.
- `dotnet build -warnaserror`: exit 0.
- Full suite: **14 test assemblies, 1868 passed / 0 failed / 1 skipped**, including Integration (Testcontainers/Postgres, Docker) at 746 passed / 1 skipped. `#1344` reported 15 assemblies and 1891 passed; the missing assembly is `Tickets.Tests`, which the module PR adds to the solution, and the 23-test difference is that project plus the module-catalog tests. Nothing was dropped — the per-slice sums add back up.

The verdict above is aggregated per assembly rather than taken from the process exit code: `dotnet test` on this solution has been observed exiting 0 while reporting failures, and zero assemblies reporting is itself treated as red.

## Docs (Golden Rule #10)

[fullstackhero/docs#238](https://github.com/fullstackhero/docs/pull/238), kept as a single PR covering **all four** slices — `internationalization.mdx` is one page whose sections map across the split, so cutting it into four would put four PRs on the same file and leave three describing half a feature. From this slice it documents the culture resolution chain, per-user language, the new config section and `code` on `ProblemDetails`, all of which are public contract.

It should merge **after the last of the four**, not with this one: landing it here alone would publish the module-catalog and front-end sections before that code is on `main`.

## Notes

- `en-US` and `pt-BR` are held at strict key **and placeholder** parity, enforced by tests, so a missing or mis-arged translation fails the build instead of shipping English. The generic reflection-driven `CatalogParityTests` that covers every module catalog travels with the module PR.
- The lost update behind the front-end hydration guard is a contract change to `PUT /identity/profile` and is tracked separately in [#1359](https://github.com/fullstackhero/dotnet-starter-kit/issues/1359).
