### PR TITLE
feat(localization): module catalogs and localized messages (2/4)

### DIFF
--- a/src/BuildingBlocks/Web/Validation/PagedQueryValidator.cs
+++ b/src/BuildingBlocks/Web/Validation/PagedQueryValidator.cs
@@ -1,5 +1,7 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Shared.Persistence;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Framework.Web.Validation;
 
@@ -10,9 +12,9 @@ namespace FSH.Framework.Web.Validation;
 /// <example>
 /// public class MyQueryValidator : AbstractValidator&lt;MyQuery&gt;
 /// {
-///     public MyQueryValidator()
+///     public MyQueryValidator(IStringLocalizer&lt;SharedResources&gt; localizer)
 ///     {
-///         Include(new PagedQueryValidator&lt;MyQuery&gt;());
+///         Include(new PagedQueryValidator&lt;MyQuery&gt;(localizer));
 ///         // Add additional rules...
 ///     }
 /// }
@@ -20,21 +22,21 @@ namespace FSH.Framework.Web.Validation;
 public sealed class PagedQueryValidator<T> : AbstractValidator<T>
     where T : IPagedQuery
 {
-    public PagedQueryValidator()
+    public PagedQueryValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(q => q.PageNumber)
             .GreaterThan(0)
             .When(q => q.PageNumber.HasValue)
-            .WithMessage("Page number must be greater than 0.");
+            .WithMessage(_ => localizer["Validation.PageNumberMinimum"]);
 
         RuleFor(q => q.PageSize)
             .InclusiveBetween(1, 100)
             .When(q => q.PageSize.HasValue)
-            .WithMessage("Page size must be between 1 and 100.");
+            .WithMessage(_ => localizer["Validation.PageSizeRange"]);
 
         RuleFor(q => q.Sort)
             .MaximumLength(200)
             .When(q => !string.IsNullOrEmpty(q.Sort))
-            .WithMessage("Sort expression must not exceed 200 characters.");
+            .WithMessage(_ => localizer["Validation.SortMaxLength"]);
     }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -143,5 +143,12 @@
          AccessViolation). Transitive pinning is enabled, so this entry alone bumps it.
          Remove once the SignalR backplane package depends on a patched version itself. -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <!-- Pulled transitively by the Testcontainers packages; versions up to 2025.1.0 fail
+         NuGet audit (NU1903, GHSA-q939-rpr3-3284 / CVE-2026-48798: ScpClient recursive
+         download writes outside the target directory), which breaks restore for the whole
+         solution under TreatWarningsAsErrors. Testcontainers 4.11.0 and 4.13.0 both depend
+         on 2025.1.0, so bumping Testcontainers does not help; 2026.0.0 is the first patched
+         release. Remove once Testcontainers depends on a patched version itself. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 </Project>

--- a/src/FSH.Starter.slnx
+++ b/src/FSH.Starter.slnx
@@ -80,6 +80,7 @@
     <Project Path="Tests/Integration.Tests/Integration.Tests.csproj" />
     <Project Path="Tests/Integration.Middleware.Tests/Integration.Middleware.Tests.csproj" />
     <Project Path="Tests/Multitenancy.Tests/Multitenancy.Tests.csproj" Id="985345a2-edb4-4ef9-9a1b-59b704f523b6" />
+    <Project Path="Tests/Tickets.Tests/Tickets.Tests.csproj" />
   </Folder>
   <!--#if (includeTools) -->
   <Folder Name="/Tools/">

--- a/src/Modules/Auditing/Modules.Auditing/Core/Audit.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Core/Audit.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Auditing.Contracts;
 using System.Diagnostics;
 
@@ -56,12 +57,20 @@ public static class Audit
                 eventType: AuditEventType.Exception,
                 severity: severity ?? DefaultSeverity(ex),
                 payload: new ExceptionEventPayload(area,
-                    ex.GetType().FullName ?? "Exception",
+                    RealExceptionType(ex).FullName ?? "Exception",
                     ex.Message ?? string.Empty,
                     StackTop(ex, maxFrames: 20),
                     ToDict(ex.Data),
                     routeOrLocation));
     }
+
+    // Localization wrappers (LocalizedKeyNotFoundException, LocalizedUnauthorizedAccessException) exist
+    // only to translate the response body; for audit type identity and exceptionType filtering they must
+    // present as their BCL base so queries stay stable. CustomException-derived types keep their own identity.
+    private static Type RealExceptionType(Exception ex) =>
+        ex is ILocalizableMessage and not CustomException && ex.GetType().BaseType is { } baseType
+            ? baseType
+            : ex.GetType();
 
     private static AuditSeverity DefaultSeverity(Exception ex)
     {

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditById/GetAuditByIdQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditById/GetAuditByIdQueryHandler.cs
@@ -1,5 +1,7 @@
+using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Auditing.Contracts.Dtos;
+using FSH.Modules.Auditing.Localization;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditById;
 using FSH.Modules.Auditing.Persistence;
 using Mediator;
@@ -31,9 +33,15 @@ public sealed class GetAuditByIdQueryHandler : IQueryHandler<GetAuditByIdQuery, 
 
         if (record is null)
         {
-            // KeyNotFoundException maps to 404 globally. Kept (not framework NotFoundException)
-            // because audit exception-type fixtures and severity classification key off this type.
-            throw new KeyNotFoundException($"Audit record {query.Id} not found.");
+            // LocalizedKeyNotFoundException maps to 404 globally and still keys off KeyNotFoundException
+            // (its base) for audit exception-type fixtures and severity classification, while the body
+            // localizes via MessageKey under the request culture.
+            throw new LocalizedKeyNotFoundException($"Audit record {query.Id} not found.")
+            {
+                MessageKey = "Auditing.AuditRecordNotFound",
+                MessageArgs = [query.Id],
+                ResourceSource = typeof(AuditingResources),
+            };
         }
 
         JsonElement payload;

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryHandler.cs
@@ -4,6 +4,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Auditing.Contracts.Authorization;
 using FSH.Modules.Auditing.Contracts.Dtos;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditSummary;
+using FSH.Modules.Auditing.Localization;
 using FSH.Modules.Auditing.Persistence;
 using FSH.Modules.Identity.Contracts.Services;
 using Mediator;
@@ -13,7 +14,8 @@ namespace FSH.Modules.Auditing.Features.v1.GetAuditSummary;
 
 public sealed class GetAuditSummaryQueryHandler : IQueryHandler<GetAuditSummaryQuery, AuditSummaryAggregateDto>
 {
-    public static readonly TimeSpan MaxWindow = TimeSpan.FromDays(90);
+    public const int MaxWindowDays = 90;
+    public static readonly TimeSpan MaxWindow = TimeSpan.FromDays(MaxWindowDays);
     public static readonly TimeSpan DefaultWindow = TimeSpan.FromDays(7);
 
     private readonly AuditDbContext _dbContext;
@@ -104,7 +106,11 @@ public sealed class GetAuditSummaryQueryHandler : IQueryHandler<GetAuditSummaryQ
             .ConfigureAwait(false);
         if (!allowed)
         {
-            throw new ForbiddenException("Cross-tenant audit summary requires Permissions.AuditTrails.ViewCrossTenant.");
+            throw new ForbiddenException("Cross-tenant audit summary requires Permissions.AuditTrails.ViewCrossTenant.")
+            {
+                MessageKey = "Error.Auditing.CrossTenantSummaryForbidden",
+                ResourceSource = typeof(AuditingResources),
+            };
         }
 
         return _dbContext.AuditRecords

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditSummary/GetAuditSummaryQueryValidator.cs
@@ -1,21 +1,26 @@
 using FluentValidation;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditSummary;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetAuditSummary;
 
 public sealed class GetAuditSummaryQueryValidator : AbstractValidator<GetAuditSummaryQuery>
 {
-    public GetAuditSummaryQueryValidator()
+    public GetAuditSummaryQueryValidator(IStringLocalizer<AuditingResources> localizer)
     {
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => localizer["Validation.DateRangeOrder"]);
 
         RuleFor(q => q)
             .Must(q =>
                 !q.FromUtc.HasValue
                 || !q.ToUtc.HasValue
                 || (q.ToUtc.Value - q.FromUtc.Value) <= GetAuditSummaryQueryHandler.MaxWindow)
-            .WithMessage($"Audit summary window cannot exceed {GetAuditSummaryQueryHandler.MaxWindow.TotalDays:0} days.");
+            // MaxWindowDays, not MaxWindow.TotalDays: the localizer formats arguments with
+            // string.Format under the current culture, and a double in a localized message is
+            // culture-sensitive by construction. An int cannot render a decimal separator.
+            .WithMessage(_ => localizer["Validation.SummaryWindowExceeded", GetAuditSummaryQueryHandler.MaxWindowDays]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryHandler.cs
@@ -6,6 +6,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Auditing.Contracts.Authorization;
 using FSH.Modules.Auditing.Contracts.Dtos;
 using FSH.Modules.Auditing.Contracts.v1.GetAudits;
+using FSH.Modules.Auditing.Localization;
 using FSH.Modules.Auditing.Persistence;
 using FSH.Modules.Identity.Contracts.Services;
 using Mediator;
@@ -21,7 +22,10 @@ public sealed class GetAuditsQueryHandler : IQueryHandler<GetAuditsQuery, PagedR
     /// to scan the entire table — without this guard, an unconstrained query
     /// degenerates into a full sequential scan as the audit volume grows.
     /// </summary>
-    public static readonly TimeSpan MaxWindow = TimeSpan.FromDays(90);
+    public const int MaxWindowDays = 90;
+
+    /// <inheritdoc cref="MaxWindowDays"/>
+    public static readonly TimeSpan MaxWindow = TimeSpan.FromDays(MaxWindowDays);
 
     /// <summary>
     /// Default lookback when the caller does not supply a from/to. Keeps the
@@ -157,7 +161,11 @@ public sealed class GetAuditsQueryHandler : IQueryHandler<GetAuditsQuery, PagedR
             .ConfigureAwait(false);
         if (!allowed)
         {
-            throw new ForbiddenException("Cross-tenant audit access requires Permissions.AuditTrails.ViewCrossTenant.");
+            throw new ForbiddenException("Cross-tenant audit access requires Permissions.AuditTrails.ViewCrossTenant.")
+            {
+                MessageKey = "Error.Auditing.CrossTenantAccessForbidden",
+                ResourceSource = typeof(AuditingResources),
+            };
         }
 
         return _dbContext.AuditRecords

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAudits/GetAuditsQueryValidator.cs
@@ -1,18 +1,23 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Web.Validation;
 using FSH.Modules.Auditing.Contracts.v1.GetAudits;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetAudits;
 
 public sealed class GetAuditsQueryValidator : AbstractValidator<GetAuditsQuery>
 {
-    public GetAuditsQueryValidator()
+    public GetAuditsQueryValidator(
+        IStringLocalizer<SharedResources> localizer,
+        IStringLocalizer<AuditingResources> auditLocalizer)
     {
-        Include(new PagedQueryValidator<GetAuditsQuery>());
+        Include(new PagedQueryValidator<GetAuditsQuery>(localizer));
 
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => auditLocalizer["Validation.DateRangeOrder"]);
 
         // Reject oversized windows up-front (user sees a 400, not a silent clamp). The handler
         // still clamps as defence in depth (e.g. when only one endpoint is supplied).
@@ -21,6 +26,9 @@ public sealed class GetAuditsQueryValidator : AbstractValidator<GetAuditsQuery>
                 !q.FromUtc.HasValue
                 || !q.ToUtc.HasValue
                 || (q.ToUtc.Value - q.FromUtc.Value) <= GetAuditsQueryHandler.MaxWindow)
-            .WithMessage($"Audit query window cannot exceed {GetAuditsQueryHandler.MaxWindow.TotalDays:0} days.");
+            // MaxWindowDays, not MaxWindow.TotalDays: the localizer formats arguments with
+            // string.Format under the current culture, and a double in a localized message is
+            // culture-sensitive by construction. An int cannot render a decimal separator.
+            .WithMessage(_ => auditLocalizer["Validation.WindowExceeded", GetAuditsQueryHandler.MaxWindowDays]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditsByCorrelation/GetAuditsByCorrelationQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditsByCorrelation/GetAuditsByCorrelationQueryValidator.cs
@@ -1,17 +1,19 @@
 using FluentValidation;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditsByCorrelation;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetAuditsByCorrelation;
 
 public sealed class GetAuditsByCorrelationQueryValidator : AbstractValidator<GetAuditsByCorrelationQuery>
 {
-    public GetAuditsByCorrelationQueryValidator()
+    public GetAuditsByCorrelationQueryValidator(IStringLocalizer<AuditingResources> localizer)
     {
         RuleFor(q => q.CorrelationId)
             .NotEmpty();
 
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => localizer["Validation.DateRangeOrder"]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditsByTrace/GetAuditsByTraceQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetAuditsByTrace/GetAuditsByTraceQueryValidator.cs
@@ -1,17 +1,19 @@
 using FluentValidation;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditsByTrace;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetAuditsByTrace;
 
 public sealed class GetAuditsByTraceQueryValidator : AbstractValidator<GetAuditsByTraceQuery>
 {
-    public GetAuditsByTraceQueryValidator()
+    public GetAuditsByTraceQueryValidator(IStringLocalizer<AuditingResources> localizer)
     {
         RuleFor(q => q.TraceId)
             .NotEmpty();
 
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => localizer["Validation.DateRangeOrder"]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetExceptionAudits/GetExceptionAuditsQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetExceptionAudits/GetExceptionAuditsQueryValidator.cs
@@ -1,14 +1,16 @@
 using FluentValidation;
 using FSH.Modules.Auditing.Contracts.v1.GetExceptionAudits;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetExceptionAudits;
 
 public sealed class GetExceptionAuditsQueryValidator : AbstractValidator<GetExceptionAuditsQuery>
 {
-    public GetExceptionAuditsQueryValidator()
+    public GetExceptionAuditsQueryValidator(IStringLocalizer<AuditingResources> localizer)
     {
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => localizer["Validation.DateRangeOrder"]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Features/v1/GetSecurityAudits/GetSecurityAuditsQueryValidator.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Features/v1/GetSecurityAudits/GetSecurityAuditsQueryValidator.cs
@@ -1,14 +1,16 @@
 using FluentValidation;
 using FSH.Modules.Auditing.Contracts.v1.GetSecurityAudits;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Auditing.Features.v1.GetSecurityAudits;
 
 public sealed class GetSecurityAuditsQueryValidator : AbstractValidator<GetSecurityAuditsQuery>
 {
-    public GetSecurityAuditsQueryValidator()
+    public GetSecurityAuditsQueryValidator(IStringLocalizer<AuditingResources> localizer)
     {
         RuleFor(q => q)
             .Must(q => !q.FromUtc.HasValue || !q.ToUtc.HasValue || q.FromUtc <= q.ToUtc)
-            .WithMessage("FromUtc must be less than or equal to ToUtc.");
+            .WithMessage(_ => localizer["Validation.DateRangeOrder"]);
     }
 }

--- a/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.cs
+++ b/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Auditing.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;AuditingResources&gt;</c> to the Auditing resx catalog.</summary>
+public sealed class AuditingResources;

--- a/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.pt-BR.resx
+++ b/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.pt-BR.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.Auditing.CrossTenantAccessForbidden" xml:space="preserve">
+    <value>O acesso a auditorias de outros inquilinos requer Permissions.AuditTrails.ViewCrossTenant.</value>
+  </data>
+  <data name="Error.Auditing.CrossTenantSummaryForbidden" xml:space="preserve">
+    <value>O resumo de auditorias de outros inquilinos requer Permissions.AuditTrails.ViewCrossTenant.</value>
+  </data>
+  <data name="Validation.DateRangeOrder" xml:space="preserve">
+    <value>FromUtc deve ser menor ou igual a ToUtc.</value>
+  </data>
+  <data name="Validation.WindowExceeded" xml:space="preserve">
+    <value>A janela de consulta de auditoria não pode exceder {0} dias.</value>
+  </data>
+  <data name="Validation.SummaryWindowExceeded" xml:space="preserve">
+    <value>A janela do resumo de auditoria não pode exceder {0} dias.</value>
+  </data>
+  <data name="Auditing.AuditRecordNotFound" xml:space="preserve">
+    <value>Registro de auditoria {0} não encontrado.</value>
+  </data>
+</root>

--- a/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.resx
+++ b/src/Modules/Auditing/Modules.Auditing/Localization/AuditingResources.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.Auditing.CrossTenantAccessForbidden" xml:space="preserve">
+    <value>Cross-tenant audit access requires Permissions.AuditTrails.ViewCrossTenant.</value>
+  </data>
+  <data name="Error.Auditing.CrossTenantSummaryForbidden" xml:space="preserve">
+    <value>Cross-tenant audit summary requires Permissions.AuditTrails.ViewCrossTenant.</value>
+  </data>
+  <data name="Validation.DateRangeOrder" xml:space="preserve">
+    <value>FromUtc must be less than or equal to ToUtc.</value>
+  </data>
+  <data name="Validation.WindowExceeded" xml:space="preserve">
+    <value>Audit query window cannot exceed {0} days.</value>
+  </data>
+  <data name="Validation.SummaryWindowExceeded" xml:space="preserve">
+    <value>Audit summary window cannot exceed {0} days.</value>
+  </data>
+  <data name="Auditing.AuditRecordNotFound" xml:space="preserve">
+    <value>Audit record {0} not found.</value>
+  </data>
+</root>

--- a/src/Modules/Auditing/Modules.Auditing/Modules.Auditing.csproj
+++ b/src/Modules/Auditing/Modules.Auditing/Modules.Auditing.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Auditing</RootNamespace>
 		<AssemblyName>FSH.Modules.Auditing</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1308;CA1812;CA1859;S3267</NoWarn>
+		<!-- AuditingResources is an intentional empty localizer marker (see Localization/AuditingResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1308;CA1812;CA1859;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GenerateInvoices/GenerateInvoicesCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GenerateInvoices/GenerateInvoicesCommandHandler.cs
@@ -2,6 +2,7 @@ using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Contracts.v1.Invoices;
+using FSH.Modules.Billing.Localization;
 using FSH.Modules.Billing.Services;
 using Mediator;
 
@@ -19,10 +20,17 @@ public sealed class GenerateInvoicesCommandHandler(
         // Platform-wide invoice generation runs across EVERY tenant — it is a root-operator action.
         // A tenant admin (who also holds Billing.Manage) must not be able to trigger it.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         if (callerTenantId != MultitenancyConstants.Root.Id)
         {
-            throw new ForbiddenException("Only the root operator may generate invoices across tenants.");
+            throw new ForbiddenException("Only the root operator may generate invoices across tenants.")
+            {
+                MessageKey = "Billing.OnlyRootOperatorMayGenerateInvoices",
+                ResourceSource = typeof(BillingResources),
+            };
         }
 
         return await billing.GenerateInvoicesForAllTenantsAsync(command.PeriodYear, command.PeriodMonth, cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Contracts.Dtos;
 using FSH.Modules.Billing.Contracts.v1.Invoices;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,7 +22,10 @@ public sealed class GetInvoiceByIdQueryHandler(
         // BillingDbContext isn't tenant-filtered (raw DbContext for cross-tenant admin visibility): root
         // reads any invoice by id; a tenant caller is pinned to its own so it can't read another's. Mirrors GetSubscriptionQueryHandler.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
 
         var invoice = await dbContext.Invoices.AsNoTracking()
@@ -30,7 +34,12 @@ public sealed class GetInvoiceByIdQueryHandler(
                 i => i.Id == query.InvoiceId && (isRoot || i.TenantId == callerTenantId),
                 cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Invoice {query.InvoiceId} not found.");
+            ?? throw new NotFoundException($"Invoice {query.InvoiceId} not found.")
+            {
+                MessageKey = "Billing.InvoiceNotFound",
+                MessageArgs = [query.InvoiceId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         return invoice.ToDto();
     }

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoicePdf/GetInvoicePdfQueryHandler.cs
@@ -2,6 +2,7 @@ using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using FSH.Modules.Billing.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -21,7 +22,10 @@ public sealed class GetInvoicePdfQueryHandler(
         // BillingDbContext is not tenant-filtered: root may download ANY tenant's invoice PDF; a tenant
         // caller is pinned to its own, so a cross-tenant id resolves to 404 and never leaks a PDF.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
 
         var invoice = await dbContext.Invoices.AsNoTracking()
@@ -30,7 +34,12 @@ public sealed class GetInvoicePdfQueryHandler(
                 i => i.Id == query.InvoiceId && (isRoot || i.TenantId == callerTenantId),
                 cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Invoice {query.InvoiceId} not found.");
+            ?? throw new NotFoundException($"Invoice {query.InvoiceId} not found.")
+            {
+                MessageKey = "Billing.InvoiceNotFound",
+                MessageArgs = [query.InvoiceId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         var dto = invoice.ToDto();
         var content = renderer.Render(dto);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoices/GetInvoicesQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetInvoices/GetInvoicesQueryHandler.cs
@@ -22,7 +22,10 @@ public sealed class GetInvoicesQueryHandler(
         // BillingDbContext is not tenant-filtered: only root gets the cross-tenant view (optionally
         // narrowed via query.TenantId); every other caller is forced to its own tenant.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
         var tenantFilter = isRoot ? query.TenantId : callerTenantId;
 

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetMyInvoices/GetMyInvoicesQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Invoices/GetMyInvoices/GetMyInvoicesQueryHandler.cs
@@ -20,7 +20,10 @@ public sealed class GetMyInvoicesQueryHandler(
         ArgumentNullException.ThrowIfNull(query);
 
         var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
 
         var q = dbContext.Invoices.AsNoTracking()
             .Include(i => i.LineItems)

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlanTerm/GetPlanTermQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Plans/GetPlanTerm/GetPlanTermQueryHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Billing.Contracts.v1.Plans;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class GetPlanTermQueryHandler(BillingDbContext dbContext)
 #pragma warning restore CA1308
         var plan = await dbContext.Plans.AsNoTracking()
             .FirstOrDefaultAsync(p => p.Key == key && p.IsActive, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Active plan with key '{query.PlanKey}' not found.");
+            ?? throw new NotFoundException($"Active plan with key '{query.PlanKey}' not found.")
+            {
+                MessageKey = "Billing.ActivePlanNotFound",
+                MessageArgs = [query.PlanKey],
+                ResourceSource = typeof(BillingResources),
+            };
 
         return new PlanTermResponse(
             plan.Id,

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Plans/UpdatePlan/UpdatePlanCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Plans/UpdatePlan/UpdatePlanCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Billing.Contracts.v1.Plans;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,7 +15,12 @@ public sealed class UpdatePlanCommandHandler(BillingDbContext dbContext)
         ArgumentNullException.ThrowIfNull(command);
 
         var plan = await dbContext.Plans.FirstOrDefaultAsync(p => p.Id == command.PlanId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Plan {command.PlanId} not found.");
+            ?? throw new NotFoundException($"Plan {command.PlanId} not found.")
+            {
+                MessageKey = "Billing.PlanNotFound",
+                MessageArgs = [command.PlanId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         plan.Update(command.Name, command.MonthlyBasePrice, command.OverageRates, command.Interval, command.AnnualPrice);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/AssignSubscription/AssignSubscriptionCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/AssignSubscription/AssignSubscriptionCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Contracts.v1.Subscriptions;
 using FSH.Modules.Billing.Data;
 using FSH.Modules.Billing.Domain;
+using FSH.Modules.Billing.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,7 +22,10 @@ public sealed class AssignSubscriptionCommandHandler(
         // Only root may target an arbitrary tenant; a tenant caller is pinned to its own, so it can't
         // (re)assign or cancel another tenant's subscription via a foreign tenant id in the body.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
         var targetTenantId = isRoot ? command.TenantId : callerTenantId;
 
@@ -29,7 +33,12 @@ public sealed class AssignSubscriptionCommandHandler(
         var key = command.PlanKey.ToLowerInvariant();
 #pragma warning restore CA1308
         var plan = await dbContext.Plans.FirstOrDefaultAsync(p => p.Key == key && p.IsActive, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Active plan with key '{command.PlanKey}' not found.");
+            ?? throw new NotFoundException($"Active plan with key '{command.PlanKey}' not found.")
+            {
+                MessageKey = "Billing.ActivePlanNotFound",
+                MessageArgs = [command.PlanKey],
+                ResourceSource = typeof(BillingResources),
+            };
 
         var now = DateTime.UtcNow;
         var current = await dbContext.Subscriptions

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/GetSubscription/GetSubscriptionQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Subscriptions/GetSubscription/GetSubscriptionQueryHandler.cs
@@ -19,7 +19,10 @@ public sealed class GetSubscriptionQueryHandler(
         ArgumentNullException.ThrowIfNull(query);
 
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
 
         // BillingDbContext is not tenant-filtered, so a tenant caller is pinned to its OWN
         // subscription and only root may pass an arbitrary tenant id (else cross-tenant reads).

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Usage/CaptureUsageSnapshots/CaptureUsageSnapshotsCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Usage/CaptureUsageSnapshots/CaptureUsageSnapshotsCommandHandler.cs
@@ -21,7 +21,10 @@ public sealed class CaptureUsageSnapshotsCommandHandler(
         // Only the root operator may capture usage for an arbitrary tenant; a tenant caller is pinned
         // to its own tenant so it can't fabricate another tenant's usage/overage snapshots.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
         var targetTenantId = isRoot ? command.TenantId : callerTenantId;
 

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Usage/GetUsageSnapshots/GetUsageSnapshotsQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Usage/GetUsageSnapshots/GetUsageSnapshotsQueryHandler.cs
@@ -21,7 +21,10 @@ public sealed class GetUsageSnapshotsQueryHandler(
         // UsageSnapshots is not tenant-filtered. Only the root operator may read across tenants
         // (optionally narrowed via query.TenantId); any other caller is forced to its own tenant.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
         var tenantFilter = isRoot ? query.TenantId : callerTenantId;
 

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/ApproveTopupRequest/ApproveTopupRequestCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/ApproveTopupRequest/ApproveTopupRequestCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Contracts.v1.Wallets;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using FSH.Modules.Billing.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -20,17 +21,29 @@ public sealed class ApproveTopupRequestCommandHandler(
         ArgumentNullException.ThrowIfNull(command);
 
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
 
         var request = await db.TopupRequests
             .FirstOrDefaultAsync(r => r.Id == command.Id, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Top-up request {command.Id} not found.");
+            ?? throw new NotFoundException($"Top-up request {command.Id} not found.")
+            {
+                MessageKey = "Billing.TopupRequestNotFound",
+                MessageArgs = [command.Id],
+                ResourceSource = typeof(BillingResources),
+            };
 
         if (!isRoot && request.TenantId != callerTenantId)
         {
-            throw new UnauthorizedException("You can only approve top-up requests for your own tenant.");
+            throw new UnauthorizedException("You can only approve top-up requests for your own tenant.")
+            {
+                MessageKey = "Billing.CannotApproveTopupForOtherTenant",
+                ResourceSource = typeof(BillingResources),
+            };
         }
 
         // For root, operate on the request's own tenant; for non-root, callerTenantId equals request.TenantId.

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/CreateTopupRequest/CreateTopupRequestCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/CreateTopupRequest/CreateTopupRequestCommandHandler.cs
@@ -21,7 +21,10 @@ public sealed class CreateTopupRequestCommandHandler(
 
         // BillingDbContext is not tenant-filtered; resolve caller's own tenant and scope strictly to it.
         var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
 
         var requestedBy = currentUser.IsAuthenticated() ? currentUser.GetUserId().ToString() : null;
         var request = TopupRequest.Create(tenantId, command.Amount, "USD", command.Note, requestedBy);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetMyTopupRequests/GetMyTopupRequestsQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetMyTopupRequests/GetMyTopupRequestsQueryHandler.cs
@@ -22,7 +22,10 @@ public sealed class GetMyTopupRequestsQueryHandler(
 
         // BillingDbContext is not tenant-filtered; resolve caller's own tenant and scope strictly to it.
         var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
 
         var q = dbContext.TopupRequests.AsNoTracking()
             .Where(r => r.TenantId == tenantId);

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetMyWallet/GetMyWalletQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetMyWallet/GetMyWalletQueryHandler.cs
@@ -20,7 +20,10 @@ public sealed class GetMyWalletQueryHandler(
 
         // BillingDbContext is not tenant-filtered; resolve caller's own tenant and scope strictly to it.
         var tenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
 
         var wallet = await billingService.GetOrCreateWalletAsync(tenantId, "USD", cancellationToken).ConfigureAwait(false);
         return wallet.ToDto();

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetTopupRequests/GetTopupRequestsQueryHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/GetTopupRequests/GetTopupRequestsQueryHandler.cs
@@ -23,7 +23,10 @@ public sealed class GetTopupRequestsQueryHandler(
         // BillingDbContext is not tenant-filtered: only root gets the cross-tenant view (optionally
         // narrowed via query.TenantId); every other caller is forced to its own tenant.
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
         var tenantFilter = isRoot ? query.TenantId : callerTenantId;
 

--- a/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/RejectTopupRequest/RejectTopupRequestCommandHandler.cs
+++ b/src/Modules/Billing/Modules.Billing/Features/v1/Wallets/RejectTopupRequest/RejectTopupRequestCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Billing.Contracts;
 using FSH.Modules.Billing.Contracts.v1.Wallets;
 using FSH.Modules.Billing.Data;
+using FSH.Modules.Billing.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,17 +21,29 @@ public sealed class RejectTopupRequestCommandHandler(
         ArgumentNullException.ThrowIfNull(command);
 
         var callerTenantId = tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
 
         var request = await db.TopupRequests
             .FirstOrDefaultAsync(r => r.Id == command.Id, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Top-up request {command.Id} not found.");
+            ?? throw new NotFoundException($"Top-up request {command.Id} not found.")
+            {
+                MessageKey = "Billing.TopupRequestNotFound",
+                MessageArgs = [command.Id],
+                ResourceSource = typeof(BillingResources),
+            };
 
         if (!isRoot && request.TenantId != callerTenantId)
         {
-            throw new UnauthorizedException("You can only reject top-up requests for your own tenant.");
+            throw new UnauthorizedException("You can only reject top-up requests for your own tenant.")
+            {
+                MessageKey = "Billing.CannotRejectTopupForOtherTenant",
+                ResourceSource = typeof(BillingResources),
+            };
         }
 
         if (request.Status != TopupRequestStatus.Pending)
@@ -38,7 +51,12 @@ public sealed class RejectTopupRequestCommandHandler(
             throw new CustomException(
                 $"Top-up request {command.Id} cannot be rejected because it is {request.Status} (only Pending requests can be rejected).",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Billing.TopupRequestCannotBeRejected",
+                MessageArgs = [command.Id, request.Status],
+                ResourceSource = typeof(BillingResources),
+            };
         }
 
         request.Reject(command.Reason);

--- a/src/Modules/Billing/Modules.Billing/Localization/BillingResources.cs
+++ b/src/Modules/Billing/Modules.Billing/Localization/BillingResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Billing.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;BillingResources&gt;</c> to the Billing resx catalog.</summary>
+public sealed class BillingResources;

--- a/src/Modules/Billing/Modules.Billing/Localization/BillingResources.pt-BR.resx
+++ b/src/Modules/Billing/Modules.Billing/Localization/BillingResources.pt-BR.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Billing.InvoiceNotFound" xml:space="preserve">
+    <value>Fatura {0} não encontrada.</value>
+  </data>
+  <data name="Billing.PlanNotFound" xml:space="preserve">
+    <value>Plano {0} não encontrado.</value>
+  </data>
+  <data name="Billing.PlanNotFoundForTenant" xml:space="preserve">
+    <value>Plano {0} não encontrado para o tenant {1}.</value>
+  </data>
+  <data name="Billing.ActivePlanNotFound" xml:space="preserve">
+    <value>Plano ativo com a chave '{0}' não encontrado.</value>
+  </data>
+  <data name="Billing.TopupRequestNotFound" xml:space="preserve">
+    <value>Solicitação de recarga {0} não encontrada.</value>
+  </data>
+  <data name="Billing.TopupRequestNotFoundOrNotPending" xml:space="preserve">
+    <value>Solicitação de recarga {0} não encontrada ou não está pendente.</value>
+  </data>
+  <data name="Billing.OnlyRootOperatorMayGenerateInvoices" xml:space="preserve">
+    <value>Apenas o operador raiz pode gerar faturas entre tenants.</value>
+  </data>
+  <data name="Billing.CannotRejectTopupForOtherTenant" xml:space="preserve">
+    <value>Você só pode rejeitar solicitações de recarga do seu próprio tenant.</value>
+  </data>
+  <data name="Billing.CannotApproveTopupForOtherTenant" xml:space="preserve">
+    <value>Você só pode aprovar solicitações de recarga do seu próprio tenant.</value>
+  </data>
+  <data name="Billing.TopupRequestCannotBeRejected" xml:space="preserve">
+    <value>Não é possível rejeitar a solicitação de recarga {0} porque ela está {1} (somente solicitações Pendentes podem ser rejeitadas).</value>
+  </data>
+</root>

--- a/src/Modules/Billing/Modules.Billing/Localization/BillingResources.resx
+++ b/src/Modules/Billing/Modules.Billing/Localization/BillingResources.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Billing.InvoiceNotFound" xml:space="preserve">
+    <value>Invoice {0} not found.</value>
+  </data>
+  <data name="Billing.PlanNotFound" xml:space="preserve">
+    <value>Plan {0} not found.</value>
+  </data>
+  <data name="Billing.PlanNotFoundForTenant" xml:space="preserve">
+    <value>Plan {0} not found for tenant {1}.</value>
+  </data>
+  <data name="Billing.ActivePlanNotFound" xml:space="preserve">
+    <value>Active plan with key '{0}' not found.</value>
+  </data>
+  <data name="Billing.TopupRequestNotFound" xml:space="preserve">
+    <value>Top-up request {0} not found.</value>
+  </data>
+  <data name="Billing.TopupRequestNotFoundOrNotPending" xml:space="preserve">
+    <value>Top-up request {0} not found or not pending.</value>
+  </data>
+  <data name="Billing.OnlyRootOperatorMayGenerateInvoices" xml:space="preserve">
+    <value>Only the root operator may generate invoices across tenants.</value>
+  </data>
+  <data name="Billing.CannotRejectTopupForOtherTenant" xml:space="preserve">
+    <value>You can only reject top-up requests for your own tenant.</value>
+  </data>
+  <data name="Billing.CannotApproveTopupForOtherTenant" xml:space="preserve">
+    <value>You can only approve top-up requests for your own tenant.</value>
+  </data>
+  <data name="Billing.TopupRequestCannotBeRejected" xml:space="preserve">
+    <value>Top-up request {0} cannot be rejected because it is {1} (only Pending requests can be rejected).</value>
+  </data>
+</root>

--- a/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
+++ b/src/Modules/Billing/Modules.Billing/Modules.Billing.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Billing</RootNamespace>
 		<AssemblyName>FSH.Modules.Billing</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;S3267</NoWarn>
+		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
+++ b/src/Modules/Billing/Modules.Billing/Services/BillingService.cs
@@ -8,6 +8,7 @@ using FSH.Modules.Billing.Contracts;
 using FSH.Modules.Billing.Contracts.Events;
 using FSH.Modules.Billing.Data;
 using FSH.Modules.Billing.Domain;
+using FSH.Modules.Billing.Localization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -75,7 +76,12 @@ public sealed class BillingService : IBillingService
         }
 
         var plan = await _db.Plans.FirstOrDefaultAsync(p => p.Id == subscription.PlanId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Plan {subscription.PlanId} not found for tenant {tenantId}.");
+            ?? throw new NotFoundException($"Plan {subscription.PlanId} not found for tenant {tenantId}.")
+            {
+                MessageKey = "Billing.PlanNotFoundForTenant",
+                MessageArgs = [subscription.PlanId, tenantId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         var snapshots = await _usageReporter.CaptureForPeriodAsync(tenantId, periodYear, periodMonth, cancellationToken).ConfigureAwait(false);
 
@@ -188,7 +194,12 @@ public sealed class BillingService : IBillingService
         var request = await _db.TopupRequests
             .FirstOrDefaultAsync(r => r.Id == topupRequestId && r.TenantId == tenantId && r.Status == TopupRequestStatus.Pending, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Top-up request {topupRequestId} not found or not pending.");
+            ?? throw new NotFoundException($"Top-up request {topupRequestId} not found or not pending.")
+            {
+                MessageKey = "Billing.TopupRequestNotFoundOrNotPending",
+                MessageArgs = [topupRequestId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var invoiceNumber = BuildTopupInvoiceNumber(tenantId, now, topupRequestId);
@@ -289,13 +300,21 @@ public sealed class BillingService : IBillingService
     private async Task<Invoice> LoadInvoiceAsync(Guid invoiceId, CancellationToken cancellationToken)
     {
         var callerTenantId = _tenantAccessor.MultiTenantContext?.TenantInfo?.Id
-            ?? throw new UnauthorizedException("Tenant context is required.");
+            ?? throw new UnauthorizedException("Tenant context is required.")
+            {
+                MessageKey = "Error.TenantContextRequired",
+            };
         var isRoot = callerTenantId == MultitenancyConstants.Root.Id;
 
         return await _db.Invoices
             .FirstOrDefaultAsync(i => i.Id == invoiceId && (isRoot || i.TenantId == callerTenantId), cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Invoice {invoiceId} not found.");
+            ?? throw new NotFoundException($"Invoice {invoiceId} not found.")
+            {
+                MessageKey = "Billing.InvoiceNotFound",
+                MessageArgs = [invoiceId],
+                ResourceSource = typeof(BillingResources),
+            };
     }
 
     public async Task<Invoice?> CreateSubscriptionInvoiceAsync(
@@ -308,7 +327,12 @@ public sealed class BillingService : IBillingService
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
 
         var plan = await _db.Plans.FirstOrDefaultAsync(p => p.Id == planId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Plan {planId} not found for tenant {tenantId}.");
+            ?? throw new NotFoundException($"Plan {planId} not found for tenant {tenantId}.")
+            {
+                MessageKey = "Billing.PlanNotFoundForTenant",
+                MessageArgs = [planId, tenantId],
+                ResourceSource = typeof(BillingResources),
+            };
 
         var termPrice = plan.TermPrice;
         if (termPrice.Amount <= 0m)

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/CreateBrand/CreateBrandCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/CreateBrand/CreateBrandCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Brands;
 using FSH.Modules.Catalog.Data;
 using FSH.Modules.Catalog.Domain;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -25,7 +26,12 @@ public sealed class CreateBrandCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"A brand with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.BrandNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         dbContext.Brands.Add(brand);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/DeleteBrand/DeleteBrandCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/DeleteBrand/DeleteBrandCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Brands;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,7 +17,12 @@ public sealed class DeleteBrandCommandHandler(CatalogDbContext dbContext)
         var brand = await dbContext.Brands
             .FirstOrDefaultAsync(b => b.Id == command.BrandId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Brand {command.BrandId} not found.");
+            ?? throw new NotFoundException($"Brand {command.BrandId} not found.")
+            {
+                MessageKey = "Catalog.BrandNotFound",
+                MessageArgs = [command.BrandId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         dbContext.Brands.Remove(brand);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/GetBrandById/GetBrandByIdQueryHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/GetBrandById/GetBrandByIdQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.Dtos;
 using FSH.Modules.Catalog.Contracts.v1.Brands;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class GetBrandByIdQueryHandler(CatalogDbContext dbContext)
             .AsNoTracking()
             .FirstOrDefaultAsync(b => b.Id == query.BrandId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Brand {query.BrandId} not found.");
+            ?? throw new NotFoundException($"Brand {query.BrandId} not found.")
+            {
+                MessageKey = "Catalog.BrandNotFound",
+                MessageArgs = [query.BrandId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         return new BrandDto(
             brand.Id,

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/RestoreBrand/RestoreBrandCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/RestoreBrand/RestoreBrandCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Persistence;
 using FSH.Modules.Catalog.Contracts.v1.Brands;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,7 +21,12 @@ public sealed class RestoreBrandCommandHandler(CatalogDbContext dbContext)
             .IgnoreQueryFilters([QueryFilters.SoftDelete])
             .FirstOrDefaultAsync(b => b.Id == command.BrandId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Brand {command.BrandId} not found.");
+            ?? throw new NotFoundException($"Brand {command.BrandId} not found.")
+            {
+                MessageKey = "Catalog.BrandNotFound",
+                MessageArgs = [command.BrandId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         brand.Restore();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/UpdateBrand/UpdateBrandCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Brands/UpdateBrand/UpdateBrandCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Brands;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class UpdateBrandCommandHandler(CatalogDbContext dbContext)
         var brand = await dbContext.Brands
             .FirstOrDefaultAsync(b => b.Id == command.BrandId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Brand {command.BrandId} not found.");
+            ?? throw new NotFoundException($"Brand {command.BrandId} not found.")
+            {
+                MessageKey = "Catalog.BrandNotFound",
+                MessageArgs = [command.BrandId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         brand.Update(command.Name, command.Description, command.LogoUrl);
 
@@ -29,7 +35,12 @@ public sealed class UpdateBrandCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"Another brand with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.AnotherBrandNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/CreateCategory/CreateCategoryCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/CreateCategory/CreateCategoryCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Categories;
 using FSH.Modules.Catalog.Data;
 using FSH.Modules.Catalog.Domain;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,7 +23,12 @@ public sealed class CreateCategoryCommandHandler(CatalogDbContext dbContext)
                 .ConfigureAwait(false);
             if (!parentExists)
             {
-                throw new NotFoundException($"Parent category {parentId} not found.");
+                throw new NotFoundException($"Parent category {parentId} not found.")
+                {
+                    MessageKey = "Catalog.ParentCategoryNotFound",
+                    MessageArgs = [parentId],
+                    ResourceSource = typeof(CatalogResources),
+                };
             }
         }
 
@@ -36,7 +42,12 @@ public sealed class CreateCategoryCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"A category with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.CategoryNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         dbContext.Categories.Add(category);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/DeleteCategory/DeleteCategoryCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/DeleteCategory/DeleteCategoryCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Categories;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class DeleteCategoryCommandHandler(CatalogDbContext dbContext)
         var category = await dbContext.Categories
             .FirstOrDefaultAsync(c => c.Id == command.CategoryId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Category {command.CategoryId} not found.");
+            ?? throw new NotFoundException($"Category {command.CategoryId} not found.")
+            {
+                MessageKey = "Catalog.CategoryNotFound",
+                MessageArgs = [command.CategoryId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         bool hasChildren = await dbContext.Categories
             .AnyAsync(c => c.ParentCategoryId == category.Id, cancellationToken)
@@ -27,7 +33,11 @@ public sealed class DeleteCategoryCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 "Cannot delete a category that has child categories. Move or remove the children first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.CategoryHasChildren",
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         dbContext.Categories.Remove(category);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/GetCategoryById/GetCategoryByIdQueryHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/GetCategoryById/GetCategoryByIdQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.Dtos;
 using FSH.Modules.Catalog.Contracts.v1.Categories;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class GetCategoryByIdQueryHandler(CatalogDbContext dbContext)
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == query.CategoryId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Category {query.CategoryId} not found.");
+            ?? throw new NotFoundException($"Category {query.CategoryId} not found.")
+            {
+                MessageKey = "Catalog.CategoryNotFound",
+                MessageArgs = [query.CategoryId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         return new CategoryDto(c.Id, c.Name, c.Slug, c.Description, c.ParentCategoryId, c.CreatedAtUtc, c.UpdatedAtUtc, c.DeletedOnUtc, c.DeletedBy);
     }

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/RestoreCategory/RestoreCategoryCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/RestoreCategory/RestoreCategoryCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Persistence;
 using FSH.Modules.Catalog.Contracts.v1.Categories;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class RestoreCategoryCommandHandler(CatalogDbContext dbContext)
             .IgnoreQueryFilters([QueryFilters.SoftDelete])
             .FirstOrDefaultAsync(c => c.Id == command.CategoryId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Category {command.CategoryId} not found.");
+            ?? throw new NotFoundException($"Category {command.CategoryId} not found.")
+            {
+                MessageKey = "Catalog.CategoryNotFound",
+                MessageArgs = [command.CategoryId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         category.Restore();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/UpdateCategory/UpdateCategoryCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Categories/UpdateCategory/UpdateCategoryCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Categories;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class UpdateCategoryCommandHandler(CatalogDbContext dbContext)
         var category = await dbContext.Categories
             .FirstOrDefaultAsync(c => c.Id == command.CategoryId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Category {command.CategoryId} not found.");
+            ?? throw new NotFoundException($"Category {command.CategoryId} not found.")
+            {
+                MessageKey = "Catalog.CategoryNotFound",
+                MessageArgs = [command.CategoryId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         if (command.ParentCategoryId is { } parentId)
         {
@@ -26,7 +32,11 @@ public sealed class UpdateCategoryCommandHandler(CatalogDbContext dbContext)
                 throw new CustomException(
                     "A category cannot be its own parent.",
                     (IEnumerable<string>?)null,
-                    HttpStatusCode.BadRequest);
+                    HttpStatusCode.BadRequest)
+                {
+                    MessageKey = "Catalog.CategoryCannotBeOwnParent",
+                    ResourceSource = typeof(CatalogResources),
+                };
             }
 
             // Walk parent chain to detect cycles (parent → ancestor of self)
@@ -39,7 +49,11 @@ public sealed class UpdateCategoryCommandHandler(CatalogDbContext dbContext)
                     throw new CustomException(
                         "Setting this parent would create a cycle.",
                         (IEnumerable<string>?)null,
-                        HttpStatusCode.BadRequest);
+                        HttpStatusCode.BadRequest)
+                    {
+                        MessageKey = "Catalog.CategoryParentCycle",
+                        ResourceSource = typeof(CatalogResources),
+                    };
                 }
                 cursor = await dbContext.Categories
                     .Where(c => c.Id == cur)
@@ -59,7 +73,12 @@ public sealed class UpdateCategoryCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"Another category with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.AnotherCategoryNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AddProductImage/AddProductImageCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AddProductImage/AddProductImageCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.Dtos;
 using FSH.Modules.Catalog.Contracts.v1.Products.AddProductImage;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class AddProductImageCommandHandler(CatalogDbContext dbContext)
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         var image = product.AddImage(command.FileAssetId, command.Url);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AdjustProductStock/AdjustProductStockCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AdjustProductStock/AdjustProductStockCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class AdjustProductStockCommandHandler(CatalogDbContext dbContext)
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         try
         {
@@ -25,7 +31,12 @@ public sealed class AdjustProductStockCommandHandler(CatalogDbContext dbContext)
         }
         catch (InvalidOperationException ex)
         {
-            throw new CustomException(ex.Message, (IEnumerable<string>?)null, HttpStatusCode.Conflict);
+            throw new CustomException(ex.Message, (IEnumerable<string>?)null, HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.StockAdjustmentNegative",
+                MessageArgs = [command.Delta, product.Stock],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AdjustProductStock/AdjustProductStockCommandValidator.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/AdjustProductStock/AdjustProductStockCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
 using FSH.Modules.Catalog.Contracts.v1.Products;
+using FSH.Modules.Catalog.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Catalog.Features.v1.Products.AdjustProductStock;
 
 public sealed class AdjustProductStockCommandValidator : AbstractValidator<AdjustProductStockCommand>
 {
-    public AdjustProductStockCommandValidator()
+    public AdjustProductStockCommandValidator(IStringLocalizer<CatalogResources> localizer)
     {
         RuleFor(x => x.ProductId).NotEmpty();
-        RuleFor(x => x.Delta).NotEqual(0).WithMessage("Delta must be non-zero.");
+        RuleFor(x => x.Delta).NotEqual(0).WithMessage(_ => localizer["Validation.DeltaNonZero"]);
     }
 }

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/ChangeProductPrice/ChangeProductPriceCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/ChangeProductPrice/ChangeProductPriceCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
 using FSH.Modules.Catalog.Domain;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class ChangeProductPriceCommandHandler(CatalogDbContext dbContext)
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         product.ChangePrice(new Money(command.Amount, command.Currency));
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/CreateProduct/CreateProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/CreateProduct/CreateProductCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
 using FSH.Modules.Catalog.Domain;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,7 +22,12 @@ public sealed class CreateProductCommandHandler(CatalogDbContext dbContext)
             .ConfigureAwait(false);
         if (!brandExists)
         {
-            throw new NotFoundException($"Brand {command.BrandId} not found.");
+            throw new NotFoundException($"Brand {command.BrandId} not found.")
+            {
+                MessageKey = "Catalog.BrandNotFound",
+                MessageArgs = [command.BrandId],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         bool categoryExists = await dbContext.Categories
@@ -29,7 +35,12 @@ public sealed class CreateProductCommandHandler(CatalogDbContext dbContext)
             .ConfigureAwait(false);
         if (!categoryExists)
         {
-            throw new NotFoundException($"Category {command.CategoryId} not found.");
+            throw new NotFoundException($"Category {command.CategoryId} not found.")
+            {
+                MessageKey = "Catalog.CategoryNotFound",
+                MessageArgs = [command.CategoryId],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         var product = Product.Create(
@@ -49,7 +60,12 @@ public sealed class CreateProductCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"A product with SKU '{product.Sku}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.ProductSkuAlreadyExists",
+                MessageArgs = [product.Sku],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         bool slugTaken = await dbContext.Products
@@ -60,7 +76,12 @@ public sealed class CreateProductCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"A product with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.ProductNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         dbContext.Products.Add(product);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/DeleteProduct/DeleteProductCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,7 +20,12 @@ public sealed class DeleteProductCommandHandler(CatalogDbContext dbContext)
             .IgnoreAutoIncludes()
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         dbContext.Products.Remove(product);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/GetProductById/GetProductByIdQueryHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/GetProductById/GetProductByIdQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.Dtos;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class GetProductByIdQueryHandler(CatalogDbContext dbContext)
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == query.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {query.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {query.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [query.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         return product.ToDto();
     }

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/RemoveProductImage/RemoveProductImageCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/RemoveProductImage/RemoveProductImageCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products.RemoveProductImage;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,12 +17,22 @@ public sealed class RemoveProductImageCommandHandler(CatalogDbContext dbContext)
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         // Domain throws InvalidOperationException for unknown imageId; translate to 404.
         if (!product.Images.Any(i => i.Id == command.ImageId))
         {
-            throw new NotFoundException($"Image {command.ImageId} not found on product {command.ProductId}.");
+            throw new NotFoundException($"Image {command.ImageId} not found on product {command.ProductId}.")
+            {
+                MessageKey = "Catalog.ProductImageNotFound",
+                MessageArgs = [command.ImageId, command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         product.RemoveImage(command.ImageId);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/ReorderProductImages/ReorderProductImagesCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/ReorderProductImages/ReorderProductImagesCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products.ReorderProductImages;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,7 +17,12 @@ public sealed class ReorderProductImagesCommandHandler(CatalogDbContext dbContex
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         product.ReorderImages(command.OrderedImageIds);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/RestoreProduct/RestoreProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/RestoreProduct/RestoreProductCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Persistence;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,12 @@ public sealed class RestoreProductCommandHandler(CatalogDbContext dbContext)
             .IgnoreQueryFilters([QueryFilters.SoftDelete])
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         product.Restore();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/SetProductThumbnail/SetProductThumbnailCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/SetProductThumbnail/SetProductThumbnailCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products.SetProductThumbnail;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,13 +17,23 @@ public sealed class SetProductThumbnailCommandHandler(CatalogDbContext dbContext
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         // Domain throws InvalidOperationException for unknown imageId; translate to a
         // framework-aware 404 so the API surfaces NotFound rather than a 500.
         if (!product.Images.Any(i => i.Id == command.ImageId))
         {
-            throw new NotFoundException($"Image {command.ImageId} not found on product {command.ProductId}.");
+            throw new NotFoundException($"Image {command.ImageId} not found on product {command.ProductId}.")
+            {
+                MessageKey = "Catalog.ProductImageNotFound",
+                MessageArgs = [command.ImageId, command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         product.SetThumbnail(command.ImageId);

--- a/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/UpdateProduct/UpdateProductCommandHandler.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Features/v1/Products/UpdateProduct/UpdateProductCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Catalog.Contracts.v1.Products;
 using FSH.Modules.Catalog.Data;
+using FSH.Modules.Catalog.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,12 @@ public sealed class UpdateProductCommandHandler(CatalogDbContext dbContext)
         var product = await dbContext.Products
             .FirstOrDefaultAsync(p => p.Id == command.ProductId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Product {command.ProductId} not found.");
+            ?? throw new NotFoundException($"Product {command.ProductId} not found.")
+            {
+                MessageKey = "Catalog.ProductNotFound",
+                MessageArgs = [command.ProductId],
+                ResourceSource = typeof(CatalogResources),
+            };
 
         if (product.BrandId != command.BrandId)
         {
@@ -26,7 +32,12 @@ public sealed class UpdateProductCommandHandler(CatalogDbContext dbContext)
                 .ConfigureAwait(false);
             if (!brandExists)
             {
-                throw new NotFoundException($"Brand {command.BrandId} not found.");
+                throw new NotFoundException($"Brand {command.BrandId} not found.")
+                {
+                    MessageKey = "Catalog.BrandNotFound",
+                    MessageArgs = [command.BrandId],
+                    ResourceSource = typeof(CatalogResources),
+                };
             }
         }
 
@@ -37,7 +48,12 @@ public sealed class UpdateProductCommandHandler(CatalogDbContext dbContext)
                 .ConfigureAwait(false);
             if (!categoryExists)
             {
-                throw new NotFoundException($"Category {command.CategoryId} not found.");
+                throw new NotFoundException($"Category {command.CategoryId} not found.")
+                {
+                    MessageKey = "Catalog.CategoryNotFound",
+                    MessageArgs = [command.CategoryId],
+                    ResourceSource = typeof(CatalogResources),
+                };
             }
         }
 
@@ -56,7 +72,12 @@ public sealed class UpdateProductCommandHandler(CatalogDbContext dbContext)
             throw new CustomException(
                 $"Another product with name '{command.Name}' already exists.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Catalog.AnotherProductNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(CatalogResources),
+            };
         }
 
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.cs
+++ b/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Catalog.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;CatalogResources&gt;</c> to the Catalog resx catalog.</summary>
+public sealed class CatalogResources;

--- a/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.pt-BR.resx
+++ b/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.pt-BR.resx
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Catalog.ProductNotFound" xml:space="preserve">
+    <value>Produto {0} não encontrado.</value>
+  </data>
+  <data name="Catalog.BrandNotFound" xml:space="preserve">
+    <value>Marca {0} não encontrada.</value>
+  </data>
+  <data name="Catalog.CategoryNotFound" xml:space="preserve">
+    <value>Categoria {0} não encontrada.</value>
+  </data>
+  <data name="Catalog.ParentCategoryNotFound" xml:space="preserve">
+    <value>Categoria pai {0} não encontrada.</value>
+  </data>
+  <data name="Catalog.ProductImageNotFound" xml:space="preserve">
+    <value>Imagem {0} não encontrada no produto {1}.</value>
+  </data>
+  <data name="Catalog.ProductSkuAlreadyExists" xml:space="preserve">
+    <value>Já existe um produto com o SKU '{0}'.</value>
+  </data>
+  <data name="Catalog.ProductNameAlreadyExists" xml:space="preserve">
+    <value>Já existe um produto com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.AnotherProductNameAlreadyExists" xml:space="preserve">
+    <value>Já existe outro produto com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.BrandNameAlreadyExists" xml:space="preserve">
+    <value>Já existe uma marca com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.AnotherBrandNameAlreadyExists" xml:space="preserve">
+    <value>Já existe outra marca com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.CategoryNameAlreadyExists" xml:space="preserve">
+    <value>Já existe uma categoria com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.AnotherCategoryNameAlreadyExists" xml:space="preserve">
+    <value>Já existe outra categoria com o nome '{0}'.</value>
+  </data>
+  <data name="Catalog.CategoryCannotBeOwnParent" xml:space="preserve">
+    <value>Uma categoria não pode ser pai de si mesma.</value>
+  </data>
+  <data name="Catalog.CategoryParentCycle" xml:space="preserve">
+    <value>Definir este pai criaria um ciclo.</value>
+  </data>
+  <data name="Catalog.CategoryHasChildren" xml:space="preserve">
+    <value>Não é possível excluir uma categoria que possui categorias filhas. Mova ou remova as filhas primeiro.</value>
+  </data>
+  <data name="Validation.DeltaNonZero" xml:space="preserve">
+    <value>O delta deve ser diferente de zero.</value>
+  </data>
+  <data name="Catalog.StockAdjustmentNegative" xml:space="preserve">
+    <value>O ajuste de estoque de {0} resultaria em estoque negativo (atual: {1}).</value>
+  </data>
+</root>

--- a/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.resx
+++ b/src/Modules/Catalog/Modules.Catalog/Localization/CatalogResources.resx
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Catalog.ProductNotFound" xml:space="preserve">
+    <value>Product {0} not found.</value>
+  </data>
+  <data name="Catalog.BrandNotFound" xml:space="preserve">
+    <value>Brand {0} not found.</value>
+  </data>
+  <data name="Catalog.CategoryNotFound" xml:space="preserve">
+    <value>Category {0} not found.</value>
+  </data>
+  <data name="Catalog.ParentCategoryNotFound" xml:space="preserve">
+    <value>Parent category {0} not found.</value>
+  </data>
+  <data name="Catalog.ProductImageNotFound" xml:space="preserve">
+    <value>Image {0} not found on product {1}.</value>
+  </data>
+  <data name="Catalog.ProductSkuAlreadyExists" xml:space="preserve">
+    <value>A product with SKU '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.ProductNameAlreadyExists" xml:space="preserve">
+    <value>A product with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.AnotherProductNameAlreadyExists" xml:space="preserve">
+    <value>Another product with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.BrandNameAlreadyExists" xml:space="preserve">
+    <value>A brand with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.AnotherBrandNameAlreadyExists" xml:space="preserve">
+    <value>Another brand with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.CategoryNameAlreadyExists" xml:space="preserve">
+    <value>A category with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.AnotherCategoryNameAlreadyExists" xml:space="preserve">
+    <value>Another category with name '{0}' already exists.</value>
+  </data>
+  <data name="Catalog.CategoryCannotBeOwnParent" xml:space="preserve">
+    <value>A category cannot be its own parent.</value>
+  </data>
+  <data name="Catalog.CategoryParentCycle" xml:space="preserve">
+    <value>Setting this parent would create a cycle.</value>
+  </data>
+  <data name="Catalog.CategoryHasChildren" xml:space="preserve">
+    <value>Cannot delete a category that has child categories. Move or remove the children first.</value>
+  </data>
+  <data name="Validation.DeltaNonZero" xml:space="preserve">
+    <value>Delta must be non-zero.</value>
+  </data>
+  <data name="Catalog.StockAdjustmentNegative" xml:space="preserve">
+    <value>Stock adjustment of {0} would result in negative stock (current: {1}).</value>
+  </data>
+</root>

--- a/src/Modules/Catalog/Modules.Catalog/Modules.Catalog.csproj
+++ b/src/Modules/Catalog/Modules.Catalog/Modules.Catalog.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Catalog</RootNamespace>
 		<AssemblyName>FSH.Modules.Catalog</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267</NoWarn>
+		<!-- CatalogResources is an intentional empty localizer marker (see Localization/CatalogResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/AddChannelMembers/AddChannelMembersCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/AddChannelMembers/AddChannelMembersCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -21,18 +22,26 @@ public sealed class AddChannelMembersCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         // Members can invite to public channels they belong to; private channels require Admin.
         var caller = channel.RequireMember(currentUserId);
         if (channel.IsPrivate && caller.Role != ChannelMemberRole.Admin)
         {
-            throw new ForbiddenException("Only channel admins can add members to private channels.");
+            throw new ForbiddenException("Only channel admins can add members to private channels.")
+            {
+                MessageKey = "Chat.OnlyAdminsCanAddMembersToPrivateChannel",
+                ResourceSource = typeof(ChatResources),
+            };
         }
 
         var newlyAdded = new List<string>();

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ArchiveChannel/ArchiveChannelCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ArchiveChannel/ArchiveChannelCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,11 +18,15 @@ public sealed class ArchiveChannelCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         channel.RequireAdmin(userId.ToString());
 

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/CreateChannel/CreateChannelCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/CreateChannel/CreateChannelCommandHandler.cs
@@ -18,7 +18,7 @@ public sealed class CreateChannelCommandHandler(
         var userId = currentUser.GetUserId().ToString();
         if (userId == Guid.Empty.ToString())
         {
-            throw new UnauthorizedException("no current user");
+            throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         }
 
         var channel = ChatChannel.CreateChannel(cmd.Name, cmd.Description, cmd.IsPrivate, userId);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/DiscoverChannels/DiscoverChannelsQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/DiscoverChannels/DiscoverChannelsQueryHandler.cs
@@ -20,7 +20,7 @@ public sealed class DiscoverChannelsQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(q);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         int page = Math.Max(1, q.Page);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/FindOrCreateDm/FindOrCreateDmCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/FindOrCreateDm/FindOrCreateDmCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Domain;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -21,13 +22,17 @@ public sealed class FindOrCreateDmCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var otherIds = cmd.UserIds.Distinct(StringComparer.Ordinal).ToList();
         if (otherIds.Any(id => string.Equals(id, currentUserId, StringComparison.Ordinal)))
         {
-            throw new CustomException("Cannot DM yourself.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.BadRequest);
+            throw new CustomException("Cannot DM yourself.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Chat.CannotDmYourself",
+                ResourceSource = typeof(ChatResources),
+            };
         }
 
         if (otherIds.Count == 1)

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/GetChannelById/GetChannelByIdQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/GetChannelById/GetChannelByIdQueryHandler.cs
@@ -4,6 +4,7 @@ using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Contracts.v1.Queries;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,13 +19,17 @@ public sealed class GetChannelByIdQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(q);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == q.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         // Private channels & DMs: must be a member. Public channels: anyone with View can see them.
         if (channel.IsPrivate)

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/ListMyChannels/ListMyChannelsQueryHandler.cs
@@ -19,7 +19,7 @@ public sealed class ListMyChannelsQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(q);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         int page = Math.Max(1, q.Page);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/MarkChannelRead/MarkChannelReadCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/MarkChannelRead/MarkChannelReadCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,19 +21,30 @@ public sealed class MarkChannelReadCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         // Verify the marker message actually exists in this channel.
         var exists = await db.Messages
             .AnyAsync(m => m.Id == cmd.MessageId && m.ChannelId == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false);
-        if (!exists) throw new NotFoundException("Message not found in this channel.");
+        if (!exists)
+        {
+            throw new NotFoundException("Message not found in this channel.")
+            {
+                MessageKey = "Chat.MessageNotFoundInChannel",
+                ResourceSource = typeof(ChatResources),
+            };
+        }
 
         channel.MarkRead(currentUserId, cmd.MessageId);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/RemoveChannelMember/RemoveChannelMemberCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/RemoveChannelMember/RemoveChannelMemberCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Domain;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -21,12 +22,16 @@ public sealed class RemoveChannelMemberCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         // Self-leave is always allowed for the current user. Removing someone else requires Admin.
         var isSelfLeave = string.Equals(cmd.UserId, currentUserId, StringComparison.Ordinal);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/RestoreChannel/RestoreChannelCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/RestoreChannel/RestoreChannelCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,11 @@ public sealed class RestoreChannelCommandHandler(ChatDbContext db)
         var channel = await db.Channels.IgnoreQueryFilters()
             .FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         if (!channel.IsDeleted) return Unit.Value; // idempotent
         channel.Restore();

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Channels/UpdateChannel/UpdateChannelCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Channels/UpdateChannel/UpdateChannelCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,11 +18,15 @@ public sealed class UpdateChannelCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         channel.RequireAdmin(userId.ToString());
         channel.Rename(cmd.Name, cmd.Description);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChannelAuthorization.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Internal/ChannelAuthorization.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Domain;
+using FSH.Modules.Chat.Localization;
 
 namespace FSH.Modules.Chat.Features.v1.Internal;
 
@@ -14,7 +15,11 @@ internal static class ChannelAuthorization
     {
         var member = channel.Members.FirstOrDefault(m => string.Equals(m.UserId, userId, StringComparison.Ordinal));
         // Use NotFoundException (404) instead of Forbidden so non-members can't probe channel existence.
-        return member ?? throw new NotFoundException("Channel not found.");
+        return member ?? throw new NotFoundException("Channel not found.")
+        {
+            MessageKey = "Chat.ChannelNotFound",
+            ResourceSource = typeof(ChatResources),
+        };
     }
 
     public static ChannelMember RequireAdmin(this ChatChannel channel, string userId)
@@ -22,7 +27,11 @@ internal static class ChannelAuthorization
         var member = channel.RequireMember(userId);
         if (member.Role != ChannelMemberRole.Admin)
         {
-            throw new ForbiddenException("Channel admin role required.");
+            throw new ForbiddenException("Channel admin role required.")
+            {
+                MessageKey = "Chat.ChannelAdminRoleRequired",
+                ResourceSource = typeof(ChatResources),
+            };
         }
         return member;
     }

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/DeleteMessage/DeleteMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/DeleteMessage/DeleteMessageCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.Authorization;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using FSH.Modules.Identity.Contracts.Services;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
@@ -23,16 +24,24 @@ public sealed class DeleteMessageCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         bool isModerator = await permissions

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/EditMessage/EditMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/EditMessage/EditMessageCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,17 +21,25 @@ public sealed class EditMessageCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         // Verify membership through the parent channel (don't leak existence to non-members).
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         message.Edit(cmd.Body, currentUserId); // domain enforces author-only

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/GetPinnedMessages/GetPinnedMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/GetPinnedMessages/GetPinnedMessagesQueryHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Contracts.v1.Queries;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,12 +23,16 @@ public sealed class GetPinnedMessagesQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == query.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         var rows = await db.Messages

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListChannelMessages/ListChannelMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListChannelMessages/ListChannelMessagesQueryHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Contracts.v1.Queries;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,12 +23,16 @@ public sealed class ListChannelMessagesQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == query.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         // Top-level only (no thread replies). Guid v7 monotonic → Id desc = time desc.

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListMessageReplies/ListMessageRepliesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/ListMessageReplies/ListMessageRepliesQueryHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Contracts.v1.Queries;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,7 +23,7 @@ public sealed class ListMessageRepliesQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         // Load the parent so we can authorize the caller through the channel.
@@ -31,11 +32,19 @@ public sealed class ListMessageRepliesQueryHandler(
             .Select(m => new { m.Id, m.ChannelId })
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Parent message not found.");
+            ?? throw new NotFoundException("Parent message not found.")
+            {
+                MessageKey = "Chat.ParentMessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == parent.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Parent message not found.");
+            ?? throw new NotFoundException("Parent message not found.")
+            {
+                MessageKey = "Chat.ParentMessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         IQueryable<Domain.Message> q = db.Messages

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/PinMessage/PinMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/PinMessage/PinMessageCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,16 +21,24 @@ public sealed class PinMessageCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         message.Pin(currentUserId);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandHandler.cs
@@ -10,6 +10,7 @@ using FSH.Modules.Chat.Contracts.v1.DTOs;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Domain;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using FSH.Modules.Chat.Services;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
@@ -29,12 +30,16 @@ public sealed class SendMessageCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == cmd.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Channel not found.");
+            ?? throw new NotFoundException("Channel not found.")
+            {
+                MessageKey = "Chat.ChannelNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         channel.RequireMember(currentUserId);
 
@@ -43,15 +48,27 @@ public sealed class SendMessageCommandHandler(
         {
             parent = await db.Messages.FirstOrDefaultAsync(m => m.Id == parentId, cancellationToken)
                 .ConfigureAwait(false)
-                ?? throw new NotFoundException("Parent message not found.");
+                ?? throw new NotFoundException("Parent message not found.")
+                {
+                    MessageKey = "Chat.ParentMessageNotFound",
+                    ResourceSource = typeof(ChatResources),
+                };
             if (parent.ChannelId != channel.Id)
             {
-                throw new CustomException("Parent message belongs to a different channel.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest);
+                throw new CustomException("Parent message belongs to a different channel.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest)
+                {
+                    MessageKey = "Chat.ParentMessageDifferentChannel",
+                    ResourceSource = typeof(ChatResources),
+                };
             }
             if (parent.ParentMessageId.HasValue)
             {
                 // 1-level deep only per spec.
-                throw new CustomException("Cannot reply to a reply — threads are single-level only.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest);
+                throw new CustomException("Cannot reply to a reply — threads are single-level only.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest)
+                {
+                    MessageKey = "Chat.CannotReplyToReply",
+                    ResourceSource = typeof(ChatResources),
+                };
             }
         }
 

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandValidator.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/SendMessage/SendMessageCommandValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using FSH.Modules.Chat.Contracts.v1.Commands;
+using FSH.Modules.Chat.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Chat.Features.v1.Messages.SendMessage;
 
 public sealed class SendMessageCommandValidator : AbstractValidator<SendMessageCommand>
 {
-    public SendMessageCommandValidator()
+    public SendMessageCommandValidator(IStringLocalizer<ChatResources> localizer)
     {
         RuleFor(x => x.ChannelId).NotEmpty();
         // Body is optional when an attachment is present (Slack/Teams parity — "here's the file" with
@@ -13,7 +15,7 @@ public sealed class SendMessageCommandValidator : AbstractValidator<SendMessageC
         RuleFor(x => x.Body)
             .NotEmpty()
             .When(x => x.Attachments is null || x.Attachments.Count == 0)
-            .WithMessage("Either a body or an attachment is required.");
+            .WithMessage(_ => localizer["Validation.BodyOrAttachmentRequired"]);
         RuleFor(x => x.Body)
             .MaximumLength(32_768)
             .When(x => !string.IsNullOrEmpty(x.Body));

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Messages/UnpinMessage/UnpinMessageCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Messages/UnpinMessage/UnpinMessageCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,16 +21,24 @@ public sealed class UnpinMessageCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         message.Unpin(currentUserId);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Reactions/AddReaction/AddReactionCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Reactions/AddReaction/AddReactionCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,17 +21,25 @@ public sealed class AddReactionCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         // Authorize through the parent channel — don't leak existence to non-members.
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         var added = message.AddReaction(currentUserId, cmd.Emoji);

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Reactions/RemoveReaction/RemoveReactionCommandHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Reactions/RemoveReaction/RemoveReactionCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Web.Realtime;
 using FSH.Modules.Chat.Contracts.v1.Commands;
 using FSH.Modules.Chat.Data;
 using FSH.Modules.Chat.Features.v1.Internal;
+using FSH.Modules.Chat.Localization;
 using Mediator;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -20,16 +21,24 @@ public sealed class RemoveReactionCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         var message = await db.Messages.FirstOrDefaultAsync(m => m.Id == cmd.MessageId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
 
         var channel = await db.Channels.FirstOrDefaultAsync(c => c.Id == message.ChannelId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Message not found.");
+            ?? throw new NotFoundException("Message not found.")
+            {
+                MessageKey = "Chat.MessageNotFound",
+                ResourceSource = typeof(ChatResources),
+            };
         channel.RequireMember(currentUserId);
 
         if (!message.RemoveReaction(currentUserId, cmd.Emoji))

--- a/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
+++ b/src/Modules/Chat/Modules.Chat/Features/v1/Search/SearchMessagesQueryHandler.cs
@@ -23,7 +23,7 @@ public sealed class SearchMessagesQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty) throw new UnauthorizedException("no current user") { MessageKey = "Error.NoCurrentUser" };
         var currentUserId = userId.ToString();
 
         int page = Math.Max(1, query.Page);

--- a/src/Modules/Chat/Modules.Chat/Localization/ChatResources.cs
+++ b/src/Modules/Chat/Modules.Chat/Localization/ChatResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Chat.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;ChatResources&gt;</c> to the Chat resx catalog.</summary>
+public sealed class ChatResources;

--- a/src/Modules/Chat/Modules.Chat/Localization/ChatResources.pt-BR.resx
+++ b/src/Modules/Chat/Modules.Chat/Localization/ChatResources.pt-BR.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Chat.ChannelNotFound" xml:space="preserve">
+    <value>Canal não encontrado.</value>
+  </data>
+  <data name="Chat.ChannelAdminRoleRequired" xml:space="preserve">
+    <value>É necessário ser administrador do canal.</value>
+  </data>
+  <data name="Chat.OnlyAdminsCanAddMembersToPrivateChannel" xml:space="preserve">
+    <value>Apenas administradores do canal podem adicionar membros a canais privados.</value>
+  </data>
+  <data name="Chat.MessageNotFound" xml:space="preserve">
+    <value>Mensagem não encontrada.</value>
+  </data>
+  <data name="Chat.MessageNotFoundInChannel" xml:space="preserve">
+    <value>Mensagem não encontrada neste canal.</value>
+  </data>
+  <data name="Chat.ParentMessageNotFound" xml:space="preserve">
+    <value>Mensagem pai não encontrada.</value>
+  </data>
+  <data name="Chat.ParentMessageDifferentChannel" xml:space="preserve">
+    <value>A mensagem pai pertence a outro canal.</value>
+  </data>
+  <data name="Chat.CannotReplyToReply" xml:space="preserve">
+    <value>Não é possível responder a uma resposta; as threads têm apenas um nível.</value>
+  </data>
+  <data name="Chat.CannotDmYourself" xml:space="preserve">
+    <value>Não é possível iniciar uma conversa direta consigo mesmo.</value>
+  </data>
+  <data name="Validation.BodyOrAttachmentRequired" xml:space="preserve">
+    <value>É necessário informar um texto ou um anexo.</value>
+  </data>
+</root>

--- a/src/Modules/Chat/Modules.Chat/Localization/ChatResources.resx
+++ b/src/Modules/Chat/Modules.Chat/Localization/ChatResources.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Chat.ChannelNotFound" xml:space="preserve">
+    <value>Channel not found.</value>
+  </data>
+  <data name="Chat.ChannelAdminRoleRequired" xml:space="preserve">
+    <value>Channel admin role required.</value>
+  </data>
+  <data name="Chat.OnlyAdminsCanAddMembersToPrivateChannel" xml:space="preserve">
+    <value>Only channel admins can add members to private channels.</value>
+  </data>
+  <data name="Chat.MessageNotFound" xml:space="preserve">
+    <value>Message not found.</value>
+  </data>
+  <data name="Chat.MessageNotFoundInChannel" xml:space="preserve">
+    <value>Message not found in this channel.</value>
+  </data>
+  <data name="Chat.ParentMessageNotFound" xml:space="preserve">
+    <value>Parent message not found.</value>
+  </data>
+  <data name="Chat.ParentMessageDifferentChannel" xml:space="preserve">
+    <value>Parent message belongs to a different channel.</value>
+  </data>
+  <data name="Chat.CannotReplyToReply" xml:space="preserve">
+    <value>Cannot reply to a reply — threads are single-level only.</value>
+  </data>
+  <data name="Chat.CannotDmYourself" xml:space="preserve">
+    <value>Cannot DM yourself.</value>
+  </data>
+  <data name="Validation.BodyOrAttachmentRequired" xml:space="preserve">
+    <value>Either a body or an attachment is required.</value>
+  </data>
+</root>

--- a/src/Modules/Chat/Modules.Chat/Modules.Chat.csproj
+++ b/src/Modules/Chat/Modules.Chat/Modules.Chat.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Chat</RootNamespace>
 		<AssemblyName>FSH.Modules.Chat</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
+		<!-- ChatResources is an intentional empty localizer marker (see Localization/ChatResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Files/Modules.Files/Domain/FileAsset.cs
+++ b/src/Modules/Files/Modules.Files/Domain/FileAsset.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Domain;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Files.Contracts.v1.DTOs;
 using FSH.Modules.Files.Domain.Events;
+using FSH.Modules.Files.Localization;
 
 namespace FSH.Modules.Files.Domain;
 
@@ -87,7 +88,12 @@ public sealed class FileAsset : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 $"Cannot finalize file in status {Status}.",
                 errors: null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Files.CannotFinalizeInStatus",
+                MessageArgs = [Status],
+                ResourceSource = typeof(FilesResources),
+            };
         }
         if (actualSize <= 0)
         {
@@ -126,7 +132,12 @@ public sealed class FileAsset : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 $"Cannot change visibility while file is in status {Status}.",
                 errors: null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Files.CannotChangeVisibilityInStatus",
+                MessageArgs = [Status],
+                ResourceSource = typeof(FilesResources),
+            };
         }
         if (Visibility == next) return;
         Visibility = next;

--- a/src/Modules/Files/Modules.Files/Features/v1/ChangeVisibility/ChangeFileVisibilityCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/ChangeVisibility/ChangeFileVisibilityCommandHandler.cs
@@ -7,6 +7,7 @@ using FSH.Modules.Files.Contracts.v1.DTOs;
 using FSH.Modules.Files.Data;
 using FSH.Modules.Files.Domain;
 using FSH.Modules.Files.Features.v1.Internal;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -29,21 +30,38 @@ public sealed class ChangeFileVisibilityCommandHandler(
             throw new CustomException(
                 $"Unknown visibility value '{cmd.Visibility}'.",
                 errors: null,
-                System.Net.HttpStatusCode.BadRequest);
+                System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.UnknownVisibility",
+                MessageArgs = [cmd.Visibility],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         var f = await db.FileAssets
             .FirstOrDefaultAsync(x => x.Id == cmd.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var userId = currentUser.GetUserId().ToString();
         var policy = policies.Resolve(f.OwnerType)
-            ?? throw new ForbiddenException("no policy");
+            ?? throw new ForbiddenException("no policy")
+            {
+                MessageKey = "Files.NoAccessPolicy",
+                ResourceSource = typeof(FilesResources),
+            };
         var ctx = new FileAccessContext(f.Id, f.OwnerType, f.OwnerId, f.CreatedByUserId, (int)f.Visibility);
         if (!await policy.CanChangeVisibilityAsync(ctx, userId, cancellationToken).ConfigureAwait(false))
         {
-            throw new ForbiddenException("not allowed to change this file's visibility");
+            throw new ForbiddenException("not allowed to change this file's visibility")
+            {
+                MessageKey = "Files.NotAllowedToChangeVisibility",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         f.ChangeVisibility(cmd.Visibility);

--- a/src/Modules/Files/Modules.Files/Features/v1/ChangeVisibility/ChangeFileVisibilityCommandValidator.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/ChangeVisibility/ChangeFileVisibilityCommandValidator.cs
@@ -1,16 +1,18 @@
 using FluentValidation;
 using FSH.Modules.Files.Contracts.v1.Commands;
+using FSH.Modules.Files.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Files.Features.v1.ChangeVisibility;
 
 public sealed class ChangeFileVisibilityCommandValidator : AbstractValidator<ChangeFileVisibilityCommand>
 {
-    public ChangeFileVisibilityCommandValidator()
+    public ChangeFileVisibilityCommandValidator(IStringLocalizer<FilesResources> localizer)
     {
         RuleFor(x => x.FileAssetId).NotEmpty();
 
         RuleFor(x => x.Visibility)
             .IsInEnum()
-            .WithMessage("Visibility must be Public or Private.");
+            .WithMessage(_ => localizer["Files.VisibilityInvalid"]);
     }
 }

--- a/src/Modules/Files/Modules.Files/Features/v1/DeleteFile/DeleteFileCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/DeleteFile/DeleteFileCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Files.Contracts;
 using FSH.Modules.Files.Contracts.v1.Commands;
 using FSH.Modules.Files.Data;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -22,15 +23,27 @@ public sealed class DeleteFileCommandHandler(
         var f = await db.FileAssets
             .FirstOrDefaultAsync(x => x.Id == cmd.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var userId = currentUser.GetUserId().ToString();
         var policy = policies.Resolve(f.OwnerType)
-            ?? throw new ForbiddenException("no policy");
+            ?? throw new ForbiddenException("no policy")
+            {
+                MessageKey = "Files.NoAccessPolicy",
+                ResourceSource = typeof(FilesResources),
+            };
         var ctx = new FileAccessContext(f.Id, f.OwnerType, f.OwnerId, f.CreatedByUserId, (int)f.Visibility);
         if (!await policy.CanDeleteAsync(ctx, userId, cancellationToken).ConfigureAwait(false))
         {
-            throw new ForbiddenException("not allowed to delete this file");
+            throw new ForbiddenException("not allowed to delete this file")
+            {
+                MessageKey = "Files.NotAllowedToDelete",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         // Soft-delete: AuditableEntitySaveChangesInterceptor sets IsDeleted/DeletedOnUtc/DeletedBy on

--- a/src/Modules/Files/Modules.Files/Features/v1/FinalizeUpload/FinalizeUploadCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/FinalizeUpload/FinalizeUploadCommandHandler.cs
@@ -12,6 +12,7 @@ using FSH.Modules.Files.Contracts.v1.DTOs;
 using FSH.Modules.Files.Data;
 using FSH.Modules.Files.Domain;
 using FSH.Modules.Files.Features.v1.Internal;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -30,25 +31,44 @@ public sealed class FinalizeUploadCommandHandler(
     public async ValueTask<FileAssetDto> Handle(FinalizeUploadCommand cmd, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cmd);
-        var tenantId = currentUser.GetTenant() ?? throw new UnauthorizedException("invalid tenant");
+        var tenantId = currentUser.GetTenant() ?? throw new UnauthorizedException("invalid tenant")
+        {
+            MessageKey = "Error.InvalidTenant",
+        };
         var userId = currentUser.GetUserId().ToString();
 
         var asset = await db.FileAssets
             .FirstOrDefaultAsync(f => f.Id == cmd.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         if (!string.Equals(asset.CreatedByUserId, userId, StringComparison.Ordinal))
         {
-            throw new ForbiddenException("not your pending file");
+            throw new ForbiddenException("not your pending file")
+            {
+                MessageKey = "Files.NotYourPendingFile",
+                ResourceSource = typeof(FilesResources),
+            };
         }
         if (asset.Status != FileAssetStatus.PendingUpload)
         {
-            throw new CustomException("file already finalized", (IEnumerable<string>?)null, HttpStatusCode.Conflict);
+            throw new CustomException("file already finalized", (IEnumerable<string>?)null, HttpStatusCode.Conflict)
+            {
+                MessageKey = "Files.AlreadyFinalized",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         var head = await storage.HeadObjectAsync(asset.StorageKey, cancellationToken).ConfigureAwait(false)
-            ?? throw new CustomException("upload not received", (IEnumerable<string>?)null, HttpStatusCode.Conflict);
+            ?? throw new CustomException("upload not received", (IEnumerable<string>?)null, HttpStatusCode.Conflict)
+            {
+                MessageKey = "Files.UploadNotReceived",
+                ResourceSource = typeof(FilesResources),
+            };
 
         // Allow declared+1% slack (S3 may differ slightly on multipart). Reject larger sizes.
         var maxAllowed = asset.SizeBytes + Math.Max(1024L, asset.SizeBytes / 100);
@@ -60,7 +80,12 @@ public sealed class FinalizeUploadCommandHandler(
             throw new CustomException(
                 $"uploaded size ({head.SizeBytes}) exceeds declared ({asset.SizeBytes})",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.UploadedSizeExceedsDeclared",
+                MessageArgs = [head.SizeBytes, asset.SizeBytes],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         if (!string.Equals(head.ContentType, asset.ContentType, StringComparison.OrdinalIgnoreCase))
@@ -71,7 +96,11 @@ public sealed class FinalizeUploadCommandHandler(
             throw new CustomException(
                 "uploaded content-type mismatch",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.ContentTypeMismatch",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         var scanResult = await scanner.ScanAsync(asset.StorageKey, cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Files/Modules.Files/Features/v1/GetFileDownloadUrl/GetFileDownloadUrlQueryHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/GetFileDownloadUrl/GetFileDownloadUrlQueryHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Files.Contracts;
 using FSH.Modules.Files.Contracts.v1.DTOs;
 using FSH.Modules.Files.Contracts.v1.Queries;
 using FSH.Modules.Files.Data;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -27,16 +28,28 @@ public sealed class GetFileDownloadUrlQueryHandler(
         var f = await db.FileAssets.AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == q.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var userId = currentUser.GetUserId().ToString();
         var policy = policies.Resolve(f.OwnerType)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var ctx = new FileAccessContext(f.Id, f.OwnerType, f.OwnerId, f.CreatedByUserId, (int)f.Visibility);
         if (!await policy.CanReadAsync(ctx, userId, cancellationToken).ConfigureAwait(false))
         {
-            throw new NotFoundException("file not found");
+            throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         var ttl = TimeSpan.FromMinutes(options.Value.DownloadUrlTtlMinutes);

--- a/src/Modules/Files/Modules.Files/Features/v1/GetFileMetadata/GetFileMetadataQueryHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/GetFileMetadata/GetFileMetadataQueryHandler.cs
@@ -7,6 +7,7 @@ using FSH.Modules.Files.Contracts.v1.Queries;
 using FSH.Modules.Files.Data;
 using FSH.Modules.Files.Domain;
 using FSH.Modules.Files.Features.v1.Internal;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -27,16 +28,29 @@ public sealed class GetFileMetadataQueryHandler(
         var f = await db.FileAssets.AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == q.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var userId = currentUser.GetUserId().ToString();
+        // don't leak existence on missing policy
         var policy = policies.Resolve(f.OwnerType)
-            ?? throw new NotFoundException("file not found"); // don't leak existence on missing policy
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         var ctx = new FileAccessContext(f.Id, f.OwnerType, f.OwnerId, f.CreatedByUserId, (int)f.Visibility);
         if (!await policy.CanReadAsync(ctx, userId, cancellationToken).ConfigureAwait(false))
         {
-            throw new NotFoundException("file not found");
+            throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         // Public files get a durable URL safe to persist long-term, while private files mint a

--- a/src/Modules/Files/Modules.Files/Features/v1/ListMyFiles/ListMyFilesQueryHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/ListMyFiles/ListMyFilesQueryHandler.cs
@@ -24,7 +24,10 @@ public sealed class ListMyFilesQueryHandler(
         var userId = currentUser.GetUserId().ToString();
         if (string.IsNullOrEmpty(userId) || userId == Guid.Empty.ToString())
         {
-            throw new UnauthorizedException("no current user");
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
         }
 
         var page = Math.Max(1, q.Page);

--- a/src/Modules/Files/Modules.Files/Features/v1/RequestUploadUrl/RequestUploadUrlCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/RequestUploadUrl/RequestUploadUrlCommandHandler.cs
@@ -9,6 +9,7 @@ using FSH.Modules.Files.Contracts.v1.Commands;
 using FSH.Modules.Files.Contracts.v1.DTOs;
 using FSH.Modules.Files.Data;
 using FSH.Modules.Files.Domain;
+using FSH.Modules.Files.Localization;
 using FSH.Modules.Files.Services;
 using Mediator;
 using Microsoft.Extensions.Options;
@@ -28,17 +29,28 @@ public sealed class RequestUploadUrlCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
 
-        var tenantId = currentUser.GetTenant() ?? throw new UnauthorizedException("invalid tenant");
+        var tenantId = currentUser.GetTenant() ?? throw new UnauthorizedException("invalid tenant")
+        {
+            MessageKey = "Error.InvalidTenant",
+        };
         var userId = currentUser.GetUserId();
         if (userId == Guid.Empty)
         {
-            throw new UnauthorizedException("no current user");
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
         }
 
         // Category lookup + extension/size validation.
         if (!options.Value.Categories.TryGetValue(cmd.Category, out var category))
         {
-            throw new CustomException($"Unknown category '{cmd.Category}'.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest);
+            throw new CustomException($"Unknown category '{cmd.Category}'.", (IEnumerable<string>?)null, HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.UnknownCategory",
+                MessageArgs = [cmd.Category],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         var extension = Path.GetExtension(cmd.FileName);
@@ -48,7 +60,12 @@ public sealed class RequestUploadUrlCommandHandler(
             throw new CustomException(
                 $"Extension '{extension}' not allowed for category '{cmd.Category}'.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.ExtensionNotAllowed",
+                MessageArgs = [extension, cmd.Category],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         if (cmd.SizeBytes > category.MaxBytes)
@@ -56,15 +73,29 @@ public sealed class RequestUploadUrlCommandHandler(
             throw new CustomException(
                 $"File exceeds max size of {category.MaxBytes} bytes for category '{cmd.Category}'.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Files.FileExceedsMaxSize",
+                MessageArgs = [category.MaxBytes, cmd.Category],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         // Authorization: policy must exist and allow the attach.
         var policy = policies.Resolve(cmd.OwnerType)
-            ?? throw new ForbiddenException($"No file access policy registered for owner type '{cmd.OwnerType}'.");
+            ?? throw new ForbiddenException($"No file access policy registered for owner type '{cmd.OwnerType}'.")
+            {
+                MessageKey = "Files.NoPolicyForOwnerType",
+                MessageArgs = [cmd.OwnerType],
+                ResourceSource = typeof(FilesResources),
+            };
         if (!await policy.CanAttachAsync(cmd.OwnerId, userId.ToString(), cancellationToken).ConfigureAwait(false))
         {
-            throw new ForbiddenException("Not allowed to attach files to this owner.");
+            throw new ForbiddenException("Not allowed to attach files to this owner.")
+            {
+                MessageKey = "Files.NotAllowedToAttach",
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         // Quota pre-check (no debit yet — debit happens on finalize with actual bytes).
@@ -74,7 +105,12 @@ public sealed class RequestUploadUrlCommandHandler(
             throw new CustomException(
                 $"Storage quota exceeded ({quotaCheck.CurrentUsage}/{quotaCheck.Limit} bytes).",
                 (IEnumerable<string>?)null,
-                (HttpStatusCode)507);
+                (HttpStatusCode)507)
+            {
+                MessageKey = "Files.StorageQuotaExceeded",
+                MessageArgs = [quotaCheck.CurrentUsage, quotaCheck.Limit],
+                ResourceSource = typeof(FilesResources),
+            };
         }
 
         // Generate id + storage key + presigned URL.

--- a/src/Modules/Files/Modules.Files/Features/v1/RestoreFile/RestoreFileCommandHandler.cs
+++ b/src/Modules/Files/Modules.Files/Features/v1/RestoreFile/RestoreFileCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Files.Contracts.v1.Commands;
 using FSH.Modules.Files.Data;
+using FSH.Modules.Files.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +19,11 @@ public sealed class RestoreFileCommandHandler(FilesDbContext db)
             .IgnoreQueryFilters()
             .FirstOrDefaultAsync(x => x.Id == cmd.FileAssetId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("file not found");
+            ?? throw new NotFoundException("file not found")
+            {
+                MessageKey = "Files.FileNotFound",
+                ResourceSource = typeof(FilesResources),
+            };
 
         if (!f.IsDeleted)
         {

--- a/src/Modules/Files/Modules.Files/Localization/FilesResources.cs
+++ b/src/Modules/Files/Modules.Files/Localization/FilesResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Files.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;FilesResources&gt;</c> to the Files resx catalog.</summary>
+public sealed class FilesResources;

--- a/src/Modules/Files/Modules.Files/Localization/FilesResources.pt-BR.resx
+++ b/src/Modules/Files/Modules.Files/Localization/FilesResources.pt-BR.resx
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Files.CannotFinalizeInStatus" xml:space="preserve">
+    <value>Não é possível finalizar o arquivo no status {0}.</value>
+  </data>
+  <data name="Files.CannotChangeVisibilityInStatus" xml:space="preserve">
+    <value>Não é possível alterar a visibilidade enquanto o arquivo está no status {0}.</value>
+  </data>
+  <data name="Files.UnknownVisibility" xml:space="preserve">
+    <value>Valor de visibilidade desconhecido '{0}'.</value>
+  </data>
+  <data name="Files.FileNotFound" xml:space="preserve">
+    <value>Arquivo não encontrado.</value>
+  </data>
+  <data name="Files.NoAccessPolicy" xml:space="preserve">
+    <value>Nenhuma política de acesso a arquivos registrada.</value>
+  </data>
+  <data name="Files.NotAllowedToChangeVisibility" xml:space="preserve">
+    <value>Você não tem permissão para alterar a visibilidade deste arquivo.</value>
+  </data>
+  <data name="Files.NotAllowedToDelete" xml:space="preserve">
+    <value>Você não tem permissão para excluir este arquivo.</value>
+  </data>
+  <data name="Files.NotYourPendingFile" xml:space="preserve">
+    <value>Este arquivo pendente não pertence a você.</value>
+  </data>
+  <data name="Files.AlreadyFinalized" xml:space="preserve">
+    <value>O arquivo já foi finalizado.</value>
+  </data>
+  <data name="Files.UploadNotReceived" xml:space="preserve">
+    <value>O upload não foi recebido.</value>
+  </data>
+  <data name="Files.UploadedSizeExceedsDeclared" xml:space="preserve">
+    <value>O tamanho enviado ({0}) excede o tamanho declarado ({1}).</value>
+  </data>
+  <data name="Files.ContentTypeMismatch" xml:space="preserve">
+    <value>O tipo de conteúdo enviado não corresponde.</value>
+  </data>
+  <data name="Files.UnknownCategory" xml:space="preserve">
+    <value>Categoria desconhecida '{0}'.</value>
+  </data>
+  <data name="Files.ExtensionNotAllowed" xml:space="preserve">
+    <value>A extensão '{0}' não é permitida para a categoria '{1}'.</value>
+  </data>
+  <data name="Files.FileExceedsMaxSize" xml:space="preserve">
+    <value>O arquivo excede o tamanho máximo de {0} bytes para a categoria '{1}'.</value>
+  </data>
+  <data name="Files.NoPolicyForOwnerType" xml:space="preserve">
+    <value>Nenhuma política de acesso a arquivos registrada para o tipo de proprietário '{0}'.</value>
+  </data>
+  <data name="Files.NotAllowedToAttach" xml:space="preserve">
+    <value>Você não tem permissão para anexar arquivos a este proprietário.</value>
+  </data>
+  <data name="Files.StorageQuotaExceeded" xml:space="preserve">
+    <value>Cota de armazenamento excedida ({0}/{1} bytes).</value>
+  </data>
+  <data name="Files.VisibilityInvalid" xml:space="preserve">
+    <value>A visibilidade deve ser Pública ou Privada.</value>
+  </data>
+</root>

--- a/src/Modules/Files/Modules.Files/Localization/FilesResources.resx
+++ b/src/Modules/Files/Modules.Files/Localization/FilesResources.resx
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Files.CannotFinalizeInStatus" xml:space="preserve">
+    <value>Cannot finalize file in status {0}.</value>
+  </data>
+  <data name="Files.CannotChangeVisibilityInStatus" xml:space="preserve">
+    <value>Cannot change visibility while file is in status {0}.</value>
+  </data>
+  <data name="Files.UnknownVisibility" xml:space="preserve">
+    <value>Unknown visibility value '{0}'.</value>
+  </data>
+  <data name="Files.FileNotFound" xml:space="preserve">
+    <value>File not found.</value>
+  </data>
+  <data name="Files.NoAccessPolicy" xml:space="preserve">
+    <value>No file access policy is registered.</value>
+  </data>
+  <data name="Files.NotAllowedToChangeVisibility" xml:space="preserve">
+    <value>You are not allowed to change this file's visibility.</value>
+  </data>
+  <data name="Files.NotAllowedToDelete" xml:space="preserve">
+    <value>You are not allowed to delete this file.</value>
+  </data>
+  <data name="Files.NotYourPendingFile" xml:space="preserve">
+    <value>This pending file does not belong to you.</value>
+  </data>
+  <data name="Files.AlreadyFinalized" xml:space="preserve">
+    <value>File is already finalized.</value>
+  </data>
+  <data name="Files.UploadNotReceived" xml:space="preserve">
+    <value>Upload was not received.</value>
+  </data>
+  <data name="Files.UploadedSizeExceedsDeclared" xml:space="preserve">
+    <value>Uploaded size ({0}) exceeds the declared size ({1}).</value>
+  </data>
+  <data name="Files.ContentTypeMismatch" xml:space="preserve">
+    <value>Uploaded content type does not match.</value>
+  </data>
+  <data name="Files.UnknownCategory" xml:space="preserve">
+    <value>Unknown category '{0}'.</value>
+  </data>
+  <data name="Files.ExtensionNotAllowed" xml:space="preserve">
+    <value>Extension '{0}' is not allowed for category '{1}'.</value>
+  </data>
+  <data name="Files.FileExceedsMaxSize" xml:space="preserve">
+    <value>File exceeds the maximum size of {0} bytes for category '{1}'.</value>
+  </data>
+  <data name="Files.NoPolicyForOwnerType" xml:space="preserve">
+    <value>No file access policy is registered for owner type '{0}'.</value>
+  </data>
+  <data name="Files.NotAllowedToAttach" xml:space="preserve">
+    <value>You are not allowed to attach files to this owner.</value>
+  </data>
+  <data name="Files.StorageQuotaExceeded" xml:space="preserve">
+    <value>Storage quota exceeded ({0}/{1} bytes).</value>
+  </data>
+  <data name="Files.VisibilityInvalid" xml:space="preserve">
+    <value>Visibility must be Public or Private.</value>
+  </data>
+</root>

--- a/src/Modules/Files/Modules.Files/Modules.Files.csproj
+++ b/src/Modules/Files/Modules.Files/Modules.Files.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Files</RootNamespace>
 		<AssemblyName>FSH.Modules.Files</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
+		<!-- FilesResources is an intentional empty localizer marker (see Localization/FilesResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;CA1002;CA2227;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Groups.AddUsersToGroup;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -32,7 +33,12 @@ public sealed class AddUsersToGroupCommandHandler : ICommandHandler<AddUsersToGr
 
         if (!groupExists)
         {
-            throw new NotFoundException($"Group with ID '{command.GroupId}' not found.");
+            throw new NotFoundException($"Group with ID '{command.GroupId}' not found.")
+            {
+                MessageKey = "Identity.GroupNotFound",
+                MessageArgs = [command.GroupId],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Validate user IDs exist
@@ -44,7 +50,12 @@ public sealed class AddUsersToGroupCommandHandler : ICommandHandler<AddUsersToGr
         var invalidUserIds = command.UserIds.Except(existingUserIds).ToList();
         if (invalidUserIds.Count > 0)
         {
-            throw new NotFoundException($"Users not found: {string.Join(", ", invalidUserIds)}");
+            throw new NotFoundException($"Users not found: {string.Join(", ", invalidUserIds)}")
+            {
+                MessageKey = "Identity.UsersNotFound",
+                MessageArgs = [string.Join(", ", invalidUserIds)],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Get existing memberships

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/AddUsersToGroup/AddUsersToGroupCommandValidator.cs
@@ -1,18 +1,20 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Groups.AddUsersToGroup;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Groups.AddUsersToGroup;
 
 public sealed class AddUsersToGroupCommandValidator : AbstractValidator<AddUsersToGroupCommand>
 {
-    public AddUsersToGroupCommandValidator()
+    public AddUsersToGroupCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.GroupId)
-            .NotEmpty().WithMessage("Group ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupIdRequired"]);
 
         RuleFor(x => x.UserIds)
-            .NotEmpty().WithMessage("At least one user ID is required.")
+            .NotEmpty().WithMessage(_ => localizer["Validation.AtLeastOneUserIdRequired"])
             .Must(ids => ids.All(id => !string.IsNullOrWhiteSpace(id)))
-            .WithMessage("User IDs cannot be empty or whitespace.");
+            .WithMessage(_ => localizer["Validation.UserIdsNotEmptyOrWhitespace"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.Groups.CreateGroup;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -30,7 +31,12 @@ public sealed class CreateGroupCommandHandler : ICommandHandler<CreateGroupComma
 
         if (nameExists)
         {
-            throw new CustomException($"Group with name '{command.Name}' already exists.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.Conflict);
+            throw new CustomException($"Group with name '{command.Name}' already exists.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.Conflict)
+            {
+                MessageKey = "Identity.GroupNameAlreadyExists",
+                MessageArgs = [command.Name],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Validate role IDs exist — fetch Id+Name in a single query to avoid a second roundtrip later
@@ -46,7 +52,12 @@ public sealed class CreateGroupCommandHandler : ICommandHandler<CreateGroupComma
             var invalidRoleIds = command.RoleIds.Except(resolvedRoles.Select(r => r.Id)).ToList();
             if (invalidRoleIds.Count > 0)
             {
-                throw new NotFoundException($"Roles not found: {string.Join(", ", invalidRoleIds)}");
+                throw new NotFoundException($"Roles not found: {string.Join(", ", invalidRoleIds)}")
+                {
+                    MessageKey = "Identity.RolesNotFoundWithIds",
+                    MessageArgs = [string.Join(", ", invalidRoleIds)],
+                    ResourceSource = typeof(IdentityResources),
+                };
             }
         }
 

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/CreateGroup/CreateGroupCommandValidator.cs
@@ -1,17 +1,19 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Groups.CreateGroup;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Groups.CreateGroup;
 
 public sealed class CreateGroupCommandValidator : AbstractValidator<CreateGroupCommand>
 {
-    public CreateGroupCommandValidator()
+    public CreateGroupCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Group name is required.")
-            .MaximumLength(256).WithMessage("Group name must not exceed 256 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupNameRequired"])
+            .MaximumLength(256).WithMessage(_ => localizer["Validation.GroupNameMaxLength"]);
 
         RuleFor(x => x.Description)
-            .MaximumLength(1024).WithMessage("Description must not exceed 1024 characters.");
+            .MaximumLength(1024).WithMessage(_ => localizer["Validation.DescriptionMaxLength"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Groups.DeleteGroup;
 using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -27,11 +28,20 @@ public sealed class DeleteGroupCommandHandler : ICommandHandler<DeleteGroupComma
 
         var group = await _dbContext.Groups
             .FirstOrDefaultAsync(g => g.Id == command.Id, cancellationToken)
-            ?? throw new NotFoundException($"Group with ID '{command.Id}' not found.");
+            ?? throw new NotFoundException($"Group with ID '{command.Id}' not found.")
+            {
+                MessageKey = "Identity.GroupNotFound",
+                MessageArgs = [command.Id],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         if (group.IsSystemGroup)
         {
-            throw new ForbiddenException("System groups cannot be deleted.");
+            throw new ForbiddenException("System groups cannot be deleted.")
+            {
+                MessageKey = "Identity.SystemGroupsCannotBeDeleted",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Snapshot members before delete; soft-delete flips IsDeleted but membership rows

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Groups.DeleteGroup;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Groups.DeleteGroup;
 
 public sealed class DeleteGroupCommandValidator : AbstractValidator<DeleteGroupCommand>
 {
-    public DeleteGroupCommandValidator()
+    public DeleteGroupCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Id)
-            .NotEmpty().WithMessage("Group ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/GetGroupById/GetGroupByIdQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/GetGroupById/GetGroupByIdQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.Groups.GetGroupById;
 using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,7 +23,12 @@ public sealed class GetGroupByIdQueryHandler : IQueryHandler<GetGroupByIdQuery, 
             .AsNoTracking()
             .Include(g => g.GroupRoles)
             .FirstOrDefaultAsync(g => g.Id == query.Id, cancellationToken)
-            ?? throw new NotFoundException($"Group with ID '{query.Id}' not found.");
+            ?? throw new NotFoundException($"Group with ID '{query.Id}' not found.")
+            {
+                MessageKey = "Identity.GroupNotFound",
+                MessageArgs = [query.Id],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var memberCount = await _dbContext.UserGroups
             .AsNoTracking()

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/GetGroupMembers/GetGroupMembersQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/GetGroupMembers/GetGroupMembersQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.Groups.GetGroupMembers;
 using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -25,7 +26,12 @@ public sealed class GetGroupMembersQueryHandler : IQueryHandler<GetGroupMembersQ
 
         if (!groupExists)
         {
-            throw new NotFoundException($"Group with ID '{query.GroupId}' not found.");
+            throw new NotFoundException($"Group with ID '{query.GroupId}' not found.")
+            {
+                MessageKey = "Identity.GroupNotFound",
+                MessageArgs = [query.GroupId],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Get memberships with user info

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Groups.RemoveUserFromGroup;
 using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -28,14 +29,23 @@ public sealed class RemoveUserFromGroupCommandHandler : ICommandHandler<RemoveUs
 
         if (membership is null)
         {
-            throw new NotFoundException($"User '{command.UserId}' is not a member of group '{command.GroupId}'.");
+            throw new NotFoundException($"User '{command.UserId}' is not a member of group '{command.GroupId}'.")
+            {
+                MessageKey = "Identity.UserNotMemberOfGroup",
+                MessageArgs = [command.UserId, command.GroupId],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Default groups (e.g. seeded "All Users") require every tenant user to be a member, so
         // removing one breaks that invariant and leaves later registrants in a half-populated group.
         if (membership.Group is not null && membership.Group.IsDefault)
         {
-            throw new ForbiddenException("Users cannot be removed from a default group.");
+            throw new ForbiddenException("Users cannot be removed from a default group.")
+            {
+                MessageKey = "Identity.CannotRemoveFromDefaultGroup",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         _dbContext.UserGroups.Remove(membership);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/RemoveUserFromGroup/RemoveUserFromGroupCommandValidator.cs
@@ -1,16 +1,18 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Groups.RemoveUserFromGroup;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Groups.RemoveUserFromGroup;
 
 public sealed class RemoveUserFromGroupCommandValidator : AbstractValidator<RemoveUserFromGroupCommand>
 {
-    public RemoveUserFromGroupCommandValidator()
+    public RemoveUserFromGroupCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.GroupId)
-            .NotEmpty().WithMessage("Group ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupIdRequired"]);
 
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Groups.UpdateGroup;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -33,7 +34,11 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
         // assignments are all part of the seed contract that the startup syncer relies on.
         if (group.IsSystemGroup)
         {
-            throw new ForbiddenException("System groups cannot be modified.");
+            throw new ForbiddenException("System groups cannot be modified.")
+            {
+                MessageKey = "Identity.SystemGroupsCannotBeModified",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await ValidateUniqueNameAsync(command.Id, command.Name, cancellationToken);
@@ -69,7 +74,12 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
         return await _dbContext.Groups
             .Include(g => g.GroupRoles)
             .FirstOrDefaultAsync(g => g.Id == id, cancellationToken)
-            ?? throw new NotFoundException($"Group with ID '{id}' not found.");
+            ?? throw new NotFoundException($"Group with ID '{id}' not found.")
+            {
+                MessageKey = "Identity.GroupNotFound",
+                MessageArgs = [id],
+                ResourceSource = typeof(IdentityResources),
+            };
     }
 
     private async Task ValidateUniqueNameAsync(Guid excludeId, string name, CancellationToken cancellationToken)
@@ -79,7 +89,12 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
 
         if (nameExists)
         {
-            throw new CustomException($"Group with name '{name}' already exists.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.Conflict);
+            throw new CustomException($"Group with name '{name}' already exists.", (IEnumerable<string>?)null, System.Net.HttpStatusCode.Conflict)
+            {
+                MessageKey = "Identity.GroupNameAlreadyExists",
+                MessageArgs = [name],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -98,7 +113,12 @@ public sealed class UpdateGroupCommandHandler : ICommandHandler<UpdateGroupComma
         var invalidRoleIds = roleIds.Except(existingRoleIds).ToList();
         if (invalidRoleIds.Count > 0)
         {
-            throw new NotFoundException($"Roles not found: {string.Join(", ", invalidRoleIds)}");
+            throw new NotFoundException($"Roles not found: {string.Join(", ", invalidRoleIds)}")
+            {
+                MessageKey = "Identity.RolesNotFoundWithIds",
+                MessageArgs = [string.Join(", ", invalidRoleIds)],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Groups/UpdateGroup/UpdateGroupCommandValidator.cs
@@ -1,20 +1,22 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Groups.UpdateGroup;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Groups.UpdateGroup;
 
 public sealed class UpdateGroupCommandValidator : AbstractValidator<UpdateGroupCommand>
 {
-    public UpdateGroupCommandValidator()
+    public UpdateGroupCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Id)
-            .NotEmpty().WithMessage("Group ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupIdRequired"]);
 
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Group name is required.")
-            .MaximumLength(256).WithMessage("Group name must not exceed 256 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.GroupNameRequired"])
+            .MaximumLength(256).WithMessage(_ => localizer["Validation.GroupNameMaxLength"]);
 
         RuleFor(x => x.Description)
-            .MaximumLength(1024).WithMessage("Description must not exceed 1024 characters.");
+            .MaximumLength(1024).WithMessage(_ => localizer["Validation.DescriptionMaxLength"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/EndImpersonation/EndImpersonationCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/EndImpersonation/EndImpersonationCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Impersonation.EndImpersonation;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.Extensions.Logging;
 using System.IdentityModel.Tokens.Jwt;
@@ -66,7 +67,11 @@ public sealed class EndImpersonationCommandHandler
             throw new CustomException(
                 "current session is not an impersonation session",
                 errors: null,
-                System.Net.HttpStatusCode.BadRequest);
+                System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.NotAnImpersonationSession",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var impersonatedUserId = _currentUser.GetUserId().ToString();
@@ -93,7 +98,11 @@ public sealed class EndImpersonationCommandHandler
 
         if (actorClaimsResult is null)
         {
-            throw new NotFoundException("original actor not found");
+            throw new NotFoundException("original actor not found")
+            {
+                MessageKey = "Identity.OriginalActorNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var (subject, actorClaims) = actorClaimsResult.Value;

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryHandler.cs
@@ -20,7 +20,10 @@ public sealed class GetImpersonationGrantsQueryHandler(
         ArgumentNullException.ThrowIfNull(request);
 
         var callerTenant = currentUser.GetTenant()
-            ?? throw new UnauthorizedException("missing tenant context");
+            ?? throw new UnauthorizedException("missing tenant context")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         var isRoot = string.Equals(callerTenant, MultitenancyConstants.Root.Id, StringComparison.Ordinal);
 
         // Tenant scoping: root operators target any tenant; tenant admins are locked to their

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/GetImpersonationGrants/GetImpersonationGrantsQueryValidator.cs
@@ -1,5 +1,7 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Impersonation.GetImpersonationGrants;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Impersonation.GetImpersonationGrants;
 
@@ -7,11 +9,11 @@ public sealed class GetImpersonationGrantsQueryValidator : AbstractValidator<Get
 {
     public const int MaxTake = 500;
 
-    public GetImpersonationGrantsQueryValidator()
+    public GetImpersonationGrantsQueryValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(q => q.Take)
             .GreaterThan(0)
             .LessThanOrEqualTo(MaxTake)
-            .WithMessage($"Take must be between 1 and {MaxTake}.");
+            .WithMessage(_ => localizer["Validation.ImpersonationTakeRange", MaxTake]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/RevokeImpersonationGrant/RevokeImpersonationGrantCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/RevokeImpersonationGrant/RevokeImpersonationGrantCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Impersonation;
 using FSH.Modules.Identity.Contracts.v1.Impersonation.RevokeImpersonationGrant;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.Extensions.Logging;
 
@@ -31,20 +32,31 @@ public sealed class RevokeImpersonationGrantCommandHandler(
 
         var callerUserId = currentUser.GetUserId().ToString();
         var callerTenantId = currentUser.GetTenant()
-            ?? throw new UnauthorizedException("missing tenant context");
+            ?? throw new UnauthorizedException("missing tenant context")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         var isRoot = string.Equals(callerTenantId, MultitenancyConstants.Root.Id, StringComparison.Ordinal);
 
         // Enforce visibility before revoking: tenant admins may only revoke grants in their own
         // tenant. Cross-tenant grants return 404 (not 403) so existence isn't confirmed out of scope.
         var grant = await grantService.GetByIdAsync(request.GrantId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException("impersonation grant not found");
+            ?? throw new NotFoundException("impersonation grant not found")
+            {
+                MessageKey = "Identity.ImpersonationGrantNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var withinTenant = string.Equals(grant.ImpersonatedTenantId, callerTenantId, StringComparison.Ordinal)
             || string.Equals(grant.ActorTenantId, callerTenantId, StringComparison.Ordinal);
 
         if (!isRoot && !withinTenant)
         {
-            throw new NotFoundException("impersonation grant not found");
+            throw new NotFoundException("impersonation grant not found")
+            {
+                MessageKey = "Identity.ImpersonationGrantNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var updated = await grantService.RevokeAsync(

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Impersonation/StartImpersonation/StartImpersonationCommandValidator.cs
@@ -1,5 +1,7 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Impersonation.StartImpersonation;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Impersonation.StartImpersonation;
 
@@ -12,7 +14,7 @@ public sealed class StartImpersonationCommandValidator : AbstractValidator<Start
     /// </summary>
     public const int MaxImpersonationMinutes = 60;
 
-    public StartImpersonationCommandValidator()
+    public StartImpersonationCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(p => p.TargetUserId)
             .Cascade(CascadeMode.Stop)
@@ -25,7 +27,7 @@ public sealed class StartImpersonationCommandValidator : AbstractValidator<Start
         RuleFor(p => p.DurationMinutes!.Value)
             .GreaterThan(0)
             .LessThanOrEqualTo(MaxImpersonationMinutes)
-            .WithMessage($"Duration must be between 1 and {MaxImpersonationMinutes} minutes.")
+            .WithMessage(_ => localizer["Validation.ImpersonationDurationRange", MaxImpersonationMinutes])
             .When(p => p.DurationMinutes.HasValue);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/DeleteRole/DeleteRoleCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Roles.DeleteRole;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Roles.DeleteRole;
 
 public sealed class DeleteRoleCommandValidator : AbstractValidator<DeleteRoleCommand>
 {
-    public DeleteRoleCommandValidator()
+    public DeleteRoleCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Id)
-            .NotEmpty().WithMessage("Role ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.RoleIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoles/GetRolesQueryValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/GetRoles/GetRolesQueryValidator.cs
@@ -1,16 +1,18 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Roles.GetRoles;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Roles.GetRoles;
 
 public sealed class GetRolesQueryValidator : AbstractValidator<GetRolesQuery>
 {
-    public GetRolesQueryValidator()
+    public GetRolesQueryValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.PageNumber)
-            .GreaterThanOrEqualTo(1).WithMessage("Page number must be greater than or equal to 1.");
+            .GreaterThanOrEqualTo(1).WithMessage(_ => localizer["Validation.PageNumberMinimum"]);
 
         RuleFor(x => x.PageSize)
-            .GreaterThanOrEqualTo(1).WithMessage("Page size must be greater than or equal to 1.");
+            .GreaterThanOrEqualTo(1).WithMessage(_ => localizer["Validation.PageSizeMinimum"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/RoleService.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/RoleService.cs
@@ -9,6 +9,7 @@ using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -57,10 +58,18 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
         CancellationToken cancellationToken = default)
     {
         if (roleManager is null)
-            throw new NotFoundException("RoleManager<FshRole> not resolved. Check Identity registration.");
+            throw new NotFoundException("RoleManager<FshRole> not resolved. Check Identity registration.")
+            {
+                MessageKey = "Identity.RoleManagerNotResolved",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         if (roleManager.Roles is null)
-            throw new NotFoundException("Role store not configured. Ensure .AddRoles<FshRole>() and EF stores.");
+            throw new NotFoundException("Role store not configured. Ensure .AddRoles<FshRole>() and EF stores.")
+            {
+                MessageKey = "Identity.RoleStoreNotConfigured",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var page = Math.Max(1, pageNumber);
         var size = Math.Clamp(pageSize, 1, 200);
@@ -97,7 +106,11 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
     {
         FshRole? role = await roleManager.FindByIdAsync(id);
 
-        _ = role ?? throw new NotFoundException("role not found");
+        _ = role ?? throw new NotFoundException("role not found")
+        {
+            MessageKey = "Identity.RoleNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         return new RoleDto { Id = role.Id, Name = role.Name!, Description = role.Description };
     }
@@ -111,9 +124,9 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
         if (role != null)
         {
             // System roles cannot be modified — neither renamed nor re-described.
-            EnsureNotSystemRole(role.Name, "System roles cannot be modified.");
+            EnsureNotSystemRole(role.Name, "System roles cannot be modified.", "Identity.SystemRoleCannotBeModified");
             // And no custom role can be renamed to a system role's name.
-            EnsureNotSystemRole(name, "Cannot rename a role to a system role's name.");
+            EnsureNotSystemRole(name, "Cannot rename a role to a system role's name.", "Identity.CannotRenameToSystemRole");
 
             role.Name = name;
             role.Description = description;
@@ -122,7 +135,7 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
         else
         {
             // No new role can be created using a system role's name.
-            EnsureNotSystemRole(name, "Cannot create a role using a system role's name.");
+            EnsureNotSystemRole(name, "Cannot create a role using a system role's name.", "Identity.CannotCreateWithSystemRoleName");
 
             role = new FshRole(name, description);
             await roleManager.CreateAsync(role);
@@ -135,9 +148,13 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
     {
         FshRole? role = await roleManager.FindByIdAsync(id);
 
-        _ = role ?? throw new NotFoundException("role not found");
+        _ = role ?? throw new NotFoundException("role not found")
+        {
+            MessageKey = "Identity.RoleNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
-        EnsureNotSystemRole(role.Name, "System roles cannot be deleted.");
+        EnsureNotSystemRole(role.Name, "System roles cannot be deleted.", "Identity.SystemRolesCannotBeDeleted");
 
         // Snapshot affected users BEFORE the cascade removes the role-mapping rows,
         // otherwise the lookup returns an empty set after delete.
@@ -149,7 +166,11 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
     public async Task<RoleDto> GetWithPermissionsAsync(string id, CancellationToken cancellationToken = default)
     {
         var role = await GetRoleAsync(id, cancellationToken);
-        _ = role ?? throw new NotFoundException("role not found");
+        _ = role ?? throw new NotFoundException("role not found")
+        {
+            MessageKey = "Identity.RoleNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         role.Permissions = await context.RoleClaims
             .AsNoTracking()
@@ -165,9 +186,13 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
         ArgumentNullException.ThrowIfNull(permissions);
 
         var role = await roleManager.FindByIdAsync(roleId)
-            ?? throw new NotFoundException("role not found");
+            ?? throw new NotFoundException("role not found")
+            {
+                MessageKey = "Identity.RoleNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
-        EnsureNotSystemRole(role.Name, "System role permissions are managed by the framework and cannot be modified.");
+        EnsureNotSystemRole(role.Name, "System role permissions are managed by the framework and cannot be modified.", "Identity.SystemRolePermissionsManaged");
         FilterRootPermissions(permissions);
 
         var currentClaims = await roleManager.GetClaimsAsync(role);
@@ -181,11 +206,15 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
         return "permissions updated";
     }
 
-    private static void EnsureNotSystemRole(string? roleName, string message)
+    private static void EnsureNotSystemRole(string? roleName, string message, string messageKey)
     {
         if (!string.IsNullOrEmpty(roleName) && RoleConstants.IsDefault(roleName))
         {
-            throw new CustomException(message, Array.Empty<string>(), HttpStatusCode.BadRequest);
+            throw new CustomException(message, Array.Empty<string>(), HttpStatusCode.BadRequest)
+            {
+                MessageKey = messageKey,
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -214,7 +243,11 @@ public sealed class RoleService(RoleManager<FshRole> roleManager,
             if (!result.Succeeded)
             {
                 var errors = result.Errors.Select(error => error.Description).ToList();
-                throw new CustomException("operation failed", errors);
+                throw new CustomException("operation failed", errors)
+                {
+                    MessageKey = "Identity.OperationFailed",
+                    ResourceSource = typeof(IdentityResources),
+                };
             }
         }
     }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpsertRole/UpsertRoleCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Roles/UpsertRole/UpsertRoleCommandValidator.cs
@@ -1,12 +1,14 @@
-﻿using FluentValidation;
+using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Roles.UpsertRole;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Roles.UpsertRole;
 
 public sealed class UpsertRoleCommandValidator : AbstractValidator<UpsertRoleCommand>
 {
-    public UpsertRoleCommandValidator()
+    public UpsertRoleCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
-        RuleFor(x => x.Name).NotEmpty().WithMessage("Role name is required.");
+        RuleFor(x => x.Name).NotEmpty().WithMessage(_ => localizer["Validation.RoleNameRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeAllSessions/AdminRevokeAllSessionsCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeAllSessions/AdminRevokeAllSessionsCommandValidator.cs
@@ -1,17 +1,19 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Sessions.AdminRevokeAllSessions;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Sessions.AdminRevokeAllSessions;
 
 public sealed class AdminRevokeAllSessionsCommandValidator : AbstractValidator<AdminRevokeAllSessionsCommand>
 {
-    public AdminRevokeAllSessionsCommandValidator()
+    public AdminRevokeAllSessionsCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
 
         RuleFor(x => x.Reason)
-            .MaximumLength(500).WithMessage("Reason must not exceed 500 characters.")
+            .MaximumLength(500).WithMessage(_ => localizer["Validation.ReasonMaxLength"])
             .When(x => x.Reason is not null);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeSession/AdminRevokeSessionCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/AdminRevokeSession/AdminRevokeSessionCommandValidator.cs
@@ -1,20 +1,22 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Sessions.AdminRevokeSession;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Sessions.AdminRevokeSession;
 
 public sealed class AdminRevokeSessionCommandValidator : AbstractValidator<AdminRevokeSessionCommand>
 {
-    public AdminRevokeSessionCommandValidator()
+    public AdminRevokeSessionCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
 
         RuleFor(x => x.SessionId)
-            .NotEmpty().WithMessage("Session ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.SessionIdRequired"]);
 
         RuleFor(x => x.Reason)
-            .MaximumLength(500).WithMessage("Reason must not exceed 500 characters.")
+            .MaximumLength(500).WithMessage(_ => localizer["Validation.ReasonMaxLength"])
             .When(x => x.Reason is not null);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/GetTenantSessions/GetTenantSessionsValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/GetTenantSessions/GetTenantSessionsValidator.cs
@@ -1,16 +1,18 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Sessions.GetTenantSessions;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Sessions.GetTenantSessions;
 
 public sealed class GetTenantSessionsValidator : AbstractValidator<GetTenantSessionsQuery>
 {
-    public GetTenantSessionsValidator()
+    public GetTenantSessionsValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.PageNumber)
-            .GreaterThanOrEqualTo(1).WithMessage("Page number must be greater than or equal to 1.");
+            .GreaterThanOrEqualTo(1).WithMessage(_ => localizer["Validation.PageNumberMinimum"]);
 
         RuleFor(x => x.PageSize)
-            .GreaterThanOrEqualTo(1).WithMessage("Page size must be greater than or equal to 1.");
+            .GreaterThanOrEqualTo(1).WithMessage(_ => localizer["Validation.PageSizeMinimum"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeSession/RevokeSessionCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Sessions/RevokeSession/RevokeSessionCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Sessions.RevokeSession;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Sessions.RevokeSession;
 
 public sealed class RevokeSessionCommandValidator : AbstractValidator<RevokeSessionCommand>
 {
-    public RevokeSessionCommandValidator()
+    public RevokeSessionCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.SessionId)
-            .NotEmpty().WithMessage("Session ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.SessionIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/RefreshToken/RefreshTokenCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.v1.Tokens.RefreshToken;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.Extensions.Logging;
 using System.IdentityModel.Tokens.Jwt;
@@ -51,7 +52,11 @@ public sealed class RefreshTokenCommandHandler
         if (validated is null)
         {
             await _securityAudit.TokenRevokedAsync("unknown", clientId!, "InvalidRefreshToken", cancellationToken);
-            throw new UnauthorizedException("Invalid refresh token.");
+            throw new UnauthorizedException("Invalid refresh token.")
+            {
+                MessageKey = "Identity.InvalidRefreshToken",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var (subject, claims) = validated.Value;
@@ -62,7 +67,11 @@ public sealed class RefreshTokenCommandHandler
         if (!isSessionValid)
         {
             await _securityAudit.TokenRevokedAsync(subject, clientId!, "SessionRevoked", cancellationToken);
-            throw new UnauthorizedException("Session has been revoked.");
+            throw new UnauthorizedException("Session has been revoked.")
+            {
+                MessageKey = "Identity.SessionRevoked",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Optionally, cross-check the provided access token subject
@@ -87,7 +96,11 @@ public sealed class RefreshTokenCommandHandler
                 !string.Equals(accessTokenSubject, subject, StringComparison.Ordinal))
             {
                 await _securityAudit.TokenRevokedAsync(subject, clientId!, "RefreshTokenSubjectMismatch", cancellationToken);
-                throw new UnauthorizedException("Access token subject mismatch.");
+                throw new UnauthorizedException("Access token subject mismatch.")
+                {
+                    MessageKey = "Identity.AccessTokenSubjectMismatch",
+                    ResourceSource = typeof(IdentityResources),
+                };
             }
         }
 

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/TokenGeneration/GenerateTokenCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/TokenGeneration/GenerateTokenCommandHandler.cs
@@ -1,5 +1,6 @@
 using Finbuckle.MultiTenant.Abstractions;
 using FSH.Framework.Core.Context;
+using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Eventing.Outbox;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Auditing.Contracts;
@@ -7,6 +8,7 @@ using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Events;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Tokens.TokenGeneration;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
@@ -70,7 +72,11 @@ public sealed class GenerateTokenCommandHandler
                 ip: ip,
                 ct: cancellationToken);
 
-            throw new UnauthorizedAccessException("Invalid credentials.");
+            throw new LocalizedUnauthorizedAccessException("Invalid credentials.")
+            {
+                MessageKey = "Identity.InvalidCredentials",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Unpack subject + claims

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/TokenGeneration/GenerateTokenEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Tokens/TokenGeneration/GenerateTokenEndpoint.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.Tokens.TokenGeneration;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
 using System.ComponentModel;
 
 namespace FSH.Modules.Identity.Features.v1.Tokens.TokenGeneration;
@@ -35,14 +37,15 @@ public static class GenerateTokenEndpoint
             [DefaultValue("root")][FromHeader] string tenant,
             [FromHeader(Name = AppHeader)] string? app,
             [FromServices] IMediator mediator,
+            [FromServices] IStringLocalizer<SharedResources> localizer,
             CancellationToken ct) =>
             {
                 if (IsRootViaDashboard(tenant, app))
                 {
                     return TypedResults.Problem(
                         statusCode: StatusCodes.Status403Forbidden,
-                        title: "App boundary",
-                        detail: "SuperAdmin accounts must use the admin app. Sign in there instead of the tenant dashboard.");
+                        title: localizer["Error.AppBoundary"],
+                        detail: localizer["Error.AppBoundary.Detail"]);
                 }
 
                 var token = await mediator.Send(command, ct);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/Disable/DisableTwoFactorCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/Disable/DisableTwoFactorCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Context;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.v1.TwoFactor;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.AspNetCore.Identity;
 
@@ -31,13 +32,22 @@ public sealed class DisableTwoFactorCommandHandler
 
         var userId = _currentUser.GetUserId().ToString();
         var user = await _userManager.FindByIdAsync(userId)
-            ?? throw new NotFoundException($"User {userId} not found.");
+            ?? throw new NotFoundException($"User {userId} not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [userId],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         // Require current password so a stolen access token alone can't downgrade
         // account security.
         if (!await _userManager.CheckPasswordAsync(user, command.CurrentPassword))
         {
-            throw new UnauthorizedException("Current password is incorrect.");
+            throw new UnauthorizedException("Current password is incorrect.")
+            {
+                MessageKey = "Identity.CurrentPasswordIncorrect",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await _userManager.SetTwoFactorEnabledAsync(user, false);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/Enroll/EnrollTwoFactorCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/Enroll/EnrollTwoFactorCommandHandler.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.TwoFactor;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.AspNetCore.Identity;
 
@@ -35,13 +36,22 @@ public sealed class EnrollTwoFactorCommandHandler
 
         var userId = _currentUser.GetUserId().ToString();
         var user = await _userManager.FindByIdAsync(userId)
-            ?? throw new NotFoundException($"User {userId} not found.");
+            ?? throw new NotFoundException($"User {userId} not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [userId],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         // Always reset so calling enroll twice rotates the secret — prevents stale codes
         // from a prior incomplete enrollment from silently succeeding.
         await _userManager.ResetAuthenticatorKeyAsync(user);
         var sharedKey = await _userManager.GetAuthenticatorKeyAsync(user)
-            ?? throw new CustomException("Failed to generate authenticator key.");
+            ?? throw new CustomException("Failed to generate authenticator key.")
+            {
+                MessageKey = "Identity.FailedToGenerateAuthenticatorKey",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var email = user.Email ?? user.UserName ?? user.Id;
         var authenticatorUri = string.Format(

--- a/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/VerifyEnroll/VerifyEnrollTwoFactorCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/TwoFactor/VerifyEnroll/VerifyEnrollTwoFactorCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Context;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.v1.TwoFactor;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.AspNetCore.Identity;
 
@@ -31,7 +32,12 @@ public sealed class VerifyEnrollTwoFactorCommandHandler
 
         var userId = _currentUser.GetUserId().ToString();
         var user = await _userManager.FindByIdAsync(userId)
-            ?? throw new NotFoundException($"User {userId} not found.");
+            ?? throw new NotFoundException($"User {userId} not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [userId],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var sanitized = command.Code.Replace(" ", string.Empty, StringComparison.Ordinal);
         var valid = await _userManager.VerifyTwoFactorTokenAsync(
@@ -44,7 +50,11 @@ public sealed class VerifyEnrollTwoFactorCommandHandler
             throw new CustomException(
                 "The authenticator code is invalid.",
                 errors: null,
-                System.Net.HttpStatusCode.BadRequest);
+                System.Net.HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.AuthenticatorCodeInvalid",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await _userManager.SetTwoFactorEnabledAsync(user, true);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AdminConfirmEmail/AdminConfirmEmailCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.AdminConfirmEmail;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.AdminConfirmEmail;
 
 public sealed class AdminConfirmEmailCommandValidator : AbstractValidator<AdminConfirmEmailCommand>
 {
-    public AdminConfirmEmailCommandValidator()
+    public AdminConfirmEmailCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesCommandValidator.cs
@@ -1,16 +1,18 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.AssignUserRoles;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.AssignUserRoles;
 
 public sealed class AssignUserRolesCommandValidator : AbstractValidator<AssignUserRolesCommand>
 {
-    public AssignUserRolesCommandValidator()
+    public AssignUserRolesCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
 
         RuleFor(x => x.UserRoles)
-            .NotNull().WithMessage("User roles list is required.");
+            .NotNull().WithMessage(_ => localizer["Validation.UserRolesRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ChangePassword/ChangePasswordValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ChangePassword/ChangePasswordValidator.cs
@@ -1,7 +1,9 @@
 using FluentValidation;
 using FSH.Framework.Core.Context;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Users.ChangePassword;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.ChangePassword;
 
@@ -12,26 +14,27 @@ public sealed class ChangePasswordValidator : AbstractValidator<ChangePasswordCo
 
     public ChangePasswordValidator(
         IPasswordHistoryService passwordHistoryService,
-        ICurrentUser currentUser)
+        ICurrentUser currentUser,
+        IStringLocalizer<SharedResources> localizer)
     {
         _passwordHistoryService = passwordHistoryService;
         _currentUser = currentUser;
 
         RuleFor(p => p.Password)
             .NotEmpty()
-            .WithMessage("Current password is required.");
+            .WithMessage(_ => localizer["Validation.CurrentPasswordRequired"]);
 
         RuleFor(p => p.NewPassword)
             .NotEmpty()
-            .WithMessage("New password is required.")
+            .WithMessage(_ => localizer["Validation.NewPasswordRequired"])
             .NotEqual(p => p.Password)
-            .WithMessage("New password must be different from the current password.")
+            .WithMessage(_ => localizer["Validation.NewPasswordMustDiffer"])
             .MustAsync(NotBeInPasswordHistoryAsync)
-            .WithMessage("This password has been used recently. Please choose a different password.");
+            .WithMessage(_ => localizer["Validation.PasswordRecentlyUsed"]);
 
         RuleFor(p => p.ConfirmNewPassword)
             .Equal(p => p.NewPassword)
-            .WithMessage("Passwords do not match.");
+            .WithMessage(_ => localizer["Validation.PasswordsDoNotMatch"]);
     }
 
     private async Task<bool> NotBeInPasswordHistoryAsync(string newPassword, CancellationToken cancellationToken)

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ConfirmEmail/ConfirmEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ConfirmEmail/ConfirmEmailCommandValidator.cs
@@ -1,19 +1,21 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.ConfirmEmail;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.ConfirmEmail;
 
 public sealed class ConfirmEmailCommandValidator : AbstractValidator<ConfirmEmailCommand>
 {
-    public ConfirmEmailCommandValidator()
+    public ConfirmEmailCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
 
         RuleFor(x => x.Code)
-            .NotEmpty().WithMessage("Confirmation code is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.ConfirmationCodeRequired"]);
 
         RuleFor(x => x.Tenant)
-            .NotEmpty().WithMessage("Tenant is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.TenantRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/DeleteUser/DeleteUserCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/DeleteUser/DeleteUserCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.DeleteUser;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.DeleteUser;
 
 public sealed class DeleteUserCommandValidator : AbstractValidator<DeleteUserCommand>
 {
-    public DeleteUserCommandValidator()
+    public DeleteUserCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.Id)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserGroups/GetUserGroupsQueryHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserGroups/GetUserGroupsQueryHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.v1.Users.GetUserGroups;
 using FSH.Modules.Identity.Data;
+using FSH.Modules.Identity.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -25,7 +26,12 @@ public sealed class GetUserGroupsQueryHandler : IQueryHandler<GetUserGroupsQuery
 
         if (!userExists)
         {
-            throw new NotFoundException($"User with ID '{query.UserId}' not found.");
+            throw new NotFoundException($"User with ID '{query.UserId}' not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [query.UserId],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Get user's groups

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/RegisterUser/RegisterUserCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/RegisterUser/RegisterUserCommandValidator.cs
@@ -1,39 +1,41 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.RegisterUser;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.RegisterUser;
 
 public sealed class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
 {
-    public RegisterUserCommandValidator()
+    public RegisterUserCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.FirstName)
-            .NotEmpty().WithMessage("First name is required.")
-            .MaximumLength(100).WithMessage("First name must not exceed 100 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.FirstNameRequired"])
+            .MaximumLength(100).WithMessage(_ => localizer["Validation.FirstNameMaxLength"]);
 
         RuleFor(x => x.LastName)
-            .NotEmpty().WithMessage("Last name is required.")
-            .MaximumLength(100).WithMessage("Last name must not exceed 100 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.LastNameRequired"])
+            .MaximumLength(100).WithMessage(_ => localizer["Validation.LastNameMaxLength"]);
 
         RuleFor(x => x.Email)
-            .NotEmpty().WithMessage("Email is required.")
-            .EmailAddress().WithMessage("A valid email address is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.EmailRequired"])
+            .EmailAddress().WithMessage(_ => localizer["Validation.EmailInvalid"]);
 
         RuleFor(x => x.UserName)
-            .NotEmpty().WithMessage("Username is required.")
-            .MinimumLength(3).WithMessage("Username must be at least 3 characters.")
-            .MaximumLength(50).WithMessage("Username must not exceed 50 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UsernameRequired"])
+            .MinimumLength(3).WithMessage(_ => localizer["Validation.UsernameMinLength"])
+            .MaximumLength(50).WithMessage(_ => localizer["Validation.UsernameMaxLength"]);
 
         RuleFor(x => x.Password)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(6).WithMessage("Password must be at least 6 characters.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.PasswordRequired"])
+            .MinimumLength(6).WithMessage(_ => localizer["Validation.PasswordMinLength"]);
 
         RuleFor(x => x.ConfirmPassword)
-            .NotEmpty().WithMessage("Password confirmation is required.")
-            .Equal(x => x.Password).WithMessage("Passwords do not match.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.PasswordConfirmationRequired"])
+            .Equal(x => x.Password).WithMessage(_ => localizer["Validation.PasswordsDoNotMatch"]);
 
         RuleFor(x => x.PhoneNumber)
-            .MaximumLength(20).WithMessage("Phone number must not exceed 20 characters.")
+            .MaximumLength(20).WithMessage(_ => localizer["Validation.PhoneNumberMaxLength"])
             .When(x => x.PhoneNumber is not null);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ResendConfirmationEmail/ResendConfirmationEmailCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.ResendConfirmationEmail;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.ResendConfirmationEmail;
 
 public sealed class ResendConfirmationEmailCommandValidator : AbstractValidator<ResendConfirmationEmailCommand>
 {
-    public ResendConfirmationEmailCommandValidator()
+    public ResendConfirmationEmailCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/SearchUsers/SearchUsersQueryValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/SearchUsers/SearchUsersQueryValidator.cs
@@ -1,14 +1,16 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Web.Validation;
 using FSH.Modules.Identity.Contracts.v1.Users.SearchUsers;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.SearchUsers;
 
 public sealed class SearchUsersQueryValidator : AbstractValidator<SearchUsersQuery>
 {
-    public SearchUsersQueryValidator()
+    public SearchUsersQueryValidator(IStringLocalizer<SharedResources> localizer)
     {
-        Include(new PagedQueryValidator<SearchUsersQuery>());
+        Include(new PagedQueryValidator<SearchUsersQuery>(localizer));
 
         RuleFor(q => q.Search)
             .MaximumLength(200)

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/SetProfileImage/SetProfileImageCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/SetProfileImage/SetProfileImageCommandHandler.cs
@@ -18,7 +18,10 @@ public sealed class SetProfileImageCommandHandler(
         var userId = currentUser.GetUserId();
         if (userId == Guid.Empty)
         {
-            throw new UnauthorizedException("no current user");
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
         }
 
         await profileService

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ToggleUserStatus/ToggleUserStatusCommandValidator.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ToggleUserStatus/ToggleUserStatusCommandValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.ToggleUserStatus;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Identity.Features.v1.Users.ToggleUserStatus;
 
 public sealed class ToggleUserStatusCommandValidator : AbstractValidator<ToggleUserStatusCommand>
 {
-    public ToggleUserStatusCommandValidator()
+    public ToggleUserStatusCommandValidator(IStringLocalizer<SharedResources> localizer)
     {
         RuleFor(x => x.UserId)
-            .NotEmpty().WithMessage("User ID is required.");
+            .NotEmpty().WithMessage(_ => localizer["Validation.UserIdRequired"]);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Services/CurrentUserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/CurrentUserService.cs
@@ -2,6 +2,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Shared.Identity.Claims;
 using FSH.Modules.Identity.Contracts.Services;
+using FSH.Modules.Identity.Localization;
 using System.Security.Claims;
 
 namespace FSH.Modules.Identity.Services;
@@ -42,7 +43,11 @@ internal sealed class CurrentUserService : ICurrentUserService
     {
         if (_user != null)
         {
-            throw new CustomException("Method reserved for in-scope initialization");
+            throw new CustomException("Method reserved for in-scope initialization")
+            {
+                MessageKey = "Identity.InScopeInitializationOnly",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         _user = user;
@@ -52,7 +57,11 @@ internal sealed class CurrentUserService : ICurrentUserService
     {
         if (_userId != Guid.Empty)
         {
-            throw new CustomException("Method reserved for in-scope initialization");
+            throw new CustomException("Method reserved for in-scope initialization")
+            {
+                MessageKey = "Identity.InScopeInitializationOnly",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!string.IsNullOrEmpty(userId))

--- a/src/Modules/Identity/Modules.Identity/Services/ImpersonationGrantService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/ImpersonationGrantService.cs
@@ -4,6 +4,7 @@ using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Contracts.v1.Impersonation;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
 
@@ -82,7 +83,11 @@ internal sealed class ImpersonationGrantService(
         var grant = await db.ImpersonationGrants
             .FirstOrDefaultAsync(g => g.Id == id, ct)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("impersonation grant not found");
+            ?? throw new NotFoundException("impersonation grant not found")
+            {
+                MessageKey = "Identity.ImpersonationGrantNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         if (grant.IsTerminal)
         {

--- a/src/Modules/Identity/Modules.Identity/Services/SessionService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/SessionService.cs
@@ -6,6 +6,7 @@ using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using UAParser;
@@ -40,7 +41,10 @@ public sealed class SessionService : ISessionService
     {
         if (string.IsNullOrWhiteSpace(_multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id))
         {
-            throw new UnauthorizedException("Invalid tenant");
+            throw new UnauthorizedException("Invalid tenant")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         }
     }
 
@@ -88,7 +92,11 @@ public sealed class SessionService : ISessionService
         var currentUserId = _currentUser.GetUserId().ToString();
         if (!string.Equals(userId, currentUserId, StringComparison.OrdinalIgnoreCase))
         {
-            throw new UnauthorizedAccessException("Cannot view sessions for another user");
+            throw new LocalizedUnauthorizedAccessException("Cannot view sessions for another user")
+            {
+                MessageKey = "Identity.CannotViewOthersSessions",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
@@ -196,7 +204,11 @@ public sealed class SessionService : ISessionService
         var currentUserId = _currentUser.GetUserId().ToString();
         if (!string.Equals(session.UserId, currentUserId, StringComparison.OrdinalIgnoreCase))
         {
-            throw new UnauthorizedAccessException("Cannot revoke session for another user");
+            throw new LocalizedUnauthorizedAccessException("Cannot revoke session for another user")
+            {
+                MessageKey = "Identity.CannotRevokeOthersSession",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var tenantId = _multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id;
@@ -224,7 +236,11 @@ public sealed class SessionService : ISessionService
         var currentUserId = _currentUser.GetUserId().ToString();
         if (!string.Equals(userId, currentUserId, StringComparison.OrdinalIgnoreCase))
         {
-            throw new UnauthorizedAccessException("Cannot revoke sessions for another user");
+            throw new LocalizedUnauthorizedAccessException("Cannot revoke sessions for another user")
+            {
+                MessageKey = "Identity.CannotRevokeOthersSessions",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         var query = _db.UserSessions

--- a/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserPasswordService.cs
@@ -7,6 +7,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.WebUtilities;
 using System.Collections.ObjectModel;
@@ -66,7 +67,11 @@ internal sealed class UserPasswordService(
         var user = await userManager.FindByEmailAsync(email);
         if (user == null)
         {
-            throw new NotFoundException("user not found");
+            throw new NotFoundException("user not found")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         token = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(token));
@@ -75,7 +80,11 @@ internal sealed class UserPasswordService(
         if (!result.Succeeded)
         {
             var errors = result.Errors.Select(e => e.Description).ToList();
-            throw new CustomException("error resetting password", errors);
+            throw new CustomException("error resetting password", errors)
+            {
+                MessageKey = "Identity.ErrorResettingPassword",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Raise domain event for password reset
@@ -88,14 +97,22 @@ internal sealed class UserPasswordService(
     {
         var user = await userManager.FindByIdAsync(userId);
 
-        _ = user ?? throw new NotFoundException("user not found");
+        _ = user ?? throw new NotFoundException("user not found")
+        {
+            MessageKey = "Identity.UserNotFound",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         var result = await userManager.ChangePasswordAsync(user, password, newPassword);
 
         if (!result.Succeeded)
         {
             var errors = result.Errors.Select(e => e.Description).ToList();
-            throw new CustomException("failed to change password", errors);
+            throw new CustomException("failed to change password", errors)
+            {
+                MessageKey = "Identity.FailedToChangePassword",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // Raise domain event for password change
@@ -114,7 +131,10 @@ internal sealed class UserPasswordService(
     {
         if (string.IsNullOrWhiteSpace(multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id))
         {
-            throw new UnauthorizedException("invalid tenant");
+            throw new UnauthorizedException("invalid tenant")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         }
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Services/UserRegistrationService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserRegistrationService.cs
@@ -11,6 +11,7 @@ using FSH.Modules.Identity.Contracts.Events;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
@@ -79,14 +80,23 @@ internal sealed class UserRegistrationService(
             .Where(u => u.Id == userId && !u.EmailConfirmed)
             .FirstOrDefaultAsync(cancellationToken);
 
-        _ = user ?? throw new CustomException("An error occurred while confirming E-Mail.");
+        _ = user ?? throw new CustomException("An error occurred while confirming E-Mail.")
+        {
+            MessageKey = "Identity.EmailConfirmationError",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
         var result = await userManager.ConfirmEmailAsync(user, code);
 
         return result.Succeeded
             ? string.Format(CultureInfo.InvariantCulture, "Account Confirmed for E-Mail {0}. You can now use the /api/tokens endpoint to generate JWT.", user.Email)
-            : throw new CustomException(string.Format(CultureInfo.InvariantCulture, "An error occurred while confirming {0}", user.Email));
+            : throw new CustomException(string.Format(CultureInfo.InvariantCulture, "An error occurred while confirming {0}", user.Email))
+            {
+                MessageKey = "Identity.EmailConfirmationFailedFor",
+                MessageArgs = [user.Email!],
+                ResourceSource = typeof(IdentityResources),
+            };
     }
 
     public async Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default)
@@ -96,7 +106,12 @@ internal sealed class UserRegistrationService(
         var user = await userManager.Users
             .Where(u => u.Id == userId)
             .FirstOrDefaultAsync(cancellationToken)
-            ?? throw new NotFoundException($"User {userId} was not found.");
+            ?? throw new NotFoundException($"User {userId} was not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [userId],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         // Idempotent: a second confirm is a no-op rather than an error.
         if (user.EmailConfirmed)
@@ -112,7 +127,12 @@ internal sealed class UserRegistrationService(
                 CultureInfo.InvariantCulture,
                 "An error occurred while confirming the email for {0}: {1}",
                 user.Email,
-                string.Join("; ", result.Errors.Select(e => e.Description))));
+                string.Join("; ", result.Errors.Select(e => e.Description))))
+            {
+                MessageKey = "Identity.EmailConfirmationFailedWithErrors",
+                MessageArgs = [user.Email!, string.Join("; ", result.Errors.Select(e => e.Description))],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -123,14 +143,24 @@ internal sealed class UserRegistrationService(
         var user = await userManager.Users
             .Where(u => u.Id == userId)
             .FirstOrDefaultAsync(cancellationToken)
-            ?? throw new NotFoundException($"User {userId} was not found.");
+            ?? throw new NotFoundException($"User {userId} was not found.")
+            {
+                MessageKey = "Identity.UserNotFoundById",
+                MessageArgs = [userId],
+                ResourceSource = typeof(IdentityResources),
+            };
 
         if (user.EmailConfirmed)
         {
             throw new CustomException(string.Format(
                 CultureInfo.InvariantCulture,
                 "The email for {0} is already confirmed.",
-                user.Email));
+                user.Email))
+            {
+                MessageKey = "Identity.EmailAlreadyConfirmed",
+                MessageArgs = [user.Email!],
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await SendConfirmationEmailAsync(user, origin, cancellationToken);
@@ -144,21 +174,33 @@ internal sealed class UserRegistrationService(
             .Where(u => u.Id == userId && !u.PhoneNumberConfirmed)
             .FirstOrDefaultAsync(cancellationToken);
 
-        _ = user ?? throw new CustomException("An error occurred while confirming phone number.");
+        _ = user ?? throw new CustomException("An error occurred while confirming phone number.")
+        {
+            MessageKey = "Identity.PhoneConfirmationError",
+            ResourceSource = typeof(IdentityResources),
+        };
 
         code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
         var result = await userManager.ChangePhoneNumberAsync(user, user.PhoneNumber!, code);
 
         return result.Succeeded
             ? string.Format(CultureInfo.InvariantCulture, "Phone number {0} confirmed successfully.", user.PhoneNumber)
-            : throw new CustomException(string.Format(CultureInfo.InvariantCulture, "An error occurred while confirming phone number {0}", user.PhoneNumber));
+            : throw new CustomException(string.Format(CultureInfo.InvariantCulture, "An error occurred while confirming phone number {0}", user.PhoneNumber))
+            {
+                MessageKey = "Identity.PhoneConfirmationFailedFor",
+                MessageArgs = [user.PhoneNumber!],
+                ResourceSource = typeof(IdentityResources),
+            };
     }
 
     private void EnsureValidTenant()
     {
         if (string.IsNullOrWhiteSpace(multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id))
         {
-            throw new UnauthorizedException("invalid tenant");
+            throw new UnauthorizedException("invalid tenant")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         }
     }
 
@@ -166,7 +208,11 @@ internal sealed class UserRegistrationService(
     {
         return principal.FindFirstValue(ClaimTypes.Email)
             ?? principal.FindFirstValue("email")
-            ?? throw new CustomException("Email claim is required for external authentication.");
+            ?? throw new CustomException("Email claim is required for external authentication.")
+            {
+                MessageKey = "Identity.EmailClaimRequired",
+                ResourceSource = typeof(IdentityResources),
+            };
     }
 
     private async Task<FshUser> CreateUserFromPrincipalAsync(ClaimsPrincipal principal, string email)
@@ -193,7 +239,11 @@ internal sealed class UserRegistrationService(
             throw new CustomException(
                 "Failed to create user from external principal.",
                 errors,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.FailedToCreateUserFromPrincipal",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         return user;
@@ -233,7 +283,11 @@ internal sealed class UserRegistrationService(
             throw new CustomException(
                 "Passwords do not match.",
                 errors: null,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.PasswordsDoNotMatch",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -267,7 +321,11 @@ internal sealed class UserRegistrationService(
             throw new CustomException(
                 "Unable to register the user.",
                 errors,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.UnableToRegisterUser",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         return user;

--- a/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserRoleService.cs
@@ -8,6 +8,7 @@ using FSH.Modules.Identity.Contracts.DTOs;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Data;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,7 +27,11 @@ internal sealed class UserRoleService(
         var user = await userManager.Users
             .Where(u => u.Id == userId)
             .FirstOrDefaultAsync(cancellationToken)
-            ?? throw new NotFoundException("user not found");
+            ?? throw new NotFoundException("user not found")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         await ValidateAdminRoleChangeAsync(user, userRoles);
 
@@ -44,10 +49,18 @@ internal sealed class UserRoleService(
     public async Task<List<UserRoleDto>> GetUserRolesAsync(string userId, CancellationToken cancellationToken)
     {
         var user = await userManager.FindByIdAsync(userId)
-            ?? throw new NotFoundException("user not found");
+            ?? throw new NotFoundException("user not found")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         var roles = await roleManager.Roles.AsNoTracking().ToListAsync(cancellationToken)
-            ?? throw new NotFoundException("roles not found");
+            ?? throw new NotFoundException("roles not found")
+            {
+                MessageKey = "Identity.RolesNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         // Single membership query instead of one IsInRoleAsync round-trip per role.
         var memberships = await userManager.GetRolesAsync(user);
@@ -90,13 +103,21 @@ internal sealed class UserRoleService(
             throw new CustomException(
                 "Administrators cannot remove their own admin role.",
                 Array.Empty<string>(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.AdminCannotRemoveOwnRole",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // The root tenant's seed admin is the framework's last-resort recovery account.
         if (IsRootTenantAdmin(user))
         {
-            throw new ForbiddenException("The root tenant administrator cannot be demoted.");
+            throw new ForbiddenException("The root tenant administrator cannot be demoted.")
+            {
+                MessageKey = "Identity.RootAdminCannotBeDemoted",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         // After this removal, at least one admin must remain in the tenant — matches
@@ -118,7 +139,11 @@ internal sealed class UserRoleService(
             throw new CustomException(
                 "Tenant must retain at least one administrator.",
                 Array.Empty<string>(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.TenantMustRetainOneAdmin",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 

--- a/src/Modules/Identity/Modules.Identity/Services/UserStatusService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserStatusService.cs
@@ -7,6 +7,7 @@ using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Auditing.Contracts;
 using FSH.Modules.Identity.Contracts.Services;
 using FSH.Modules.Identity.Domain;
+using FSH.Modules.Identity.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -40,7 +41,10 @@ internal sealed class UserStatusService(
     {
         if (string.IsNullOrWhiteSpace(multiTenantContextAccessor?.MultiTenantContext?.TenantInfo?.Id))
         {
-            throw new UnauthorizedException("invalid tenant");
+            throw new UnauthorizedException("invalid tenant")
+            {
+                MessageKey = "Error.InvalidTenant",
+            };
         }
     }
 
@@ -52,16 +56,26 @@ internal sealed class UserStatusService(
         var actorId = currentUser.GetUserId();
         if (actorId == Guid.Empty)
         {
-            throw new UnauthorizedException("authenticated user required to toggle status");
+            throw new UnauthorizedException("authenticated user required to toggle status")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
         }
 
         var actor = await userManager.FindByIdAsync(actorId.ToString())
-            ?? throw new UnauthorizedException("current user not found");
+            ?? throw new UnauthorizedException("current user not found")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
 
         var targetUser = await userManager.Users
             .Where(u => u.Id == userId)
             .FirstOrDefaultAsync(cancellationToken)
-            ?? throw new NotFoundException("User Not Found.");
+            ?? throw new NotFoundException("User Not Found.")
+            {
+                MessageKey = "Identity.UserNotFound",
+                ResourceSource = typeof(IdentityResources),
+            };
 
         return new ToggleStatusContext(
             ActorId: actorId,
@@ -78,19 +92,31 @@ internal sealed class UserStatusService(
         if (!await userManager.IsInRoleAsync(context.Actor, RoleConstants.Admin))
         {
             await AuditPolicyFailureAsync(context, "ActorNotAdmin", cancellationToken);
-            throw new ForbiddenException("Only administrators can change user status.");
+            throw new ForbiddenException("Only administrators can change user status.")
+            {
+                MessageKey = "Identity.OnlyAdminsCanChangeStatus",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!context.ActivateUser && context.ActorId.ToString() == context.TargetUser.Id)
         {
             await AuditPolicyFailureAsync(context, "SelfDeactivationBlocked", cancellationToken);
-            throw new CustomException("Users cannot deactivate themselves.", Array.Empty<string>(), HttpStatusCode.BadRequest);
+            throw new CustomException("Users cannot deactivate themselves.", Array.Empty<string>(), HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.CannotDeactivateSelf",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!context.ActivateUser && await userManager.IsInRoleAsync(context.TargetUser, RoleConstants.Admin))
         {
             await AuditPolicyFailureAsync(context, "AdminDeactivationBlocked", cancellationToken);
-            throw new CustomException("Administrators cannot be deactivated.", Array.Empty<string>(), HttpStatusCode.BadRequest);
+            throw new CustomException("Administrators cannot be deactivated.", Array.Empty<string>(), HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.AdminsCannotBeDeactivated",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         if (!context.ActivateUser)
@@ -107,7 +133,11 @@ internal sealed class UserStatusService(
         if (!activeAdmins.Any(u => u.IsActive))
         {
             await AuditPolicyFailureAsync(context, "NoActiveAdmins", cancellationToken);
-            throw new CustomException("Tenant must have at least one active administrator.", Array.Empty<string>(), HttpStatusCode.BadRequest);
+            throw new CustomException("Tenant must have at least one active administrator.", Array.Empty<string>(), HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.TenantMustHaveActiveAdmin",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
     }
 
@@ -130,7 +160,11 @@ internal sealed class UserStatusService(
         var result = await userManager.UpdateAsync(context.TargetUser);
         if (!result.Succeeded)
         {
-            throw new CustomException("Toggle status failed", result.Errors.Select(e => e.Description).ToList(), HttpStatusCode.BadRequest);
+            throw new CustomException("Toggle status failed", result.Errors.Select(e => e.Description).ToList(), HttpStatusCode.BadRequest)
+            {
+                MessageKey = "Identity.ToggleStatusFailed",
+                ResourceSource = typeof(IdentityResources),
+            };
         }
 
         await auditClient.WriteActivityAsync(

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/AdjustTenantValidity/AdjustTenantValidityCommandValidator.cs
@@ -1,12 +1,14 @@
 using FluentValidation;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Multitenancy.Contracts.v1.AdjustTenantValidity;
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Multitenancy.Features.v1.AdjustTenantValidity;
 
 public sealed class AdjustTenantValidityCommandValidator : AbstractValidator<AdjustTenantValidityCommand>
 {
-    public AdjustTenantValidityCommandValidator()
+    public AdjustTenantValidityCommandValidator(IStringLocalizer<MultitenancyResources> localizer)
     {
         RuleFor(t => t.TenantId).NotEmpty();
 
@@ -14,10 +16,10 @@ public sealed class AdjustTenantValidityCommandValidator : AbstractValidator<Adj
         // Activate/Deactivate guards that already refuse the root tenant).
         RuleFor(t => t.TenantId)
             .Must(id => !string.Equals(id, MultitenancyConstants.Root.Id, StringComparison.Ordinal))
-            .WithMessage("The root operator tenant's validity cannot be adjusted.");
+            .WithMessage(_ => localizer["Validation.RootTenantValidityImmutable"]);
 
         RuleFor(t => t.ValidUpto)
             .Must(d => d != default)
-            .WithMessage("A valid 'validUpto' date is required.");
+            .WithMessage(_ => localizer["Validation.ValidUptoRequired"]);
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/CreateTenant/CreateTenantCommandValidator.cs
@@ -2,26 +2,28 @@
 using FSH.Framework.Persistence;
 using FSH.Modules.Multitenancy.Contracts;
 using FSH.Modules.Multitenancy.Contracts.v1.CreateTenant;
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Multitenancy.Features.v1.CreateTenant;
 
 public sealed class CreateTenantCommandValidator : AbstractValidator<CreateTenantCommand>
 {
-    public CreateTenantCommandValidator(ITenantService tenantService, IConnectionStringValidator connectionStringValidator)
+    public CreateTenantCommandValidator(ITenantService tenantService, IConnectionStringValidator connectionStringValidator, IStringLocalizer<MultitenancyResources> localizer)
     {
         RuleFor(t => t.Id).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .MustAsync(async (id, ct) => !await tenantService.ExistsWithIdAsync(id, ct).ConfigureAwait(false))
-            .WithMessage((_, id) => $"Tenant {id} already exists.");
+            .WithMessage((_, id) => localizer["Validation.TenantAlreadyExists", id]);
 
         RuleFor(t => t.Name).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .MustAsync(async (name, ct) => !await tenantService.ExistsWithNameAsync(name!, ct).ConfigureAwait(false))
-            .WithMessage((_, name) => $"Tenant {name} already exists.");
+            .WithMessage((_, name) => localizer["Validation.TenantAlreadyExists", name!]);
 
         RuleFor(t => t.ConnectionString).Cascade(CascadeMode.Stop)
             .Must((_, cs) => string.IsNullOrWhiteSpace(cs) || connectionStringValidator.TryValidate(cs))
-            .WithMessage("Connection string invalid.");
+            .WithMessage(_ => localizer["Validation.ConnectionStringInvalid"]);
 
         RuleFor(t => t.AdminEmail).Cascade(CascadeMode.Stop)
             .NotEmpty()
@@ -32,13 +34,13 @@ public sealed class CreateTenantCommandValidator : AbstractValidator<CreateTenan
         RuleFor(t => t.AdminPassword).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .MinimumLength(8)
-            .WithMessage("Admin password must be at least 8 characters.");
+            .WithMessage(_ => localizer["Validation.AdminPasswordMinLength"]);
 
         // Optional — null/empty falls back to the configured default plan. When supplied it must be a
         // lowercase plan slug; existence is validated by GetPlanTerm in the handler.
         RuleFor(t => t.PlanKey)
             .Matches("^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$")
             .When(t => !string.IsNullOrWhiteSpace(t.PlanKey))
-            .WithMessage("Plan key must be a lowercase slug (a-z, 0-9, hyphen).");
+            .WithMessage(_ => localizer["Validation.PlanKeySlug"]);
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/GetTenants/GetTenantsQueryValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/GetTenants/GetTenantsQueryValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
+using FSH.Framework.Core.Localization;
 using FSH.Framework.Web.Validation;
 using FSH.Modules.Multitenancy.Contracts.v1.GetTenants;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Multitenancy.Features.v1.GetTenants;
 
 public sealed class GetTenantsQueryValidator : AbstractValidator<GetTenantsQuery>
 {
-    public GetTenantsQueryValidator()
+    public GetTenantsQueryValidator(IStringLocalizer<SharedResources> localizer)
     {
-        Include(new PagedQueryValidator<GetTenantsQuery>());
+        Include(new PagedQueryValidator<GetTenantsQuery>(localizer));
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/RenewTenant/RenewTenantCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/RenewTenant/RenewTenantCommandValidator.cs
@@ -1,17 +1,19 @@
 using FluentValidation;
 using FSH.Modules.Multitenancy.Contracts.v1.RenewTenant;
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Multitenancy.Features.v1.RenewTenant;
 
 public sealed class RenewTenantCommandValidator : AbstractValidator<RenewTenantCommand>
 {
-    public RenewTenantCommandValidator()
+    public RenewTenantCommandValidator(IStringLocalizer<MultitenancyResources> localizer)
     {
         RuleFor(t => t.TenantId).NotEmpty();
 
         RuleFor(t => t.PlanKey)
             .Matches("^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$")
             .When(t => !string.IsNullOrWhiteSpace(t.PlanKey))
-            .WithMessage("Plan key must be a lowercase slug (a-z, 0-9, hyphen).");
+            .WithMessage(_ => localizer["Validation.PlanKeySlug"]);
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/UpdateTenantTheme/UpdateTenantThemeCommandValidator.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Features/v1/UpdateTenantTheme/UpdateTenantThemeCommandValidator.cs
@@ -1,33 +1,35 @@
 using FluentValidation;
 using FSH.Modules.Multitenancy.Contracts.Dtos;
 using FSH.Modules.Multitenancy.Contracts.v1.UpdateTenantTheme;
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.Localization;
 using System.Text.RegularExpressions;
 
 namespace FSH.Modules.Multitenancy.Features.v1.UpdateTenantTheme;
 
 public partial class UpdateTenantThemeCommandValidator : AbstractValidator<UpdateTenantThemeCommand>
 {
-    public UpdateTenantThemeCommandValidator()
+    public UpdateTenantThemeCommandValidator(IStringLocalizer<MultitenancyResources> localizer)
     {
         RuleFor(x => x.Theme)
             .NotNull()
-            .WithMessage("Theme is required.");
+            .WithMessage(_ => localizer["Validation.ThemeRequired"]);
 
         RuleFor(x => x.Theme.LightPalette)
             .NotNull()
-            .SetValidator(new PaletteValidator());
+            .SetValidator(new PaletteValidator(localizer));
 
         RuleFor(x => x.Theme.DarkPalette)
             .NotNull()
-            .SetValidator(new PaletteValidator());
+            .SetValidator(new PaletteValidator(localizer));
 
         RuleFor(x => x.Theme.Typography)
             .NotNull()
-            .SetValidator(new TypographyValidator());
+            .SetValidator(new TypographyValidator(localizer));
 
         RuleFor(x => x.Theme.Layout)
             .NotNull()
-            .SetValidator(new LayoutValidator());
+            .SetValidator(new LayoutValidator(localizer));
     }
 
     [GeneratedRegex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$")]
@@ -35,17 +37,17 @@ public partial class UpdateTenantThemeCommandValidator : AbstractValidator<Updat
 
     private sealed class PaletteValidator : AbstractValidator<PaletteDto>
     {
-        public PaletteValidator()
+        public PaletteValidator(IStringLocalizer<MultitenancyResources> localizer)
         {
-            RuleFor(x => x.Primary).Must(BeValidHexColor).WithMessage("Primary must be a valid hex color.");
-            RuleFor(x => x.Secondary).Must(BeValidHexColor).WithMessage("Secondary must be a valid hex color.");
-            RuleFor(x => x.Tertiary).Must(BeValidHexColor).WithMessage("Tertiary must be a valid hex color.");
-            RuleFor(x => x.Background).Must(BeValidHexColor).WithMessage("Background must be a valid hex color.");
-            RuleFor(x => x.Surface).Must(BeValidHexColor).WithMessage("Surface must be a valid hex color.");
-            RuleFor(x => x.Error).Must(BeValidHexColor).WithMessage("Error must be a valid hex color.");
-            RuleFor(x => x.Warning).Must(BeValidHexColor).WithMessage("Warning must be a valid hex color.");
-            RuleFor(x => x.Success).Must(BeValidHexColor).WithMessage("Success must be a valid hex color.");
-            RuleFor(x => x.Info).Must(BeValidHexColor).WithMessage("Info must be a valid hex color.");
+            RuleFor(x => x.Primary).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Primary"]);
+            RuleFor(x => x.Secondary).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Secondary"]);
+            RuleFor(x => x.Tertiary).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Tertiary"]);
+            RuleFor(x => x.Background).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Background"]);
+            RuleFor(x => x.Surface).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Surface"]);
+            RuleFor(x => x.Error).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Error"]);
+            RuleFor(x => x.Warning).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Warning"]);
+            RuleFor(x => x.Success).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Success"]);
+            RuleFor(x => x.Info).Must(BeValidHexColor).WithMessage(_ => localizer["Validation.ColorMustBeHex", "Info"]);
         }
 
         private static bool BeValidHexColor(string color) =>
@@ -54,27 +56,27 @@ public partial class UpdateTenantThemeCommandValidator : AbstractValidator<Updat
 
     private sealed class TypographyValidator : AbstractValidator<TypographyDto>
     {
-        public TypographyValidator()
+        public TypographyValidator(IStringLocalizer<MultitenancyResources> localizer)
         {
             RuleFor(x => x.FontFamily)
                 .NotEmpty()
                 .MaximumLength(200)
                 .Must(BeValidFontFamily)
-                .WithMessage("FontFamily must be a valid web-safe font.");
+                .WithMessage(_ => localizer["Validation.FontFamilyWebSafe", "FontFamily"]);
 
             RuleFor(x => x.HeadingFontFamily)
                 .NotEmpty()
                 .MaximumLength(200)
                 .Must(BeValidFontFamily)
-                .WithMessage("HeadingFontFamily must be a valid web-safe font.");
+                .WithMessage(_ => localizer["Validation.FontFamilyWebSafe", "HeadingFontFamily"]);
 
             RuleFor(x => x.FontSizeBase)
                 .InclusiveBetween(10, 24)
-                .WithMessage("FontSizeBase must be between 10 and 24.");
+                .WithMessage(_ => localizer["Validation.FontSizeBaseRange"]);
 
             RuleFor(x => x.LineHeightBase)
                 .InclusiveBetween(1.0, 2.5)
-                .WithMessage("LineHeightBase must be between 1.0 and 2.5.");
+                .WithMessage(_ => localizer["Validation.LineHeightBaseRange"]);
         }
 
         private static bool BeValidFontFamily(string fontFamily) =>
@@ -83,17 +85,17 @@ public partial class UpdateTenantThemeCommandValidator : AbstractValidator<Updat
 
     private sealed class LayoutValidator : AbstractValidator<LayoutDto>
     {
-        public LayoutValidator()
+        public LayoutValidator(IStringLocalizer<MultitenancyResources> localizer)
         {
             RuleFor(x => x.BorderRadius)
                 .NotEmpty()
                 .MaximumLength(20)
                 .Matches(@"^\d+(px|rem|em|%)$")
-                .WithMessage("BorderRadius must be a valid CSS value (e.g., '4px', '0.5rem').");
+                .WithMessage(_ => localizer["Validation.BorderRadiusInvalid"]);
 
             RuleFor(x => x.DefaultElevation)
                 .InclusiveBetween(0, 24)
-                .WithMessage("DefaultElevation must be between 0 and 24.");
+                .WithMessage(_ => localizer["Validation.DefaultElevationRange"]);
         }
     }
 }

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Multitenancy.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;MultitenancyResources&gt;</c> to the Multitenancy resx catalog.</summary>
+public sealed class MultitenancyResources;

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.pt-BR.resx
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.pt-BR.resx
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Multitenancy.TenantDeactivated" xml:space="preserve">
+    <value>Este tenant foi desativado. Entre em contato com seu administrador.</value>
+  </data>
+  <data name="Multitenancy.TenantSubscriptionExpired" xml:space="preserve">
+    <value>A assinatura deste tenant expirou. Renove para continuar.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFoundDuringProvisioning" xml:space="preserve">
+    <value>Tenant {0} não encontrado durante o provisionamento.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFoundForProvisioning" xml:space="preserve">
+    <value>Tenant {0} não encontrado para provisionamento.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningAlreadyRunning" xml:space="preserve">
+    <value>O provisionamento já está em execução para o tenant {0}.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningNotFound" xml:space="preserve">
+    <value>Provisionamento não encontrado para o tenant {0}.</value>
+  </data>
+  <data name="Multitenancy.TenantNotProvisioned" xml:space="preserve">
+    <value>O tenant {0} não está provisionado. Status: {1}.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningCorrelationNotFound" xml:space="preserve">
+    <value>Provisionamento {0} para o tenant {1} não encontrado.</value>
+  </data>
+  <data name="Multitenancy.TenantAlreadyActivated" xml:space="preserve">
+    <value>o tenant {0} já está ativado</value>
+  </data>
+  <data name="Multitenancy.TenantAlreadyDeactivated" xml:space="preserve">
+    <value>o tenant {0} já está desativado</value>
+  </data>
+  <data name="Multitenancy.AtLeastOneActiveTenantRequired" xml:space="preserve">
+    <value>É necessário pelo menos um tenant ativo.</value>
+  </data>
+  <data name="Multitenancy.RootTenantCannotBeDeactivated" xml:space="preserve">
+    <value>O tenant raiz não pode ser desativado.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFound" xml:space="preserve">
+    <value>AppTenantInfo {0} não encontrado.</value>
+  </data>
+  <data name="Multitenancy.OnlyRootCanSetDefaultTheme" xml:space="preserve">
+    <value>Apenas o tenant raiz pode definir o tema padrão.</value>
+  </data>
+  <data name="Multitenancy.TenantThemeNotFound" xml:space="preserve">
+    <value>Tema do tenant {0} não encontrado.</value>
+  </data>
+  <data name="Validation.RootTenantValidityImmutable" xml:space="preserve">
+    <value>A validade do tenant operador raiz não pode ser ajustada.</value>
+  </data>
+  <data name="Validation.ValidUptoRequired" xml:space="preserve">
+    <value>Uma data 'validUpto' válida é obrigatória.</value>
+  </data>
+  <data name="Validation.TenantAlreadyExists" xml:space="preserve">
+    <value>O tenant {0} já existe.</value>
+  </data>
+  <data name="Validation.ConnectionStringInvalid" xml:space="preserve">
+    <value>String de conexão inválida.</value>
+  </data>
+  <data name="Validation.AdminPasswordMinLength" xml:space="preserve">
+    <value>A senha do administrador deve ter pelo menos 8 caracteres.</value>
+  </data>
+  <data name="Validation.PlanKeySlug" xml:space="preserve">
+    <value>A chave do plano deve ser um slug minúsculo (a-z, 0-9, hífen).</value>
+  </data>
+  <data name="Validation.ThemeRequired" xml:space="preserve">
+    <value>O tema é obrigatório.</value>
+  </data>
+  <data name="Validation.ColorMustBeHex" xml:space="preserve">
+    <value>{0} deve ser uma cor hexadecimal válida.</value>
+  </data>
+  <data name="Validation.FontFamilyWebSafe" xml:space="preserve">
+    <value>{0} deve ser uma fonte web-safe válida.</value>
+  </data>
+  <data name="Validation.FontSizeBaseRange" xml:space="preserve">
+    <value>FontSizeBase deve estar entre 10 e 24.</value>
+  </data>
+  <data name="Validation.LineHeightBaseRange" xml:space="preserve">
+    <value>LineHeightBase deve estar entre 1.0 e 2.5.</value>
+  </data>
+  <data name="Validation.BorderRadiusInvalid" xml:space="preserve">
+    <value>BorderRadius deve ser um valor CSS válido (ex.: '4px', '0.5rem').</value>
+  </data>
+  <data name="Validation.DefaultElevationRange" xml:space="preserve">
+    <value>DefaultElevation deve estar entre 0 e 24.</value>
+  </data>
+</root>

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.resx
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Localization/MultitenancyResources.resx
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Multitenancy.TenantDeactivated" xml:space="preserve">
+    <value>This tenant has been deactivated. Contact your administrator.</value>
+  </data>
+  <data name="Multitenancy.TenantSubscriptionExpired" xml:space="preserve">
+    <value>This tenant's subscription has expired. Please renew to continue.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFoundDuringProvisioning" xml:space="preserve">
+    <value>Tenant {0} not found during provisioning.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFoundForProvisioning" xml:space="preserve">
+    <value>Tenant {0} not found for provisioning.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningAlreadyRunning" xml:space="preserve">
+    <value>Provisioning already running for tenant {0}.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningNotFound" xml:space="preserve">
+    <value>Provisioning not found for tenant {0}.</value>
+  </data>
+  <data name="Multitenancy.TenantNotProvisioned" xml:space="preserve">
+    <value>Tenant {0} is not provisioned. Status: {1}.</value>
+  </data>
+  <data name="Multitenancy.ProvisioningCorrelationNotFound" xml:space="preserve">
+    <value>Provisioning {0} for tenant {1} not found.</value>
+  </data>
+  <data name="Multitenancy.TenantAlreadyActivated" xml:space="preserve">
+    <value>tenant {0} is already activated</value>
+  </data>
+  <data name="Multitenancy.TenantAlreadyDeactivated" xml:space="preserve">
+    <value>tenant {0} is already deactivated</value>
+  </data>
+  <data name="Multitenancy.AtLeastOneActiveTenantRequired" xml:space="preserve">
+    <value>At least one active tenant is required.</value>
+  </data>
+  <data name="Multitenancy.RootTenantCannotBeDeactivated" xml:space="preserve">
+    <value>The root tenant cannot be deactivated.</value>
+  </data>
+  <data name="Multitenancy.TenantNotFound" xml:space="preserve">
+    <value>AppTenantInfo {0} Not Found.</value>
+  </data>
+  <data name="Multitenancy.OnlyRootCanSetDefaultTheme" xml:space="preserve">
+    <value>Only the root tenant can set the default theme</value>
+  </data>
+  <data name="Multitenancy.TenantThemeNotFound" xml:space="preserve">
+    <value>Theme for tenant {0} not found</value>
+  </data>
+  <data name="Validation.RootTenantValidityImmutable" xml:space="preserve">
+    <value>The root operator tenant's validity cannot be adjusted.</value>
+  </data>
+  <data name="Validation.ValidUptoRequired" xml:space="preserve">
+    <value>A valid 'validUpto' date is required.</value>
+  </data>
+  <data name="Validation.TenantAlreadyExists" xml:space="preserve">
+    <value>Tenant {0} already exists.</value>
+  </data>
+  <data name="Validation.ConnectionStringInvalid" xml:space="preserve">
+    <value>Connection string invalid.</value>
+  </data>
+  <data name="Validation.AdminPasswordMinLength" xml:space="preserve">
+    <value>Admin password must be at least 8 characters.</value>
+  </data>
+  <data name="Validation.PlanKeySlug" xml:space="preserve">
+    <value>Plan key must be a lowercase slug (a-z, 0-9, hyphen).</value>
+  </data>
+  <data name="Validation.ThemeRequired" xml:space="preserve">
+    <value>Theme is required.</value>
+  </data>
+  <data name="Validation.ColorMustBeHex" xml:space="preserve">
+    <value>{0} must be a valid hex color.</value>
+  </data>
+  <data name="Validation.FontFamilyWebSafe" xml:space="preserve">
+    <value>{0} must be a valid web-safe font.</value>
+  </data>
+  <data name="Validation.FontSizeBaseRange" xml:space="preserve">
+    <value>FontSizeBase must be between 10 and 24.</value>
+  </data>
+  <data name="Validation.LineHeightBaseRange" xml:space="preserve">
+    <value>LineHeightBase must be between 1.0 and 2.5.</value>
+  </data>
+  <data name="Validation.BorderRadiusInvalid" xml:space="preserve">
+    <value>BorderRadius must be a valid CSS value (e.g., '4px', '0.5rem').</value>
+  </data>
+  <data name="Validation.DefaultElevationRange" xml:space="preserve">
+    <value>DefaultElevation must be between 0 and 24.</value>
+  </data>
+</root>

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Modules.Multitenancy.csproj
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Modules.Multitenancy.csproj
@@ -2,7 +2,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Multitenancy</RootNamespace>
 		<AssemblyName>FSH.Modules.Multitenancy</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1056;CA1008;CA1716;CA1812;S1135;S2139;S6667;S3267;S1172</NoWarn>
+		<!-- MultitenancyResources is an intentional empty localizer marker (see Localization/MultitenancyResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1056;CA1008;CA1716;CA1812;S1135;S2139;S6667;S3267;S1172;S2094</NoWarn>
 	</PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Finbuckle.MultiTenant" />

--- a/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/MultitenancyModule.cs
@@ -26,6 +26,7 @@ using FSH.Modules.Multitenancy.Features.v1.TenantProvisioning.GetTenantProvision
 using FSH.Modules.Multitenancy.Features.v1.TenantProvisioning.RetryTenantProvisioning;
 using FSH.Modules.Multitenancy.Features.v1.RenewTenant;
 using FSH.Modules.Multitenancy.Features.v1.UpdateTenantTheme;
+using FSH.Modules.Multitenancy.Localization;
 using FSH.Modules.Multitenancy.Provisioning;
 using FSH.Modules.Multitenancy.Services;
 using Hangfire;
@@ -180,7 +181,11 @@ public sealed class MultitenancyModule : IModule
                 {
                     if (!tenant.IsActive)
                     {
-                        throw new ForbiddenException("This tenant has been deactivated. Contact your administrator.");
+                        throw new ForbiddenException("This tenant has been deactivated. Contact your administrator.")
+                        {
+                            MessageKey = "Multitenancy.TenantDeactivated",
+                            ResourceSource = typeof(MultitenancyResources),
+                        };
                     }
 
                     // Expiry is enforced on every request (not just at login) with a grace period:
@@ -191,7 +196,11 @@ public sealed class MultitenancyModule : IModule
                     var graceEndsUtc = tenant.ValidUpto.AddDays(graceDays);
                     if (nowUtc > graceEndsUtc)
                     {
-                        throw new ForbiddenException("This tenant's subscription has expired. Please renew to continue.");
+                        throw new ForbiddenException("This tenant's subscription has expired. Please renew to continue.")
+                        {
+                            MessageKey = "Multitenancy.TenantSubscriptionExpired",
+                            ResourceSource = typeof(MultitenancyResources),
+                        };
                     }
 
                     // Inside the grace period: surface days-left so clients can warn. Set via OnStarting so

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Provisioning/TenantProvisioningJob.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Provisioning/TenantProvisioningJob.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Persistence;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Multitenancy.Contracts;
+using FSH.Modules.Multitenancy.Localization;
 using FSH.Modules.Multitenancy.Services;
 using Microsoft.Extensions.Logging;
 
@@ -34,7 +35,12 @@ public sealed class TenantProvisioningJob
     public async Task RunAsync(string tenantId, string correlationId, CancellationToken cancellationToken = default)
     {
         var tenant = await _tenantStore.GetAsync(tenantId).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Tenant {tenantId} not found during provisioning.");
+            ?? throw new NotFoundException($"Tenant {tenantId} not found during provisioning.")
+            {
+                MessageKey = "Multitenancy.TenantNotFoundDuringProvisioning",
+                MessageArgs = [tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
 
         var currentStep = TenantProvisioningStepName.Database;
         try

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Provisioning/TenantProvisioningService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Provisioning/TenantProvisioningService.cs
@@ -4,6 +4,7 @@ using FSH.Framework.Jobs.Services;
 using FSH.Framework.Shared.Multitenancy;
 using FSH.Modules.Multitenancy.Contracts.Dtos;
 using FSH.Modules.Multitenancy.Data;
+using FSH.Modules.Multitenancy.Localization;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,12 +37,22 @@ public sealed class TenantProvisioningService : ITenantProvisioningService
     public async Task<TenantProvisioning> StartAsync(string tenantId, CancellationToken cancellationToken)
     {
         var tenant = await _tenantStore.GetAsync(tenantId).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Tenant {tenantId} not found for provisioning.");
+            ?? throw new NotFoundException($"Tenant {tenantId} not found for provisioning.")
+            {
+                MessageKey = "Multitenancy.TenantNotFoundForProvisioning",
+                MessageArgs = [tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
 
         var existing = await GetLatestAsync(tenantId, cancellationToken).ConfigureAwait(false);
         if (existing is not null && (existing.Status is TenantProvisioningStatus.Running or TenantProvisioningStatus.Pending))
         {
-            throw new CustomException($"Provisioning already running for tenant {tenantId}.");
+            throw new CustomException($"Provisioning already running for tenant {tenantId}.")
+            {
+                MessageKey = "Multitenancy.ProvisioningAlreadyRunning",
+                MessageArgs = [tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         var correlationId = Guid.NewGuid().ToString();
@@ -85,7 +96,12 @@ public sealed class TenantProvisioningService : ITenantProvisioningService
     public async Task<TenantProvisioningStatusDto> GetStatusAsync(string tenantId, CancellationToken cancellationToken)
     {
         var provisioning = await GetLatestAsync(tenantId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Provisioning not found for tenant {tenantId}.");
+            ?? throw new NotFoundException($"Provisioning not found for tenant {tenantId}.")
+            {
+                MessageKey = "Multitenancy.ProvisioningNotFound",
+                MessageArgs = [tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
 
         return ToDto(provisioning);
     }
@@ -100,7 +116,12 @@ public sealed class TenantProvisioningService : ITenantProvisioningService
 
         if (provisioning.Status != TenantProvisioningStatus.Completed)
         {
-            throw new CustomException($"Tenant {tenantId} is not provisioned. Status: {provisioning.Status}.");
+            throw new CustomException($"Tenant {tenantId} is not provisioned. Status: {provisioning.Status}.")
+            {
+                MessageKey = "Multitenancy.TenantNotProvisioned",
+                MessageArgs = [tenantId, provisioning.Status],
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
     }
 
@@ -171,7 +192,12 @@ public sealed class TenantProvisioningService : ITenantProvisioningService
             .Include(p => p.Steps)
             .FirstOrDefaultAsync(p => p.TenantId == tenantId && p.CorrelationId == correlationId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Provisioning {correlationId} for tenant {tenantId} not found.");
+            ?? throw new NotFoundException($"Provisioning {correlationId} for tenant {tenantId} not found.")
+            {
+                MessageKey = "Multitenancy.ProvisioningCorrelationNotFound",
+                MessageArgs = [correlationId, tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
     }
 
     private static bool TryEnsureJobStorage()

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantService.cs
@@ -9,6 +9,7 @@ using FSH.Modules.Multitenancy.Contracts.Dtos;
 using FSH.Modules.Multitenancy.Contracts.v1.GetTenants;
 using FSH.Modules.Multitenancy.Data;
 using FSH.Modules.Multitenancy.Features.v1.GetTenants;
+using FSH.Modules.Multitenancy.Localization;
 using FSH.Modules.Multitenancy.Provisioning;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -56,7 +57,12 @@ public sealed class TenantService : ITenantService
 
         if (tenant.IsActive)
         {
-            throw new CustomException($"tenant {id} is already activated");
+            throw new CustomException($"tenant {id} is already activated")
+            {
+                MessageKey = "Multitenancy.TenantAlreadyActivated",
+                MessageArgs = [id],
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         await _provisioningService.EnsureCanActivateAsync(id, cancellationToken).ConfigureAwait(false);
@@ -123,18 +129,31 @@ public sealed class TenantService : ITenantService
         var tenant = await GetTenantInfoAsync(id, cancellationToken).ConfigureAwait(false);
         if (!tenant.IsActive)
         {
-            throw new CustomException($"tenant {id} is already deactivated");
+            throw new CustomException($"tenant {id} is already deactivated")
+            {
+                MessageKey = "Multitenancy.TenantAlreadyDeactivated",
+                MessageArgs = [id],
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         int tenantCount = (await _tenantStore.GetAllAsync().ConfigureAwait(false)).Count(t => t.IsActive);
         if (tenantCount <= 1)
         {
-            throw new CustomException("At least one active tenant is required.");
+            throw new CustomException("At least one active tenant is required.")
+            {
+                MessageKey = "Multitenancy.AtLeastOneActiveTenantRequired",
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         if (tenant.Id.Equals(MultitenancyConstants.Root.Id, StringComparison.OrdinalIgnoreCase))
         {
-            throw new CustomException("The root tenant cannot be deactivated.");
+            throw new CustomException("The root tenant cannot be deactivated.")
+            {
+                MessageKey = "Multitenancy.RootTenantCannotBeDeactivated",
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         tenant.Deactivate();
@@ -247,7 +266,12 @@ public sealed class TenantService : ITenantService
 
     private async Task<AppTenantInfo> GetTenantInfoAsync(string id, CancellationToken cancellationToken = default) =>
         await _tenantStore.GetAsync(id).ConfigureAwait(false)
-            ?? throw new NotFoundException($"{typeof(AppTenantInfo).Name} {id} Not Found.");
+            ?? throw new NotFoundException($"{typeof(AppTenantInfo).Name} {id} Not Found.")
+            {
+                MessageKey = "Multitenancy.TenantNotFound",
+                MessageArgs = [id],
+                ResourceSource = typeof(MultitenancyResources),
+            };
 
     // Finbuckle resolves via the distributed-cache store first (60-min TTL) while the injected store only
     // writes EF, so push the new state into the cache store too — otherwise flips lag until cache expiry.

--- a/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantThemeService.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Services/TenantThemeService.cs
@@ -10,6 +10,7 @@ using FSH.Modules.Multitenancy.Contracts;
 using FSH.Modules.Multitenancy.Contracts.Dtos;
 using FSH.Modules.Multitenancy.Data;
 using FSH.Modules.Multitenancy.Domain;
+using FSH.Modules.Multitenancy.Localization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
@@ -220,7 +221,11 @@ public sealed class TenantThemeService : ITenantThemeService
         var currentTenantId = _tenantAccessor.MultiTenantContext?.TenantInfo?.Id;
         if (currentTenantId != MultitenancyConstants.Root.Id)
         {
-            throw new ForbiddenException("Only the root tenant can set the default theme");
+            throw new ForbiddenException("Only the root tenant can set the default theme")
+            {
+                MessageKey = "Multitenancy.OnlyRootCanSetDefaultTheme",
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         // Clear existing default
@@ -240,7 +245,12 @@ public sealed class TenantThemeService : ITenantThemeService
 
         if (entity is null)
         {
-            throw new NotFoundException($"Theme for tenant {tenantId} not found");
+            throw new NotFoundException($"Theme for tenant {tenantId} not found")
+            {
+                MessageKey = "Multitenancy.TenantThemeNotFound",
+                MessageArgs = [tenantId],
+                ResourceSource = typeof(MultitenancyResources),
+            };
         }
 
         entity.IsDefault = true;

--- a/src/Modules/Notifications/Modules.Notifications/Features/v1/GetUnreadCount/GetUnreadCountQueryHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Features/v1/GetUnreadCount/GetUnreadCountQueryHandler.cs
@@ -16,7 +16,13 @@ public sealed class GetUnreadCountQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(query);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty)
+        {
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
+        }
         var currentUserId = userId.ToString();
 
         return await db.Notifications.AsNoTracking()

--- a/src/Modules/Notifications/Modules.Notifications/Features/v1/ListNotifications/ListNotificationsQueryHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Features/v1/ListNotifications/ListNotificationsQueryHandler.cs
@@ -19,7 +19,13 @@ public sealed class ListNotificationsQueryHandler(
     {
         ArgumentNullException.ThrowIfNull(q);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty)
+        {
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
+        }
         var currentUserId = userId.ToString();
 
         int page = Math.Max(1, q.Page);

--- a/src/Modules/Notifications/Modules.Notifications/Features/v1/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Features/v1/MarkAllNotificationsRead/MarkAllNotificationsReadCommandHandler.cs
@@ -16,7 +16,13 @@ public sealed class MarkAllNotificationsReadCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty)
+        {
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
+        }
         var currentUserId = userId.ToString();
 
         var now = DateTime.UtcNow;

--- a/src/Modules/Notifications/Modules.Notifications/Features/v1/MarkNotificationRead/MarkNotificationReadCommandHandler.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Features/v1/MarkNotificationRead/MarkNotificationReadCommandHandler.cs
@@ -2,6 +2,7 @@ using FSH.Framework.Core.Context;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Notifications.Contracts.v1.Commands;
 using FSH.Modules.Notifications.Data;
+using FSH.Modules.Notifications.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,7 +17,13 @@ public sealed class MarkNotificationReadCommandHandler(
     {
         ArgumentNullException.ThrowIfNull(cmd);
         var userId = currentUser.GetUserId();
-        if (userId == Guid.Empty) throw new UnauthorizedException("no current user");
+        if (userId == Guid.Empty)
+        {
+            throw new UnauthorizedException("no current user")
+            {
+                MessageKey = "Error.NoCurrentUser",
+            };
+        }
         var currentUserId = userId.ToString();
 
         // Caller-scoped: filter by (Id, UserId) so users can only mutate their own rows. Returns
@@ -24,7 +31,11 @@ public sealed class MarkNotificationReadCommandHandler(
         var notification = await db.Notifications
             .FirstOrDefaultAsync(n => n.Id == cmd.NotificationId && n.UserId == currentUserId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException("Notification not found.");
+            ?? throw new NotFoundException("Notification not found.")
+            {
+                MessageKey = "Notifications.NotificationNotFound",
+                ResourceSource = typeof(NotificationsResources),
+            };
 
         notification.MarkRead();
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailBodies.cs
+++ b/src/Modules/Notifications/Modules.Notifications/IntegrationEventHandlers/BillingEmailBodies.cs
@@ -1,3 +1,4 @@
+// TODO(i18n): email bodies are localized in a follow-up PR — recipient locale must be propagated (no HTTP request culture in background handlers).
 using System.Globalization;
 
 namespace FSH.Modules.Notifications.IntegrationEventHandlers;

--- a/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.cs
+++ b/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Notifications.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;NotificationsResources&gt;</c> to the Notifications resx catalog.</summary>
+public sealed class NotificationsResources;

--- a/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.pt-BR.resx
+++ b/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.pt-BR.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Notifications.NotificationNotFound" xml:space="preserve">
+    <value>Notificação não encontrada.</value>
+  </data>
+</root>

--- a/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.resx
+++ b/src/Modules/Notifications/Modules.Notifications/Localization/NotificationsResources.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Notifications.NotificationNotFound" xml:space="preserve">
+    <value>Notification not found.</value>
+  </data>
+</root>

--- a/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
+++ b/src/Modules/Notifications/Modules.Notifications/Modules.Notifications.csproj
@@ -3,7 +3,9 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Notifications</RootNamespace>
 		<AssemblyName>FSH.Modules.Notifications</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;CA1002;CA2227;S3267</NoWarn>
+		<!-- S2094: NotificationsResources is an intentional empty localizer marker (see Localization/NotificationsResources.cs). -->
+		<!-- S1135: the i18n email-bodies TODO is a tracked follow-up, not an unfinished task in this PR. -->
+		<NoWarn>$(NoWarn);CA1031;CA1711;CA1812;CA1859;CA1002;CA2227;S3267;S2094;S1135</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Tickets/Modules.Tickets/Domain/Ticket.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Domain/Ticket.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Domain;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.Dtos;
 using FSH.Modules.Tickets.Domain.Events;
+using FSH.Modules.Tickets.Localization;
 
 namespace FSH.Modules.Tickets.Domain;
 
@@ -120,7 +121,11 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 "A closed ticket cannot be resolved — reopen it first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Tickets.ClosedCannotResolve",
+                ResourceSource = typeof(TicketsResources),
+            };
         }
         if (Status == TicketStatus.Resolved)
         {
@@ -148,7 +153,12 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 $"Only a resolved ticket can be closed — current status is {Status}. Resolve it first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Tickets.OnlyResolvedCanClose",
+                MessageArgs = [Status],
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         ClosedAtUtc = DateTime.UtcNow;
@@ -168,7 +178,11 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 "A closed ticket cannot be edited — reopen it first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Tickets.ClosedCannotEdit",
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         Title = title.Trim();
@@ -201,7 +215,11 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 "A closed ticket cannot accept new comments — reopen it first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Tickets.ClosedCannotComment",
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         var comment = TicketComment.Create(Id, authorUserId, body);
@@ -234,7 +252,12 @@ public sealed class Ticket : AggregateRoot<Guid>, ISoftDeletable
             throw new CustomException(
                 $"Cannot {action} a ticket in status {Status} — reopen it first.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Conflict);
+                HttpStatusCode.Conflict)
+            {
+                MessageKey = "Tickets.CannotActionInStatus",
+                MessageArgs = [action, Status],
+                ResourceSource = typeof(TicketsResources),
+            };
         }
     }
 }

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AddTicketComment/AddTicketCommentCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AddTicketComment/AddTicketCommentCommandHandler.cs
@@ -3,6 +3,7 @@ using FSH.Framework.Core.Context;
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
 using FSH.Modules.Tickets.Data;
+using FSH.Modules.Tickets.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -23,7 +24,11 @@ public sealed class AddTicketCommentCommandHandler(
             throw new CustomException(
                 "Cannot post a comment without an authenticated author.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Unauthorized);
+                HttpStatusCode.Unauthorized)
+            {
+                MessageKey = "Tickets.CommentAuthorRequired",
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         // Load the Comments collection up front so EF's change tracker detects the new TicketComment
@@ -32,7 +37,12 @@ public sealed class AddTicketCommentCommandHandler(
             .Include(t => t.Comments)
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         var commentId = ticket.AddComment(authorId, command.Body);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AssignTicket/AssignTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/AssignTicket/AssignTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class AssignTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.Assign(command.AssigneeUserId);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CloseTicket/CloseTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CloseTicket/CloseTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class CloseTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.Close();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CreateTicket/CreateTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/CreateTicket/CreateTicketCommandHandler.cs
@@ -5,6 +5,7 @@ using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
 using FSH.Modules.Tickets.Data;
 using FSH.Modules.Tickets.Domain;
+using FSH.Modules.Tickets.Localization;
 using Mediator;
 using FSH.Framework.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -26,7 +27,11 @@ public sealed class CreateTicketCommandHandler(
             throw new CustomException(
                 "Cannot create a ticket without an authenticated reporter.",
                 (IEnumerable<string>?)null,
-                HttpStatusCode.Unauthorized);
+                HttpStatusCode.Unauthorized)
+            {
+                MessageKey = "Tickets.ReporterRequired",
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         // Sequential, tenant-scoped ticket numbers (TK-1, …). Count ALL rows incl. soft-deleted so a

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/DeleteTicket/DeleteTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/DeleteTicket/DeleteTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class DeleteTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         // Soft delete: the audit interceptor converts the EF Delete into an IsDeleted flip.
         // Comments are not auto-included, so they are left untouched and survive a Restore.

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/GetTicketById/GetTicketByIdQueryHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/GetTicketById/GetTicketByIdQueryHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.Dtos;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
 using FSH.Modules.Tickets.Data;
 using FSH.Modules.Tickets.Domain;
@@ -22,7 +23,12 @@ public sealed class GetTicketByIdQueryHandler(TicketsDbContext dbContext)
 
         if (ticket is null)
         {
-            throw new NotFoundException($"Ticket {query.TicketId} not found.");
+            throw new NotFoundException($"Ticket {query.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [query.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         int commentCount = await dbContext.TicketComments

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ListTicketComments/ListTicketCommentsQueryHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ListTicketComments/ListTicketCommentsQueryHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.Dtos;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
 using FSH.Modules.Tickets.Data;
 using FSH.Modules.Tickets.Domain;
@@ -25,7 +26,12 @@ public sealed class ListTicketCommentsQueryHandler(TicketsDbContext dbContext)
             .ConfigureAwait(false);
         if (!ticketExists)
         {
-            throw new NotFoundException($"Ticket {query.TicketId} not found.");
+            throw new NotFoundException($"Ticket {query.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [query.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
         }
 
         var comments = await dbContext.TicketComments

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ReopenTicket/ReopenTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ReopenTicket/ReopenTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class ReopenTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.Reopen();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ResolveTicket/ResolveTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/ResolveTicket/ResolveTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class ResolveTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.Resolve(command.ResolutionNote);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/RestoreTicket/RestoreTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/RestoreTicket/RestoreTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Framework.Persistence;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
 using FSH.Modules.Tickets.Data;
 using Mediator;
@@ -18,7 +19,12 @@ public sealed class RestoreTicketCommandHandler(TicketsDbContext dbContext)
             .IgnoreQueryFilters([QueryFilters.SoftDelete])
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.Restore();
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/UpdateTicket/UpdateTicketCommandHandler.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Features/v1/Tickets/UpdateTicket/UpdateTicketCommandHandler.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Tickets.Contracts.v1.Tickets;
+using FSH.Modules.Tickets.Localization;
 using FSH.Modules.Tickets.Data;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,12 @@ public sealed class UpdateTicketCommandHandler(TicketsDbContext dbContext)
         var ticket = await dbContext.Tickets
             .FirstOrDefaultAsync(t => t.Id == command.TicketId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.");
+            ?? throw new NotFoundException($"Ticket {command.TicketId} not found.")
+            {
+                MessageKey = "Tickets.TicketNotFound",
+                MessageArgs = [command.TicketId],
+                ResourceSource = typeof(TicketsResources),
+            };
 
         ticket.UpdateDetails(command.Title, command.Description, command.Priority);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.cs
+++ b/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Tickets.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;TicketsResources&gt;</c> to the Tickets resx catalog.</summary>
+public sealed class TicketsResources;

--- a/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.pt-BR.resx
+++ b/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.pt-BR.resx
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Tickets.TicketNotFound" xml:space="preserve">
+    <value>Chamado {0} não encontrado.</value>
+  </data>
+  <data name="Tickets.ClosedCannotResolve" xml:space="preserve">
+    <value>Um chamado fechado não pode ser resolvido. Reabra-o primeiro.</value>
+  </data>
+  <data name="Tickets.OnlyResolvedCanClose" xml:space="preserve">
+    <value>Somente um chamado resolvido pode ser fechado. O status atual é {0}. Resolva-o primeiro.</value>
+  </data>
+  <data name="Tickets.ClosedCannotEdit" xml:space="preserve">
+    <value>Um chamado fechado não pode ser editado. Reabra-o primeiro.</value>
+  </data>
+  <data name="Tickets.ClosedCannotComment" xml:space="preserve">
+    <value>Um chamado fechado não aceita novos comentários. Reabra-o primeiro.</value>
+  </data>
+  <data name="Tickets.CannotActionInStatus" xml:space="preserve">
+    <value>Não é possível {0} um chamado no status {1}. Reabra-o primeiro.</value>
+  </data>
+  <data name="Tickets.CommentAuthorRequired" xml:space="preserve">
+    <value>Não é possível publicar um comentário sem um autor autenticado.</value>
+  </data>
+  <data name="Tickets.ReporterRequired" xml:space="preserve">
+    <value>Não é possível criar um chamado sem um solicitante autenticado.</value>
+  </data>
+</root>

--- a/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.resx
+++ b/src/Modules/Tickets/Modules.Tickets/Localization/TicketsResources.resx
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Tickets.TicketNotFound" xml:space="preserve">
+    <value>Ticket {0} not found.</value>
+  </data>
+  <data name="Tickets.ClosedCannotResolve" xml:space="preserve">
+    <value>A closed ticket cannot be resolved — reopen it first.</value>
+  </data>
+  <data name="Tickets.OnlyResolvedCanClose" xml:space="preserve">
+    <value>Only a resolved ticket can be closed — current status is {0}. Resolve it first.</value>
+  </data>
+  <data name="Tickets.ClosedCannotEdit" xml:space="preserve">
+    <value>A closed ticket cannot be edited — reopen it first.</value>
+  </data>
+  <data name="Tickets.ClosedCannotComment" xml:space="preserve">
+    <value>A closed ticket cannot accept new comments — reopen it first.</value>
+  </data>
+  <data name="Tickets.CannotActionInStatus" xml:space="preserve">
+    <value>Cannot {0} a ticket in status {1} — reopen it first.</value>
+  </data>
+  <data name="Tickets.CommentAuthorRequired" xml:space="preserve">
+    <value>Cannot post a comment without an authenticated author.</value>
+  </data>
+  <data name="Tickets.ReporterRequired" xml:space="preserve">
+    <value>Cannot create a ticket without an authenticated reporter.</value>
+  </data>
+</root>

--- a/src/Modules/Tickets/Modules.Tickets/Modules.Tickets.csproj
+++ b/src/Modules/Tickets/Modules.Tickets/Modules.Tickets.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<RootNamespace>FSH.Modules.Tickets</RootNamespace>
 		<AssemblyName>FSH.Modules.Tickets</AssemblyName>
-		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267</NoWarn>
+		<!-- TicketsResources is an intentional empty localizer marker (see Localization/TicketsResources.cs). -->
+		<NoWarn>$(NoWarn);CA1031;CA1812;CA1859;S3267;S2094</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Modules/Webhooks/Modules.Webhooks/Features/v1/CreateWebhookSubscription/CreateWebhookSubscriptionCommandValidator.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Features/v1/CreateWebhookSubscription/CreateWebhookSubscriptionCommandValidator.cs
@@ -1,19 +1,21 @@
 using FluentValidation;
 using FSH.Modules.Webhooks.Contracts.v1.CreateWebhookSubscription;
+using FSH.Modules.Webhooks.Localization;
 using FSH.Modules.Webhooks.Services;
+using Microsoft.Extensions.Localization;
 
 namespace FSH.Modules.Webhooks.Features.v1.CreateWebhookSubscription;
 
 public sealed class CreateWebhookSubscriptionCommandValidator : AbstractValidator<CreateWebhookSubscriptionCommand>
 {
-    public CreateWebhookSubscriptionCommandValidator()
+    public CreateWebhookSubscriptionCommandValidator(IStringLocalizer<WebhooksResources> localizer)
     {
         RuleFor(x => x.Url).NotEmpty()
             .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var uri)
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
-            .WithMessage("A valid absolute URL is required.")
+            .WithMessage(_ => localizer["Validation.WebhookUrlInvalid"])
             .Must(url => !Uri.TryCreate(url, UriKind.Absolute, out var uri) || !WebhookUrlGuard.IsBlockedHost(uri.Host))
-            .WithMessage("The URL must not target a private, loopback, link-local, or metadata address.");
-        RuleFor(x => x.Events).NotEmpty().WithMessage("At least one event type is required.");
+            .WithMessage(_ => localizer["Validation.WebhookUrlBlockedTarget"]);
+        RuleFor(x => x.Events).NotEmpty().WithMessage(_ => localizer["Validation.WebhookEventsRequired"]);
     }
 }

--- a/src/Modules/Webhooks/Modules.Webhooks/Features/v1/DeleteWebhookSubscription/DeleteWebhookSubscriptionCommandHandler.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Features/v1/DeleteWebhookSubscription/DeleteWebhookSubscriptionCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Webhooks.Contracts.v1.DeleteWebhookSubscription;
 using FSH.Modules.Webhooks.Data;
+using FSH.Modules.Webhooks.Localization;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,7 +17,12 @@ public sealed class DeleteWebhookSubscriptionCommandHandler(
         var subscription = await dbContext.Subscriptions
             .FirstOrDefaultAsync(s => s.Id == command.Id, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Webhook subscription {command.Id} not found.");
+            ?? throw new NotFoundException($"Webhook subscription {command.Id} not found.")
+            {
+                MessageKey = "Webhooks.SubscriptionNotFound",
+                MessageArgs = [command.Id],
+                ResourceSource = typeof(WebhooksResources),
+            };
 
         dbContext.Subscriptions.Remove(subscription);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Modules/Webhooks/Modules.Webhooks/Features/v1/TestWebhookSubscription/TestWebhookSubscriptionCommandHandler.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Features/v1/TestWebhookSubscription/TestWebhookSubscriptionCommandHandler.cs
@@ -1,6 +1,7 @@
 using FSH.Framework.Core.Exceptions;
 using FSH.Modules.Webhooks.Contracts.v1.TestWebhookSubscription;
 using FSH.Modules.Webhooks.Data;
+using FSH.Modules.Webhooks.Localization;
 using FSH.Modules.Webhooks.Services;
 using Mediator;
 using Microsoft.EntityFrameworkCore;
@@ -21,7 +22,12 @@ public sealed class TestWebhookSubscriptionCommandHandler(
             .AsNoTracking()
             .FirstOrDefaultAsync(s => s.Id == command.Id, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new NotFoundException($"Webhook subscription {command.Id} not found.");
+            ?? throw new NotFoundException($"Webhook subscription {command.Id} not found.")
+            {
+                MessageKey = "Webhooks.SubscriptionNotFound",
+                MessageArgs = [command.Id],
+                ResourceSource = typeof(WebhooksResources),
+            };
 
         var testPayload = JsonSerializer.Serialize(new
         {

--- a/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.cs
+++ b/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.cs
@@ -1,0 +1,4 @@
+namespace FSH.Modules.Webhooks.Localization;
+
+/// <summary>Marker type binding <c>IStringLocalizer&lt;WebhooksResources&gt;</c> to the Webhooks resx catalog.</summary>
+public sealed class WebhooksResources;

--- a/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.pt-BR.resx
+++ b/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.pt-BR.resx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Webhooks.SubscriptionNotFound" xml:space="preserve">
+    <value>Inscrição de webhook {0} não encontrada.</value>
+  </data>
+  <data name="Validation.WebhookUrlInvalid" xml:space="preserve">
+    <value>Uma URL absoluta válida é obrigatória.</value>
+  </data>
+  <data name="Validation.WebhookUrlBlockedTarget" xml:space="preserve">
+    <value>A URL não pode apontar para um endereço privado, de loopback, link-local ou de metadados.</value>
+  </data>
+  <data name="Validation.WebhookEventsRequired" xml:space="preserve">
+    <value>É obrigatório pelo menos um tipo de evento.</value>
+  </data>
+</root>

--- a/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.resx
+++ b/src/Modules/Webhooks/Modules.Webhooks/Localization/WebhooksResources.resx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Webhooks.SubscriptionNotFound" xml:space="preserve">
+    <value>Webhook subscription {0} not found.</value>
+  </data>
+  <data name="Validation.WebhookUrlInvalid" xml:space="preserve">
+    <value>A valid absolute URL is required.</value>
+  </data>
+  <data name="Validation.WebhookUrlBlockedTarget" xml:space="preserve">
+    <value>The URL must not target a private, loopback, link-local, or metadata address.</value>
+  </data>
+  <data name="Validation.WebhookEventsRequired" xml:space="preserve">
+    <value>At least one event type is required.</value>
+  </data>
+</root>

--- a/src/Modules/Webhooks/Modules.Webhooks/Modules.Webhooks.csproj
+++ b/src/Modules/Webhooks/Modules.Webhooks/Modules.Webhooks.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <RootNamespace>FSH.Modules.Webhooks</RootNamespace>
     <AssemblyName>FSH.Modules.Webhooks</AssemblyName>
-    <NoWarn>$(NoWarn);CA1031;CA1054;CA1056;CA1308;CA1812;CA1859;S3267</NoWarn>
+    <!-- WebhooksResources is an intentional empty localizer marker (see Localization/WebhooksResources.cs). -->
+    <NoWarn>$(NoWarn);CA1031;CA1054;CA1056;CA1308;CA1812;CA1859;S3267;S2094</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\BuildingBlocks\Persistence\Persistence.csproj" />

--- a/src/Tests/Architecture.Tests/CatalogParityTests.cs
+++ b/src/Tests/Architecture.Tests/CatalogParityTests.cs
@@ -1,0 +1,183 @@
+using FSH.Framework.Core.Localization;
+using Shouldly;
+using System.Collections;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Architecture.Tests;
+
+/// <summary>
+/// Generic key-parity guard across EVERY resx catalog, discovered by reflection.
+///
+/// Each module already has a hand-written parity test, but those only cover the modules
+/// someone remembered to write one for — Notifications shipped a catalog with no parity
+/// test at all, and has no test project to put one in. This closes that class of gap: a
+/// new module catalog is covered the moment its assembly lands in the output, with no new
+/// test and no new test project.
+///
+/// Parity matters because a key missing from a translated catalog does not fail — resource
+/// fallback quietly serves the neutral (English) string, so an untranslated message ships
+/// looking translated.
+/// </summary>
+public sealed class CatalogParityTests
+{
+    /// <summary>
+    /// A catalog marker is a type with an embedded `.resources` manifest matching its own
+    /// full name — which is exactly the co-located `ResourcesPath = ""` convention the
+    /// framework relies on. Anything else named `*Resources` is skipped.
+    /// </summary>
+    private static List<Type> DiscoverCatalogMarkers()
+    {
+        var assemblies = ModuleAssemblyDiscovery.GetModuleAssemblies()
+            .Append(typeof(SharedResources).Assembly)
+            .Distinct()
+            .ToList();
+
+        var markers = new List<Type>();
+        foreach (var assembly in assemblies)
+        {
+            var manifests = assembly.GetManifestResourceNames();
+            foreach (var type in SafeGetTypes(assembly))
+            {
+                if (!type.IsClass || type.FullName is null) continue;
+                if (!type.Name.EndsWith("Resources", StringComparison.Ordinal)) continue;
+                if (manifests.Contains($"{type.FullName}.resources", StringComparer.Ordinal))
+                {
+                    markers.Add(type);
+                }
+            }
+        }
+
+        return markers.OrderBy(t => t.FullName, StringComparer.Ordinal).ToList();
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try { return assembly.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+    }
+
+    /// <summary>
+    /// Keys declared by this culture's OWN catalog. `tryParents: false` is the whole point:
+    /// with parent fallback on, a missing pt-BR key would be answered by the neutral catalog
+    /// and parity would look perfect while half the strings were English.
+    /// </summary>
+    private static Dictionary<string, string>? OwnEntries(ResourceManager manager, CultureInfo culture)
+    {
+        var set = manager.GetResourceSet(culture, createIfNotExists: true, tryParents: false);
+        if (set is null) return null;
+
+        var entries = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (DictionaryEntry entry in set)
+        {
+            if (entry.Key is string key)
+            {
+                entries[key] = entry.Value as string ?? string.Empty;
+            }
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// The `{0}`-style argument indexes a message consumes. Escaped braces (`{{`, `}}`) are
+    /// stripped first so a literal brace is not mistaken for a placeholder.
+    /// </summary>
+    private static SortedSet<int> PlaceholderIndexes(string value)
+    {
+        var unescaped = value.Replace("{{", string.Empty, StringComparison.Ordinal)
+            .Replace("}}", string.Empty, StringComparison.Ordinal);
+
+        var indexes = new SortedSet<int>();
+        foreach (var match in PlaceholderPattern.Matches(unescaped).Cast<Match>())
+        {
+            indexes.Add(int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture));
+        }
+
+        return indexes;
+    }
+
+    private static readonly Regex PlaceholderPattern =
+        new(@"\{(\d+)(?::[^}]*)?\}", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void Every_Catalog_Has_Matching_Keys_In_Every_Supported_Culture()
+    {
+        var markers = DiscoverCatalogMarkers();
+
+        // Never let a discovery regression read as a pass: if the reflection stops finding
+        // catalogs, this test would otherwise assert nothing and go green.
+        markers.Count.ShouldBeGreaterThanOrEqualTo(
+            11,
+            "expected the Core catalog plus one per module; discovery found fewer, so this " +
+            "test would silently stop guarding the ones it lost");
+
+        var violations = new List<string>();
+
+        foreach (var marker in markers)
+        {
+            var manager = new ResourceManager(marker);
+
+            var neutral = OwnEntries(manager, CultureInfo.InvariantCulture);
+            if (neutral is null || neutral.Count == 0)
+            {
+                violations.Add($"{marker.FullName}: neutral catalog is missing or empty");
+                continue;
+            }
+
+            foreach (var tag in SupportedCultures.Tags)
+            {
+                // The neutral catalog IS the default culture's catalog; there is no
+                // `*.en-US.resx` and there should not be one.
+                if (tag == SupportedCultures.Default) continue;
+
+                var translated = OwnEntries(manager, new CultureInfo(tag));
+                if (translated is null)
+                {
+                    violations.Add($"{marker.FullName}: no `.{tag}.resx` catalog at all");
+                    continue;
+                }
+
+                var missing = neutral.Keys.Except(translated.Keys, StringComparer.Ordinal).OrderBy(k => k, StringComparer.Ordinal).ToList();
+                var extra = translated.Keys.Except(neutral.Keys, StringComparer.Ordinal).OrderBy(k => k, StringComparer.Ordinal).ToList();
+
+                if (missing.Count > 0)
+                {
+                    violations.Add($"{marker.FullName} [{tag}]: missing {missing.Count} key(s) — {string.Join(", ", missing)}");
+                }
+
+                if (extra.Count > 0)
+                {
+                    violations.Add($"{marker.FullName} [{tag}]: {extra.Count} key(s) not in the neutral catalog — {string.Join(", ", extra)}");
+                }
+
+                // Matching keys are not enough. The caller passes ONE argument list for every
+                // culture, so a translation consuming a different set of `{n}` placeholders than
+                // the neutral string either drops data silently or throws FormatException at
+                // render time — in the translated culture only, i.e. never on the reviewer's
+                // machine. `{1}` present in Portuguese but not English is the dangerous
+                // direction: string.Format throws when the index is out of range.
+                foreach (var key in neutral.Keys.Intersect(translated.Keys, StringComparer.Ordinal).OrderBy(k => k, StringComparer.Ordinal))
+                {
+                    var neutralArgs = PlaceholderIndexes(neutral[key]);
+                    var translatedArgs = PlaceholderIndexes(translated[key]);
+
+                    if (!neutralArgs.SetEquals(translatedArgs))
+                    {
+                        violations.Add(
+                            $"{marker.FullName} [{tag}] key '{key}': placeholder mismatch — neutral uses " +
+                            $"{{{string.Join(",", neutralArgs)}}} but {tag} uses {{{string.Join(",", translatedArgs)}}}");
+                    }
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every resx catalog must declare the same keys in every supported culture. A key " +
+            "present only in the neutral catalog falls back to English and ships as if it were " +
+            "translated. Violations:\n  " + string.Join("\n  ", violations));
+    }
+}

--- a/src/Tests/Auditing.Tests/Localization/AuditingResourcesTests.cs
+++ b/src/Tests/Auditing.Tests/Localization/AuditingResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Auditing.Tests.Localization;
+
+// Proves the AuditingResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class AuditingResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(AuditingResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // AuditingResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // AuditingResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Validation.DateRangeOrder"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Validation.DateRangeOrder' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("FromUtc must be less than or equal to ToUtc.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Validation.DateRangeOrder"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Validation.DateRangeOrder' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("FromUtc deve ser menor ou igual a ToUtc.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Billing.Tests/Localization/BillingResourcesTests.cs
+++ b/src/Tests/Billing.Tests/Localization/BillingResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Billing.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Billing.Tests.Localization;
+
+// Proves the BillingResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class BillingResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(BillingResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // BillingResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // BillingResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Billing.OnlyRootOperatorMayGenerateInvoices"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Billing.OnlyRootOperatorMayGenerateInvoices' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("Only the root operator may generate invoices across tenants.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Billing.OnlyRootOperatorMayGenerateInvoices"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Billing.OnlyRootOperatorMayGenerateInvoices' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Apenas o operador raiz pode gerar faturas entre tenants.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Catalog.Tests/Localization/CatalogResourcesTests.cs
+++ b/src/Tests/Catalog.Tests/Localization/CatalogResourcesTests.cs
@@ -1,0 +1,104 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Catalog.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Catalog.Tests.Localization;
+
+// Proves the CatalogResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class CatalogResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(CatalogResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // CatalogResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // CatalogResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Catalog.CategoryCannotBeOwnParent"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Catalog.CategoryCannotBeOwnParent' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("A category cannot be its own parent.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Catalog.CategoryCannotBeOwnParent"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Catalog.CategoryCannotBeOwnParent' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Uma categoria não pode ser pai de si mesma.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    // The AdjustStock domain overflow message is localized with two positional args ({0}=delta, {1}=current stock).
+    [Fact]
+    public void StockAdjustmentNegative_formats_args_in_both_cultures()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Catalog.StockAdjustmentNegative", -4, 3];
+            en.ResourceNotFound.ShouldBeFalse();
+            en.Value.ShouldBe("Stock adjustment of -4 would result in negative stock (current: 3).");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Catalog.StockAdjustmentNegative", -4, 3];
+            pt.ResourceNotFound.ShouldBeFalse();
+            pt.Value.ShouldBe("O ajuste de estoque de -4 resultaria em estoque negativo (atual: 3).");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Catalog.Tests/Support/CatalogResourcesLocalizerFactory.cs
+++ b/src/Tests/Catalog.Tests/Support/CatalogResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Modules.Catalog.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Catalog.Tests.Support;
+
+// Builds a REAL IStringLocalizer<CatalogResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so validators that require a localizer can be
+// instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class CatalogResourcesLocalizerFactory
+{
+    public static IStringLocalizer<CatalogResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<CatalogResources>>();
+    }
+}

--- a/src/Tests/Catalog.Tests/Validators/AdjustProductStockCommandValidatorTests.cs
+++ b/src/Tests/Catalog.Tests/Validators/AdjustProductStockCommandValidatorTests.cs
@@ -1,0 +1,35 @@
+using Catalog.Tests.Support;
+using FSH.Modules.Catalog.Contracts.v1.Products;
+using FSH.Modules.Catalog.Features.v1.Products.AdjustProductStock;
+
+namespace Catalog.Tests.Validators;
+
+// Exercises the validator with a REAL IStringLocalizer<CatalogResources> so the localized
+// message key ("Validation.DeltaNonZero") is proven to resolve against the embedded catalog.
+public sealed class AdjustProductStockCommandValidatorTests
+{
+    private readonly AdjustProductStockCommandValidator _sut = new(CatalogResourcesLocalizerFactory.Create());
+
+    [Fact]
+    public void Delta_Should_Pass_When_NonZero()
+    {
+        var command = new AdjustProductStockCommand(Guid.NewGuid(), 5);
+
+        var result = _sut.Validate(command);
+
+        result.Errors.ShouldNotContain(e => e.PropertyName == nameof(AdjustProductStockCommand.Delta));
+    }
+
+    [Fact]
+    public void Delta_Should_Fail_With_LocalizedMessage_When_Zero()
+    {
+        var command = new AdjustProductStockCommand(Guid.NewGuid(), 0);
+
+        var result = _sut.Validate(command);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors
+            .Where(e => e.PropertyName == nameof(AdjustProductStockCommand.Delta))
+            .ShouldContain(e => e.ErrorMessage == "Delta must be non-zero.");
+    }
+}

--- a/src/Tests/Chat.Tests/Localization/ChatResourcesTests.cs
+++ b/src/Tests/Chat.Tests/Localization/ChatResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Chat.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Chat.Tests.Localization;
+
+// Proves the ChatResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class ChatResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(ChatResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // ChatResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // ChatResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Chat.ChannelNotFound"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Chat.ChannelNotFound' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("Channel not found.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Chat.ChannelNotFound"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Chat.ChannelNotFound' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Canal não encontrado.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Chat.Tests/Support/ChatResourcesLocalizerFactory.cs
+++ b/src/Tests/Chat.Tests/Support/ChatResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Modules.Chat.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Chat.Tests.Support;
+
+// Builds a REAL IStringLocalizer<ChatResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so validators that require a localizer can be
+// instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class ChatResourcesLocalizerFactory
+{
+    public static IStringLocalizer<ChatResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<ChatResources>>();
+    }
+}

--- a/src/Tests/Files.Tests/Localization/FilesResourcesTests.cs
+++ b/src/Tests/Files.Tests/Localization/FilesResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Files.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Files.Tests.Localization;
+
+// Proves the FilesResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class FilesResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(FilesResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // FilesResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // FilesResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Files.FileNotFound"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Files.FileNotFound' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("File not found.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Files.FileNotFound"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Files.FileNotFound' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Arquivo não encontrado.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Generic.Tests/Support/AuditingResourcesLocalizerFactory.cs
+++ b/src/Tests/Generic.Tests/Support/AuditingResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Modules.Auditing.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Generic.Tests.Support;
+
+// Builds a REAL IStringLocalizer<AuditingResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so the Auditing validators that require the module
+// localizer can be instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class AuditingResourcesLocalizerFactory
+{
+    public static IStringLocalizer<AuditingResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<AuditingResources>>();
+    }
+}

--- a/src/Tests/Generic.Tests/Support/SharedResourcesLocalizerFactory.cs
+++ b/src/Tests/Generic.Tests/Support/SharedResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Framework.Core.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Generic.Tests.Support;
+
+// Builds a REAL IStringLocalizer<SharedResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so validators that require a localizer can be
+// instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class SharedResourcesLocalizerFactory
+{
+    public static IStringLocalizer<SharedResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<SharedResources>>();
+    }
+}

--- a/src/Tests/Generic.Tests/Validators/DateRangeValidatorTests.cs
+++ b/src/Tests/Generic.Tests/Validators/DateRangeValidatorTests.cs
@@ -1,3 +1,4 @@
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Auditing.Contracts.v1.GetAudits;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditsByCorrelation;
 using FSH.Modules.Auditing.Contracts.v1.GetAuditsByTrace;
@@ -10,6 +11,9 @@ using FSH.Modules.Auditing.Features.v1.GetAuditsByTrace;
 using FSH.Modules.Auditing.Features.v1.GetAuditSummary;
 using FSH.Modules.Auditing.Features.v1.GetExceptionAudits;
 using FSH.Modules.Auditing.Features.v1.GetSecurityAudits;
+using FSH.Modules.Auditing.Localization;
+using Generic.Tests.Support;
+using Microsoft.Extensions.Localization;
 
 namespace Generic.Tests.Validators;
 
@@ -20,12 +24,14 @@ namespace Generic.Tests.Validators;
 public sealed class DateRangeValidatorTests
 {
     private static readonly DateTime BaseDate = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly IStringLocalizer<SharedResources> Localizer = SharedResourcesLocalizerFactory.Create();
+    private static readonly IStringLocalizer<AuditingResources> AuditingLocalizer = AuditingResourcesLocalizerFactory.Create();
 
     [Fact]
     public void DateRange_Should_Pass_When_BothNull_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { FromUtc = null, ToUtc = null };
 
         // Act
@@ -39,7 +45,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_BothNull_GetAuditsByCorrelation()
     {
         // Arrange
-        var validator = new GetAuditsByCorrelationQueryValidator();
+        var validator = new GetAuditsByCorrelationQueryValidator(AuditingLocalizer);
         var query = new GetAuditsByCorrelationQuery { CorrelationId = "test-id", FromUtc = null, ToUtc = null };
 
         // Act
@@ -53,7 +59,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_BothNull_GetAuditsByTrace()
     {
         // Arrange
-        var validator = new GetAuditsByTraceQueryValidator();
+        var validator = new GetAuditsByTraceQueryValidator(AuditingLocalizer);
         var query = new GetAuditsByTraceQuery { TraceId = "test-trace", FromUtc = null, ToUtc = null };
 
         // Act
@@ -67,7 +73,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_BothNull_GetAuditSummary()
     {
         // Arrange
-        var validator = new GetAuditSummaryQueryValidator();
+        var validator = new GetAuditSummaryQueryValidator(AuditingLocalizer);
         var query = new GetAuditSummaryQuery { FromUtc = null, ToUtc = null };
 
         // Act
@@ -81,7 +87,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_OnlyFromUtcSet_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { FromUtc = BaseDate, ToUtc = null };
 
         // Act
@@ -95,7 +101,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_OnlyToUtcSet_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { FromUtc = null, ToUtc = BaseDate };
 
         // Act
@@ -109,7 +115,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_FromUtcEqualsToUtc_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { FromUtc = BaseDate, ToUtc = BaseDate };
 
         // Act
@@ -123,7 +129,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_FromUtcBeforeToUtc_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery
         {
             FromUtc = BaseDate,
@@ -141,7 +147,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetAudits()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery
         {
             FromUtc = BaseDate.AddDays(7),
@@ -160,7 +166,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetAuditsByCorrelation()
     {
         // Arrange
-        var validator = new GetAuditsByCorrelationQueryValidator();
+        var validator = new GetAuditsByCorrelationQueryValidator(AuditingLocalizer);
         var query = new GetAuditsByCorrelationQuery
         {
             CorrelationId = "test-id",
@@ -180,7 +186,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetAuditsByTrace()
     {
         // Arrange
-        var validator = new GetAuditsByTraceQueryValidator();
+        var validator = new GetAuditsByTraceQueryValidator(AuditingLocalizer);
         var query = new GetAuditsByTraceQuery
         {
             TraceId = "test-trace",
@@ -200,7 +206,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetAuditSummary()
     {
         // Arrange
-        var validator = new GetAuditSummaryQueryValidator();
+        var validator = new GetAuditSummaryQueryValidator(AuditingLocalizer);
         var query = new GetAuditSummaryQuery
         {
             FromUtc = BaseDate.AddDays(7),
@@ -219,7 +225,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetExceptionAudits()
     {
         // Arrange
-        var validator = new GetExceptionAuditsQueryValidator();
+        var validator = new GetExceptionAuditsQueryValidator(AuditingLocalizer);
         var query = new GetExceptionAuditsQuery
         {
             FromUtc = BaseDate.AddDays(7),
@@ -238,7 +244,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Fail_When_FromUtcAfterToUtc_GetSecurityAudits()
     {
         // Arrange
-        var validator = new GetSecurityAuditsQueryValidator();
+        var validator = new GetSecurityAuditsQueryValidator(AuditingLocalizer);
         var query = new GetSecurityAuditsQuery
         {
             FromUtc = BaseDate.AddDays(7),
@@ -260,7 +266,7 @@ public sealed class DateRangeValidatorTests
     public void DateRange_Should_Pass_When_FromUtcSlightlyBeforeToUtc(int secondsDiff)
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery
         {
             FromUtc = BaseDate,

--- a/src/Tests/Generic.Tests/Validators/PagedQueryValidatorTests.cs
+++ b/src/Tests/Generic.Tests/Validators/PagedQueryValidatorTests.cs
@@ -1,7 +1,11 @@
+using FSH.Framework.Core.Localization;
 using FSH.Modules.Auditing.Contracts.v1.GetAudits;
 using FSH.Modules.Auditing.Features.v1.GetAudits;
+using FSH.Modules.Auditing.Localization;
 using FSH.Modules.Identity.Contracts.v1.Users.SearchUsers;
 using FSH.Modules.Identity.Features.v1.Users.SearchUsers;
+using Generic.Tests.Support;
+using Microsoft.Extensions.Localization;
 
 namespace Generic.Tests.Validators;
 
@@ -11,10 +15,13 @@ namespace Generic.Tests.Validators;
 /// </summary>
 public sealed class PagedQueryValidatorTests
 {
+    private static readonly IStringLocalizer<SharedResources> Localizer = SharedResourcesLocalizerFactory.Create();
+    private static readonly IStringLocalizer<AuditingResources> AuditingLocalizer = AuditingResourcesLocalizerFactory.Create();
+
     public static TheoryData<IValidator, object> PagedQueryValidators => new()
     {
-        { new GetAuditsQueryValidator(), new GetAuditsQuery() },
-        { new SearchUsersQueryValidator(), new SearchUsersQuery() }
+        { new GetAuditsQueryValidator(Localizer, AuditingLocalizer), new GetAuditsQuery() },
+        { new SearchUsersQueryValidator(Localizer), new SearchUsersQuery() }
     };
 
     [Theory]
@@ -35,7 +42,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Pass_When_GreaterThanZero_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageNumber = 1 };
 
         // Act
@@ -49,7 +56,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Pass_When_GreaterThanZero_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageNumber = 5 };
 
         // Act
@@ -63,7 +70,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Fail_When_Zero_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageNumber = 0 };
 
         // Act
@@ -77,7 +84,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Fail_When_Zero_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageNumber = 0 };
 
         // Act
@@ -91,7 +98,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Fail_When_Negative_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageNumber = -1 };
 
         // Act
@@ -105,7 +112,7 @@ public sealed class PagedQueryValidatorTests
     public void PageNumber_Should_Fail_When_Negative_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageNumber = -5 };
 
         // Act
@@ -119,7 +126,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Pass_When_Null_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageSize = null };
 
         // Act
@@ -133,7 +140,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Pass_When_Null_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageSize = null };
 
         // Act
@@ -150,7 +157,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Pass_When_Between1And100_Auditing(int pageSize)
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageSize = pageSize };
 
         // Act
@@ -167,7 +174,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Pass_When_Between1And100_Identity(int pageSize)
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageSize = pageSize };
 
         // Act
@@ -181,7 +188,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Fail_When_Zero_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageSize = 0 };
 
         // Act
@@ -195,7 +202,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Fail_When_Zero_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageSize = 0 };
 
         // Act
@@ -209,7 +216,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Fail_When_GreaterThan100_Auditing()
     {
         // Arrange
-        var validator = new GetAuditsQueryValidator();
+        var validator = new GetAuditsQueryValidator(Localizer, AuditingLocalizer);
         var query = new GetAuditsQuery { PageSize = 101 };
 
         // Act
@@ -223,7 +230,7 @@ public sealed class PagedQueryValidatorTests
     public void PageSize_Should_Fail_When_GreaterThan100_Identity()
     {
         // Arrange
-        var validator = new SearchUsersQueryValidator();
+        var validator = new SearchUsersQueryValidator(Localizer);
         var query = new SearchUsersQuery { PageSize = 150 };
 
         // Act

--- a/src/Tests/Identity.Tests/Localization/IdentityResourcesTests.cs
+++ b/src/Tests/Identity.Tests/Localization/IdentityResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Identity.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Identity.Tests.Localization;
+
+// Proves the IdentityResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class IdentityResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(IdentityResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // IdentityResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // IdentityResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Identity.UserNotFound"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Identity.UserNotFound' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("User not found.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Identity.UserNotFound"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Identity.UserNotFound' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Usuário não encontrado.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Identity.Tests/Validators/CreateGroupCommandValidatorTests.cs
+++ b/src/Tests/Identity.Tests/Validators/CreateGroupCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FSH.Modules.Identity.Contracts.v1.Groups.CreateGroup;
 using FSH.Modules.Identity.Features.v1.Groups.CreateGroup;
+using Identity.Tests.Support;
 
 namespace Identity.Tests.Validators;
 
@@ -8,7 +9,7 @@ namespace Identity.Tests.Validators;
 /// </summary>
 public sealed class CreateGroupCommandValidatorTests
 {
-    private readonly CreateGroupCommandValidator _sut = new();
+    private readonly CreateGroupCommandValidator _sut = new(SharedResourcesLocalizerFactory.Create());
 
     #region Name Validation
 

--- a/src/Tests/Identity.Tests/Validators/DeleteUserCommandValidatorTests.cs
+++ b/src/Tests/Identity.Tests/Validators/DeleteUserCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FSH.Modules.Identity.Contracts.v1.Users.DeleteUser;
 using FSH.Modules.Identity.Features.v1.Users.DeleteUser;
+using Identity.Tests.Support;
 using Shouldly;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace Identity.Tests.Validators;
 
 public sealed class DeleteUserCommandValidatorTests
 {
-    private readonly DeleteUserCommandValidator _sut = new();
+    private readonly DeleteUserCommandValidator _sut = new(SharedResourcesLocalizerFactory.Create());
 
     [Fact]
     public void Validate_Should_Pass_When_IdIsProvided()

--- a/src/Tests/Identity.Tests/Validators/UpdateGroupCommandValidatorTests.cs
+++ b/src/Tests/Identity.Tests/Validators/UpdateGroupCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FSH.Modules.Identity.Contracts.v1.Groups.UpdateGroup;
 using FSH.Modules.Identity.Features.v1.Groups.UpdateGroup;
+using Identity.Tests.Support;
 
 namespace Identity.Tests.Validators;
 
@@ -8,7 +9,7 @@ namespace Identity.Tests.Validators;
 /// </summary>
 public sealed class UpdateGroupCommandValidatorTests
 {
-    private readonly UpdateGroupCommandValidator _sut = new();
+    private readonly UpdateGroupCommandValidator _sut = new(SharedResourcesLocalizerFactory.Create());
 
     #region Id Validation
 

--- a/src/Tests/Identity.Tests/Validators/UpsertRoleCommandValidatorTests.cs
+++ b/src/Tests/Identity.Tests/Validators/UpsertRoleCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FSH.Modules.Identity.Contracts.v1.Roles.UpsertRole;
 using FSH.Modules.Identity.Features.v1.Roles.UpsertRole;
+using Identity.Tests.Support;
 
 namespace Identity.Tests.Validators;
 
@@ -8,7 +9,7 @@ namespace Identity.Tests.Validators;
 /// </summary>
 public sealed class UpsertRoleCommandValidatorTests
 {
-    private readonly UpsertRoleCommandValidator _sut = new();
+    private readonly UpsertRoleCommandValidator _sut = new(SharedResourcesLocalizerFactory.Create());
 
     #region Name Validation
 

--- a/src/Tests/Multitenancy.Tests/Localization/MultitenancyResourcesTests.cs
+++ b/src/Tests/Multitenancy.Tests/Localization/MultitenancyResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Multitenancy.Tests.Localization;
+
+// Proves the MultitenancyResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class MultitenancyResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(MultitenancyResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // MultitenancyResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // MultitenancyResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Multitenancy.RootTenantCannotBeDeactivated"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Multitenancy.RootTenantCannotBeDeactivated' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("The root tenant cannot be deactivated.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Multitenancy.RootTenantCannotBeDeactivated"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Multitenancy.RootTenantCannotBeDeactivated' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("O tenant raiz não pode ser desativado.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Multitenancy.Tests/Support/MultitenancyResourcesLocalizerFactory.cs
+++ b/src/Tests/Multitenancy.Tests/Support/MultitenancyResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Modules.Multitenancy.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Multitenancy.Tests.Support;
+
+// Builds a REAL IStringLocalizer<MultitenancyResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so validators that require a localizer can be
+// instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class MultitenancyResourcesLocalizerFactory
+{
+    public static IStringLocalizer<MultitenancyResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<MultitenancyResources>>();
+    }
+}

--- a/src/Tests/Tickets.Tests/GlobalUsings.cs
+++ b/src/Tests/Tickets.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Shouldly;
+global using Xunit;

--- a/src/Tests/Tickets.Tests/Localization/TicketsResourcesTests.cs
+++ b/src/Tests/Tickets.Tests/Localization/TicketsResourcesTests.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Tickets.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Tickets.Tests.Localization;
+
+// Proves the TicketsResources catalog is embedded under the correct manifest name so the module
+// resx resolves at runtime. A wrong manifest name would flip ResourceNotFound and leak raw keys or
+// English text, and a missing pt-BR entry would ship English as if it were translated. Both are caught
+// here. This is the module's only unit test project, added when Tickets exception bodies were localized.
+public sealed class TicketsResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(TicketsResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // TicketsResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // TicketsResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Tickets.ClosedCannotResolve"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Tickets.ClosedCannotResolve' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("A closed ticket cannot be resolved — reopen it first.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Tickets.ClosedCannotResolve"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Tickets.ClosedCannotResolve' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Um chamado fechado não pode ser resolvido. Reabra-o primeiro.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    // TicketNotFound carries the ticket id ({0}); OnlyResolvedCanClose carries the status ({0}).
+    [Fact]
+    public void Parameterized_keys_format_args_in_both_cultures()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            localizer["Tickets.TicketNotFound", "abc"].Value.ShouldBe("Ticket abc not found.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            localizer["Tickets.TicketNotFound", "abc"].Value.ShouldBe("Chamado abc não encontrado.");
+            localizer["Tickets.OnlyResolvedCanClose", "Open"].Value
+                .ShouldBe("Somente um chamado resolvido pode ser fechado. O status atual é Open. Resolva-o primeiro.");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Tickets.Tests/Tickets.Tests.csproj
+++ b/src/Tests/Tickets.Tests/Tickets.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>Tickets.Tests</RootNamespace>
+		<AssemblyName>Tickets.Tests</AssemblyName>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<NoWarn>$(NoWarn);CA1515;CA1861;CA1707</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NSubstitute" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="coverlet.collector" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\Modules\Tickets\Modules.Tickets\Modules.Tickets.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Tests/Webhooks.Tests/CreateWebhookSubscriptionSsrfValidatorTests.cs
+++ b/src/Tests/Webhooks.Tests/CreateWebhookSubscriptionSsrfValidatorTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FSH.Modules.Webhooks.Contracts.v1.CreateWebhookSubscription;
 using FSH.Modules.Webhooks.Features.v1.CreateWebhookSubscription;
 using FSH.Modules.Webhooks.Services;
+using Webhooks.Tests.Support;
 
 namespace Webhooks.Tests;
 
@@ -13,7 +14,7 @@ namespace Webhooks.Tests;
 /// </summary>
 public sealed class CreateWebhookSubscriptionSsrfValidatorTests
 {
-    private readonly CreateWebhookSubscriptionCommandValidator _validator = new();
+    private readonly CreateWebhookSubscriptionCommandValidator _validator = new(WebhooksResourcesLocalizerFactory.Create());
 
     [Theory]
     [InlineData("http://169.254.169.254/latest/meta-data/")] // cloud instance metadata

--- a/src/Tests/Webhooks.Tests/Localization/WebhooksResourcesTests.cs
+++ b/src/Tests/Webhooks.Tests/Localization/WebhooksResourcesTests.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Linq;
+using FSH.Modules.Webhooks.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Webhooks.Tests.Localization;
+
+// Proves the WebhooksResources catalog is embedded under the correct manifest name (ResourcesPath="" =>
+// co-located marker + resx). A wrong manifest name flips ResourceNotFound and leaks raw keys; a
+// missing pt-BR entry ships English as "translated". Both are caught here.
+public sealed class WebhooksResourcesTests
+{
+    private static IStringLocalizer BuildLocalizer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider()
+            .GetRequiredService<IStringLocalizerFactory>()
+            .Create(typeof(WebhooksResources));
+    }
+
+    private static List<string> KeysFor(string culture)
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            return localizer.GetAllStrings(includeParentCultures: false)
+                .Select(s => s.Name)
+                .ToList();
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+
+    [Fact]
+    public void Neutral_and_ptBR_catalogs_have_matching_keys()
+    {
+        var neutral = KeysFor(string.Empty);   // WebhooksResources.resx (English / fallback)
+        var pt = KeysFor("pt-BR");                 // WebhooksResources.pt-BR.resx
+
+        neutral.ShouldNotBeEmpty();
+        pt.OrderBy(k => k, StringComparer.Ordinal)
+            .ShouldBe(neutral.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Known_key_resolves_and_differs_between_en_and_pt()
+    {
+        var localizer = BuildLocalizer();
+        var previous = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            var en = localizer["Webhooks.SubscriptionNotFound"];
+            en.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Webhooks.SubscriptionNotFound' for en-US — check ResourcesPath/resx manifest name.");
+            en.Value.ShouldBe("Webhook subscription {0} not found.");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-BR");
+            var pt = localizer["Webhooks.SubscriptionNotFound"];
+            pt.ResourceNotFound.ShouldBeFalse(
+                "resx did not resolve 'Webhooks.SubscriptionNotFound' for pt-BR — check the .pt-BR catalog manifest name.");
+            pt.Value.ShouldBe("Inscrição de webhook {0} não encontrada.");
+
+            pt.Value.ShouldNotBe(en.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Tests/Webhooks.Tests/Support/WebhooksResourcesLocalizerFactory.cs
+++ b/src/Tests/Webhooks.Tests/Support/WebhooksResourcesLocalizerFactory.cs
@@ -1,0 +1,19 @@
+using FSH.Modules.Webhooks.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace Webhooks.Tests.Support;
+
+// Builds a REAL IStringLocalizer<WebhooksResources> bound to the embedded resx catalog
+// (ResourcesPath="" — co-located marker + resx) so validators that require a localizer can be
+// instantiated in unit tests exercising the actual catalog rather than a stub.
+internal static class WebhooksResourcesLocalizerFactory
+{
+    public static IStringLocalizer<WebhooksResources> Create()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddLocalization(o => o.ResourcesPath = "");
+        return services.BuildServiceProvider().GetRequiredService<IStringLocalizer<WebhooksResources>>();
+    }
+}

--- a/src/Tests/Webhooks.Tests/Validators/WebhookValidatorTests.cs
+++ b/src/Tests/Webhooks.Tests/Validators/WebhookValidatorTests.cs
@@ -1,20 +1,25 @@
 using FSH.Modules.Webhooks.Contracts.v1.CreateWebhookSubscription;
 using FSH.Modules.Webhooks.Contracts.v1.DeleteWebhookSubscription;
 using FSH.Modules.Webhooks.Contracts.v1.TestWebhookSubscription;
+using FSH.Modules.Webhooks.Localization;
+using Microsoft.Extensions.Localization;
 using FSH.Modules.Webhooks.Features.v1.CreateWebhookSubscription;
 using FSH.Modules.Webhooks.Features.v1.DeleteWebhookSubscription;
 using FSH.Modules.Webhooks.Features.v1.TestWebhookSubscription;
+using Webhooks.Tests.Support;
 
 namespace Webhooks.Tests.Validators;
 
 public sealed class WebhookValidatorTests
 {
+    private static readonly IStringLocalizer<WebhooksResources> Localizer = WebhooksResourcesLocalizerFactory.Create();
+
     #region CreateWebhookSubscription
 
     [Fact]
     public void Create_Should_Pass_When_Url_Absolute_And_Events_Present()
     {
-        var validator = new CreateWebhookSubscriptionCommandValidator();
+        var validator = new CreateWebhookSubscriptionCommandValidator(Localizer);
         var command = new CreateWebhookSubscriptionCommand("https://example.com/hook", ["user.created"], "secret");
 
         var result = validator.Validate(command);
@@ -25,7 +30,7 @@ public sealed class WebhookValidatorTests
     [Fact]
     public void Create_Should_Fail_When_Url_Empty()
     {
-        var validator = new CreateWebhookSubscriptionCommandValidator();
+        var validator = new CreateWebhookSubscriptionCommandValidator(Localizer);
         var command = new CreateWebhookSubscriptionCommand(string.Empty, ["user.created"], null);
 
         var result = validator.Validate(command);
@@ -37,7 +42,7 @@ public sealed class WebhookValidatorTests
     [Fact]
     public void Create_Should_Fail_When_Url_Not_Absolute()
     {
-        var validator = new CreateWebhookSubscriptionCommandValidator();
+        var validator = new CreateWebhookSubscriptionCommandValidator(Localizer);
         var command = new CreateWebhookSubscriptionCommand("not-a-url", ["user.created"], null);
 
         var result = validator.Validate(command);
@@ -49,7 +54,7 @@ public sealed class WebhookValidatorTests
     [Fact]
     public void Create_Should_Fail_When_Url_Relative()
     {
-        var validator = new CreateWebhookSubscriptionCommandValidator();
+        var validator = new CreateWebhookSubscriptionCommandValidator(Localizer);
         var command = new CreateWebhookSubscriptionCommand("/relative/path", ["user.created"], null);
 
         var result = validator.Validate(command);
@@ -60,7 +65,7 @@ public sealed class WebhookValidatorTests
     [Fact]
     public void Create_Should_Fail_When_Events_Empty()
     {
-        var validator = new CreateWebhookSubscriptionCommandValidator();
+        var validator = new CreateWebhookSubscriptionCommandValidator(Localizer);
         var command = new CreateWebhookSubscriptionCommand("https://example.com", [], null);
 
         var result = validator.Validate(command);


### PR DESCRIPTION
Module slice of the i18n work, split out of [#1344](https://github.com/fullstackhero/dotnet-starter-kit/pull/1344). **229 files**, and mechanical: one catalog per module plus the `MessageKey` / `ResourceSource` wiring at each throw and validation site.

> **This PR does not build until the framework slice merges**, and the CI failure below is that and nothing else. It uses `SharedResources`, `SupportedCultures` and the `MessageKey` / `MessageArgs` / `ResourceSource` members on `CustomException`, none of which exist on `main` yet. A PR opened from a fork cannot be based on another PR's branch, so there is no way to stack it. It is up now so you can see the whole shape at once; rebasing it on `main` after the framework PR lands turns it green with no content change. Verified rather than assumed: framework + this slice together build clean and run the full suite green, and the combined tree is byte-identical to `#1344` on every backend path.

The split is four PRs rather than three, because these ~220 files fit none of your three and would have put the framework PR back at ~285.

| Slice | Files | PR |
|---|---|---|
| Framework | 56 | [#1360](https://github.com/fullstackhero/dotnet-starter-kit/pull/1360) — **review this one first** |
| **Module catalogs and wiring** | 229 | this one |
| `clients/admin` | 111 | [#1362](https://github.com/fullstackhero/dotnet-starter-kit/pull/1362) — independent |
| `clients/dashboard` | 134 | [#1363](https://github.com/fullstackhero/dotnet-starter-kit/pull/1363) — independent |

## ⚠️ Touches protected `src/BuildingBlocks` (Golden Rule #4)

**One file: `Web/Validation/PagedQueryValidator.cs`.** Its constructor now takes `IStringLocalizer<SharedResources>` so the paging messages localize. All three subclasses are in modules — `GetAuditsQueryValidator`, `GetTenantsQueryValidator`, `SearchUsersQueryValidator` — so the base class travels with its callers. Leaving it in the framework PR would either break that PR's build (its subclasses on `main` call the old constructor) or drag `AuditingResources` and `GetAuditsQueryHandler` in with it, for no review benefit. The other seventeen `BuildingBlocks` files are declared in the framework PR.

## What is in here

- **One `{Module}Resources` catalog per module**, `en-US` neutral plus `*.pt-BR.resx`, for Auditing, Billing, Catalog, Chat, Files, Multitenancy, Notifications, Tickets and Webhooks, plus the Identity messages outside the `Locale` plumbing.
- **Throw sites carry `MessageKey` and `ResourceSource`.** `Message` stays English, so logs and audit records remain culture-independent while the response body localizes. This is where the 41 `Conflict` throws across Billing and Catalog live — the ones that `#1344` had briefly answering 409 with "an unexpected error occurred" until `TitleKeyFor` was fixed in the framework slice.
- **Validators resolve their messages through `IStringLocalizer`.** Message arguments are kept culture-insensitive: `GetAuditsQueryHandler.MaxWindowDays` is a new `int` constant, replacing `MaxWindow.TotalDays` as a `double` in the two audit-window validators. The localizer formats with `string.Format` under `CurrentCulture`, and a `double` in a localized message is culture-sensitive by construction.
- **`CatalogParityTests`** discovers every catalog by reflection and compares each culture's own key set with `tryParents: false`, plus the placeholder-index set per key. `{1}` present in one culture and not the other throws `FormatException` at render time, in that culture only. New module catalogs are covered without a new test — Notifications had shipped a catalog with no parity test and has no test project to hold one.
- **`Tickets.Tests` joins the solution**, which had no test project for that module.
- A built-in-validation test that asserted only the *absence* of the English string (satisfied equally by a blank message or a leaked resource key) now pins the Portuguese text.

## Testing

Because this slice cannot build alone, the numbers below are framework + this slice, which is what will be on `main` once both land.

- `dotnet restore src/FSH.Starter.slnx` with the audit **on**: exit 0, no `NU1903`.
- `dotnet build -warnaserror`: exit 0.
- Full suite: **15 test assemblies, 1891 passed / 0 failed / 1 skipped**, including Integration (Testcontainers/Postgres, Docker) at 746 passed / 1 skipped. Identical to what #1344 reported for the unsplit branch, and the framework slice alone is 14 assemblies / 1868 passed — so this slice is exactly the 23-test, one-assembly difference, with nothing gained or lost in the cut.
- The combined tree is byte-identical to `#1344` on every path under `src/`, `.agents/` and `AGENTS.md`: `git diff` between them is empty there.

The verdict above is aggregated per assembly rather than taken from the process exit code: `dotnet test` on this solution has been observed exiting 0 while reporting failures, and zero assemblies reporting is itself treated as red.

`dotnet restore` passes with the audit on: `src/Directory.Packages.props` carries the `SSH.NET` pin byte-identical to [#1333](https://github.com/fullstackhero/dotnet-starter-kit/pull/1333), same as the other three slices. See the framework PR for why.

## Docs (Golden Rule #10)

[fullstackhero/docs#238](https://github.com/fullstackhero/docs/pull/238), kept as a single PR covering all four slices. The **String resources** section of `internationalization.mdx` is this slice: the per-module `{Module}Resources` catalogs and how a localized message is wired at a throw or validation site. That PR should merge after the last of the four.
