### PR TITLE
fix(identity): reject stale profile updates with ETag/If-Match instead of losing the write

### DIFF
--- a/clients/dashboard/src/api/identity.ts
+++ b/clients/dashboard/src/api/identity.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "@/lib/api-client";
+import { apiFetch, ApiRequestError } from "@/lib/api-client";
 import type { PagedResponse } from "@/api/catalog";
 
 // -----------------------------
@@ -397,16 +397,52 @@ export type UpdateProfileInput = {
 };
 
 /**
+ * Reads the profile along with the ETag the server publishes for it. The tag is the
+ * profile's version marker: echoing it back in `If-Match` on the PUT below is what lets
+ * the server reject a save built from a snapshot someone else has since changed.
+ */
+async function readProfileWithETag(): Promise<{ profile: UserDto; etag: string | null }> {
+  let etag: string | null = null;
+  const profile = await apiFetch<UserDto>("/api/v1/identity/profile", {
+    onResponse: (response) => {
+      etag = response.headers.get("ETag");
+    },
+  });
+  return { profile, etag };
+}
+
+/**
  * Updates the authenticated user's profile. Maps to UpdateUserCommand
  * server-side. Image and email changes go through their own dedicated
  * endpoints — this is for the editable profile fields surfaced in
  * settings/profile. Reads the current profile first so unset optional
  * fields keep their existing values instead of being nulled.
+ *
+ * That read-modify-write is why the PUT carries `If-Match`: the server answers 412 when
+ * the profile moved in between, instead of accepting a full representation built from a
+ * stale copy and blanking the concurrent change. A 412 is retried once against a fresh
+ * read, because the token also rotates on writes the user never sees as profile edits (a
+ * password change, a failed sign-in, a new avatar) and surfacing those as a failed save
+ * would be noise. A second 412 means the profile is changing faster than this client can
+ * follow, and the error propagates.
  */
 export async function updateMyProfile(input: UpdateProfileInput): Promise<void> {
-  const profile = await getMyProfile();
+  try {
+    await putProfileFromFreshRead(input);
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.status === 412) {
+      await putProfileFromFreshRead(input);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function putProfileFromFreshRead(input: UpdateProfileInput): Promise<void> {
+  const { profile, etag } = await readProfileWithETag();
   await apiFetch<unknown>(`/api/v1/identity/profile`, {
     method: "PUT",
+    headers: etag ? { "If-Match": etag } : undefined,
     body: JSON.stringify({
       id: profile.id,
       firstName: input.firstName ?? profile.firstName ?? null,

--- a/clients/dashboard/src/lib/api-client.ts
+++ b/clients/dashboard/src/lib/api-client.ts
@@ -73,6 +73,13 @@ type RequestInitEx = RequestInit & {
    * uploads) should override this explicitly.
    */
   timeoutMs?: number;
+  /**
+   * Called with the final response before its body is read, so a caller can pick up a
+   * response header `apiFetch` does not model — the `ETag` on `GET /identity/profile`,
+   * which a later `PUT` echoes back in `If-Match`. Runs for error responses too, and
+   * must not throw.
+   */
+  onResponse?: (response: Response) => void;
 };
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -156,7 +163,7 @@ export async function apiFetch<T = unknown>(
   path: string,
   init: RequestInitEx = {},
 ): Promise<T> {
-  const { skipAuth, headers, timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...rest } = init;
+  const { skipAuth, headers, timeoutMs = DEFAULT_TIMEOUT_MS, signal, onResponse, ...rest } = init;
 
   const mergedHeaders = new Headers(headers);
   if (!mergedHeaders.has("Content-Type") && rest.body && typeof rest.body === "string") {
@@ -217,6 +224,8 @@ export async function apiFetch<T = unknown>(
       retryTimer.cleanup();
     }
   }
+
+  onResponse?.(response);
 
   if (!response.ok) {
     const problem = await parseError(response);

--- a/clients/dashboard/tests/settings/profile.spec.ts
+++ b/clients/dashboard/tests/settings/profile.spec.ts
@@ -2,20 +2,22 @@ import { expect, test } from "@playwright/test";
 import { mockJsonResponse, mockProblemDetails } from "../helpers/api-mocks";
 import { seedAuthedSession, TEST_USER } from "../helpers/auth-seed";
 
+const PROFILE = {
+  id: TEST_USER.sub,
+  userName: "alice",
+  email: TEST_USER.email,
+  firstName: TEST_USER.firstName,
+  lastName: TEST_USER.lastName,
+  phoneNumber: "",
+  isActive: true,
+  emailConfirmed: true,
+  twoFactorEnabled: false,
+};
+
 // All settings tests need an authed session and a mocked profile fetch.
 test.beforeEach(async ({ page }) => {
   await seedAuthedSession(page, TEST_USER);
-  await mockJsonResponse(page, "**/api/v1/identity/profile", {
-    id: TEST_USER.sub,
-    userName: "alice",
-    email: TEST_USER.email,
-    firstName: TEST_USER.firstName,
-    lastName: TEST_USER.lastName,
-    phoneNumber: "",
-    isActive: true,
-    emailConfirmed: true,
-    twoFactorEnabled: false,
-  });
+  await mockJsonResponse(page, "**/api/v1/identity/profile", PROFILE);
 });
 
 test.describe("settings/profile — wired to PUT /identity/profile", () => {
@@ -105,6 +107,105 @@ test.describe("settings/profile — wired to PUT /identity/profile", () => {
 
     await expect(page.getByText(/save failed/i)).toBeVisible();
     await expect(page.getByText(/first name cannot be empty/i)).toBeVisible();
+  });
+
+  // The dashboard talks to the API cross-origin in dev, and `ETag` is not a CORS-safelisted
+  // response header — the browser hides it from JS unless the server also sends
+  // `Access-Control-Expose-Headers: ETag`. These mocks send it for the same reason the API
+  // has to: without it the client reads `null` and silently stops sending `If-Match`.
+  const ETAG_CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Expose-Headers": "ETag",
+  } as const;
+
+  test("echoes the profile ETag back as If-Match on save", async ({ page }) => {
+    const etag = '"stamp-1"';
+    await page.route("**/api/v1/identity/profile", async (route) => {
+      if (route.request().method() === "PUT") {
+        await route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: '""',
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { ...ETAG_CORS_HEADERS, ETag: etag },
+        body: JSON.stringify(PROFILE),
+      });
+    });
+
+    await page.goto("/settings/profile");
+    await expect(page.getByLabel("First name")).toHaveValue("Alice");
+
+    await page.getByLabel("First name").fill("Alicia");
+
+    const putReqPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/identity/profile") &&
+        req.method() === "PUT" &&
+        !req.url().includes("/image"),
+      { timeout: 5_000 },
+    );
+    await page.getByRole("button", { name: /save changes/i }).click();
+    const putReq = await putReqPromise;
+
+    // Without this the server cannot tell a deliberate overwrite from a lost update.
+    expect(putReq.headers()["if-match"]).toBe(etag);
+  });
+
+  test("refetches and retries once when the save is rejected with 412", async ({ page }) => {
+    // The token also rotates on writes the user never sees as profile edits (a password
+    // change, a failed sign-in, a new avatar), so a single 412 has to resolve itself
+    // against a fresh read instead of surfacing as a failed save.
+    const sentIfMatch: string[] = [];
+    let getCount = 0;
+
+    await page.route("**/api/v1/identity/profile", async (route) => {
+      const request = route.request();
+      if (request.method() === "PUT") {
+        sentIfMatch.push(request.headers()["if-match"] ?? "");
+        if (sentIfMatch.length === 1) {
+          await route.fulfill({
+            status: 412,
+            headers: { "Content-Type": "application/problem+json" },
+            body: JSON.stringify({
+              status: 412,
+              title: "CustomException",
+              detail: "The profile changed since you loaded it.",
+            }),
+          });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: '""',
+        });
+        return;
+      }
+
+      // Every read hands out a fresh token, so the retry provably carries a re-read one.
+      getCount += 1;
+      await route.fulfill({
+        status: 200,
+        headers: { ...ETAG_CORS_HEADERS, ETag: `"stamp-${getCount}"` },
+        body: JSON.stringify(PROFILE),
+      });
+    });
+
+    await page.goto("/settings/profile");
+    await expect(page.getByLabel("First name")).toHaveValue("Alice");
+
+    await page.getByLabel("First name").fill("Alicia");
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    await expect(page.getByText(/profile saved/i)).toBeVisible();
+    await expect(page.getByText(/save failed/i)).toBeHidden();
+    expect(sentIfMatch).toHaveLength(2);
+    expect(sentIfMatch[0]).not.toBe("");
+    expect(sentIfMatch[1]).not.toBe(sentIfMatch[0]);
   });
 
   test("Reset button reverts edits to the original profile values", async ({ page }) => {

--- a/clients/dashboard/tests/settings/profile.spec.ts
+++ b/clients/dashboard/tests/settings/profile.spec.ts
@@ -111,8 +111,10 @@ test.describe("settings/profile — wired to PUT /identity/profile", () => {
 
   // The dashboard talks to the API cross-origin in dev, and `ETag` is not a CORS-safelisted
   // response header — the browser hides it from JS unless the server also sends
-  // `Access-Control-Expose-Headers: ETag`. These mocks send it for the same reason the API
-  // has to: without it the client reads `null` and silently stops sending `If-Match`.
+  // `Access-Control-Expose-Headers: ETag`. These mocks mirror what the CORS policy now sends;
+  // without it the client reads `null` and silently stops sending `If-Match`. The server side of
+  // that contract is asserted by `GetProfile_Should_ExposeETagToCrossOriginCallers_When_ProfileIsRead`,
+  // since a mock alone would keep passing if the policy stopped exposing the header.
   const ETAG_CORS_HEADERS = {
     "Content-Type": "application/json",
     "Access-Control-Expose-Headers": "ETag",

--- a/src/BuildingBlocks/Web/Cors/Extensions.cs
+++ b/src/BuildingBlocks/Web/Cors/Extensions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using System;
 using AspNetCorsOptions = Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions;
 
@@ -53,6 +54,12 @@ public static class Extensions
                             .WithMethods(settings.AllowedMethods)
                             .AllowCredentials();
                     }
+
+                    // `ETag` is not a CORS-safelisted response header, so a browser hides it from JS on any
+                    // cross-origin call — and a front-end that cannot read the validator cannot send
+                    // `If-Match`, which degrades an optimistic-concurrency endpoint back to a lost update.
+                    // Exposed for both policies: the header carries no data of its own, only a validator.
+                    builder.WithExposedHeaders(HeaderNames.ETag);
                 });
             });
         });

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -143,5 +143,12 @@
          AccessViolation). Transitive pinning is enabled, so this entry alone bumps it.
          Remove once the SignalR backplane package depends on a patched version itself. -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <!-- Pulled transitively by the Testcontainers packages; versions up to 2025.1.0 fail
+         NuGet audit (NU1903, GHSA-q939-rpr3-3284 / CVE-2026-48798: ScpClient recursive
+         download writes outside the target directory), which breaks restore for the whole
+         solution under TreatWarningsAsErrors. Testcontainers 4.11.0 and 4.13.0 both depend
+         on 2025.1.0, so bumping Testcontainers does not help; 2026.0.0 is the first patched
+         release. Remove once Testcontainers depends on a patched version itself. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Host/FSH.Starter.Api/appsettings.Production.json
+++ b/src/Host/FSH.Starter.Api/appsettings.Production.json
@@ -59,7 +59,7 @@
   "CorsOptions": {
     "AllowAll": false,
     "AllowedOrigins": [],
-    "AllowedHeaders": [ "content-type", "authorization" ],
+    "AllowedHeaders": [ "content-type", "authorization", "if-match" ],
     "AllowedMethods": [ "GET", "POST", "PUT", "DELETE" ]
   },
   "JwtOptions": {

--- a/src/Host/FSH.Starter.Api/appsettings.json
+++ b/src/Host/FSH.Starter.Api/appsettings.json
@@ -100,7 +100,7 @@
       "http://localhost:5173",
       "http://localhost:5174"
     ],
-    "AllowedHeaders": [ "content-type", "authorization" ],
+    "AllowedHeaders": [ "content-type", "authorization", "if-match" ],
     "AllowedMethods": [ "GET", "POST", "PUT", "DELETE" ]
   },
   "JwtOptions": {

--- a/src/Modules/Identity/Modules.Identity.Contracts/DTOs/UserDto.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/DTOs/UserDto.cs
@@ -1,4 +1,6 @@
-﻿namespace FSH.Modules.Identity.Contracts.DTOs;
+﻿using System.Text.Json.Serialization;
+
+namespace FSH.Modules.Identity.Contracts.DTOs;
 
 public class UserDto
 {
@@ -22,4 +24,12 @@ public class UserDto
 
     /// <summary>Whether the user has enrolled in TOTP-based two-factor authentication.</summary>
     public bool TwoFactorEnabled { get; set; }
+
+    /// <summary>
+    /// The stored optimistic-concurrency token for this user, populated only by the self-profile
+    /// read. It never reaches the response body — <c>GET /identity/profile</c> turns it into the
+    /// response's <c>ETag</c>, and that header is the token clients echo back in <c>If-Match</c>.
+    /// </summary>
+    [JsonIgnore]
+    public string? ConcurrencyStamp { get; set; }
 }

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserProfileService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserProfileService.cs
@@ -24,9 +24,11 @@ public interface IUserProfileService
     Task<int> GetCountAsync(CancellationToken cancellationToken);
 
     /// <summary>
-    /// Updates a user's profile.
+    /// Updates a user's profile. When <paramref name="expectedConcurrencyStamps"/> is non-null the
+    /// update is rejected with <see cref="System.Net.HttpStatusCode.PreconditionFailed"/> unless the
+    /// stored concurrency token matches one of the entries — the caller edited a stale copy.
     /// </summary>
-    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default);
+    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, IReadOnlyList<string>? expectedConcurrencyStamps, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets the profile image URL directly (no upload). Used by the presigned-upload flow:

--- a/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/Services/IUserService.cs
@@ -15,7 +15,7 @@ public interface IUserService
     Task ToggleStatusAsync(bool activateUser, string userId, CancellationToken cancellationToken);
     Task<string> GetOrCreateFromPrincipalAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default);
     Task<string> RegisterAsync(string firstName, string lastName, string email, string userName, string password, string confirmPassword, string phoneNumber, string origin, CancellationToken cancellationToken);
-    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default);
+    Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, IReadOnlyList<string>? expectedConcurrencyStamps, CancellationToken cancellationToken = default);
     Task DeleteAsync(string userId, CancellationToken cancellationToken = default);
     Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken);
     Task AdminConfirmEmailAsync(string userId, CancellationToken cancellationToken = default);

--- a/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/UpdateUser/UpdateUserCommand.cs
+++ b/src/Modules/Identity/Modules.Identity.Contracts/v1/Users/UpdateUser/UpdateUserCommand.cs
@@ -1,5 +1,6 @@
 using FSH.Framework.Shared.Storage;
 using Mediator;
+using System.Text.Json.Serialization;
 
 namespace FSH.Modules.Identity.Contracts.v1.Users.UpdateUser;
 
@@ -12,4 +13,16 @@ public class UpdateUserCommand : ICommand<Unit>
     public string? Email { get; set; }
     public FileUploadRequest? Image { get; set; }
     public bool DeleteCurrentImage { get; set; }
+
+    /// <summary>
+    /// Concurrency tokens the caller is willing to overwrite, taken from the request's
+    /// <c>If-Match</c> header by the endpoint. <see langword="null"/> means the caller sent no
+    /// precondition and accepts whatever version is stored; a non-null list means the update
+    /// only proceeds when the stored token matches one of the entries.
+    /// </summary>
+    /// <remarks>
+    /// Header-derived, never read from the request body — the endpoint always overwrites it.
+    /// </remarks>
+    [JsonIgnore]
+    public IReadOnlyList<string>? ExpectedConcurrencyStamps { get; set; }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserProfile/GetUserProfileEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserProfile/GetUserProfileEndpoint.cs
@@ -6,6 +6,7 @@ using Mediator;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
 using System.Security.Claims;
 
 namespace FSH.Modules.Identity.Features.v1.Users.GetUserProfile;
@@ -14,18 +15,29 @@ public static class GetUserProfileEndpoint
 {
     internal static RouteHandlerBuilder MapGetMeEndpoint(this IEndpointRouteBuilder endpoints)
     {
-        return endpoints.MapGet("/profile", async (ClaimsPrincipal user, IMediator mediator, CancellationToken cancellationToken) =>
+        return endpoints.MapGet("/profile", async (ClaimsPrincipal user, HttpResponse response, IMediator mediator, CancellationToken cancellationToken) =>
         {
             if (user.GetUserId() is not { } userId || string.IsNullOrEmpty(userId))
             {
                 throw new UnauthorizedException();
             }
 
-            return TypedResults.Ok(await mediator.Send(new GetCurrentUserProfileQuery(userId), cancellationToken));
+            var profile = await mediator.Send(new GetCurrentUserProfileQuery(userId), cancellationToken);
+
+            // The profile is a full-representation resource: PUT /profile rewrites every field, so
+            // a caller editing a stale copy would blank whatever changed meanwhile. Publishing the
+            // stored concurrency token as a strong ETag lets that caller echo it back in If-Match
+            // and have the server reject the stale write.
+            if (!string.IsNullOrEmpty(profile.ConcurrencyStamp))
+            {
+                response.Headers.ETag = new EntityTagHeaderValue($"\"{profile.ConcurrencyStamp}\"", isWeak: false).ToString();
+            }
+
+            return TypedResults.Ok(profile);
         })
         .WithName("GetCurrentUserProfile")
         .WithSummary("Get current user profile")
-        .WithDescription("Retrieve the authenticated user's profile from the access token.")
+        .WithDescription("Retrieve the authenticated user's profile from the access token. The response carries a strong ETag — echo it in If-Match on PUT /identity/profile to reject a lost update.")
         .RequireAuthorization()
         .Produces<UserDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized);

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandHandler.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserCommandHandler.cs
@@ -24,6 +24,7 @@ public sealed class UpdateUserCommandHandler : ICommandHandler<UpdateUserCommand
             command.PhoneNumber ?? string.Empty,
             command.Image!,
             command.DeleteCurrentImage,
+            command.ExpectedConcurrencyStamps,
             cancellationToken).ConfigureAwait(false);
 
         return Unit.Value;

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/UpdateUser/UpdateUserEndpoint.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
 using System.Security.Claims;
 
 namespace FSH.Modules.Identity.Features.v1.Users.UpdateUser;
@@ -14,7 +15,7 @@ public static class UpdateUserEndpoint
 {
     internal static RouteHandlerBuilder MapUpdateUserEndpoint(this IEndpointRouteBuilder endpoints)
     {
-        return endpoints.MapPut("/profile", async ([FromBody] UpdateUserCommand request, ClaimsPrincipal user, IMediator mediator, CancellationToken cancellationToken) =>
+        return endpoints.MapPut("/profile", async ([FromBody] UpdateUserCommand request, ClaimsPrincipal user, HttpRequest httpRequest, IMediator mediator, CancellationToken cancellationToken) =>
         {
             if (user.GetUserId() is not { } userId || string.IsNullOrEmpty(userId))
             {
@@ -25,15 +26,54 @@ public static class UpdateUserEndpoint
             // only, regardless of any id the caller supplied in the body.
             request.Id = userId;
 
+            // Header-derived, so it overwrites whatever the body carried.
+            request.ExpectedConcurrencyStamps = ReadExpectedConcurrencyStamps(httpRequest);
+
             await mediator.Send(request, cancellationToken);
             return TypedResults.Ok();
         })
         .WithName("UpdateUserProfile")
         .WithSummary("Update user profile")
         .RequireAuthorization()
-        .WithDescription("Update profile details for the authenticated user. Any signed-in user may edit their own profile; no admin permission required.")
+        .WithDescription("Update profile details for the authenticated user. Any signed-in user may edit their own profile; no admin permission required. Echo the ETag from GET /identity/profile in If-Match and a stale full-representation update is rejected with 412 instead of silently overwriting a concurrent change.")
         .Produces(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
-        .Produces(StatusCodes.Status400BadRequest);
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status412PreconditionFailed);
+    }
+
+    /// <summary>
+    /// Turns the request's <c>If-Match</c> header into the set of concurrency tokens the caller is
+    /// willing to overwrite. Returns <see langword="null"/> when there is no precondition to
+    /// enforce: either the header is absent, or it is <c>*</c>, which asks only that the resource
+    /// exist — and it does, or the update answers 404 on its own.
+    /// </summary>
+    private static List<string>? ReadExpectedConcurrencyStamps(HttpRequest request)
+    {
+        var ifMatch = request.Headers.IfMatch;
+        if (ifMatch.Count == 0)
+        {
+            return null;
+        }
+
+        if (!EntityTagHeaderValue.TryParseStrictList(ifMatch, out var entityTags))
+        {
+            // Answering 412 would send a well-behaved client into a refetch-and-retry loop it can
+            // never win, since the malformed header is its own bug. 400 names the bug instead.
+            throw new BadHttpRequestException("The If-Match header is not a valid entity-tag list.");
+        }
+
+        if (entityTags.Contains(EntityTagHeaderValue.Any))
+        {
+            return null;
+        }
+
+        // If-Match mandates the strong comparison function, so a weak validator can never match.
+        // Dropping the weak entries leaves a list no stored token matches, which is exactly the
+        // 412 the RFC asks for.
+        return entityTags
+            .Where(entityTag => !entityTag.IsWeak)
+            .Select(entityTag => entityTag.Tag.ToString().Trim('"'))
+            .ToList();
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserProfileService.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using System.Net;
 
 namespace FSH.Modules.Identity.Services;
 
@@ -21,6 +22,7 @@ internal sealed class UserProfileService(
     IStorageService storageService,
     IMultiTenantContextAccessor<AppTenantInfo> multiTenantContextAccessor,
     IOptions<OriginOptions> originOptions,
+    IdentityErrorDescriber errorDescriber,
     IHttpContextAccessor httpContextAccessor) : IUserProfileService
 {
     private readonly Uri? _originUrl = originOptions.Value.OriginUrl;
@@ -48,6 +50,7 @@ internal sealed class UserProfileService(
             EmailConfirmed = user.EmailConfirmed,
             PhoneNumber = user.PhoneNumber,
             TwoFactorEnabled = user.TwoFactorEnabled,
+            ConcurrencyStamp = user.ConcurrencyStamp,
         };
     }
 
@@ -75,11 +78,17 @@ internal sealed class UserProfileService(
         return result;
     }
 
-    public async Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default)
+    public async Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, IReadOnlyList<string>? expectedConcurrencyStamps, CancellationToken cancellationToken = default)
     {
         var user = await userManager.FindByIdAsync(userId);
 
         _ = user ?? throw new NotFoundException("user not found");
+
+        // This is a full-representation update, so a caller working from a stale read would
+        // silently blank whatever changed since. The precondition is checked here, before the
+        // storage calls below: a rejected update must not leave an orphan upload behind, and on
+        // the deleteCurrentImage path it must not remove the avatar with no database change.
+        EnsureConcurrencyStampMatches(user, expectedConcurrencyStamps);
 
         Uri imageUri = user.ImageUrl ?? null!;
         // image is optional: text-only edits forward a null FileUploadRequest, so guard before
@@ -108,13 +117,46 @@ internal sealed class UserProfileService(
         }
 
         var result = await userManager.UpdateAsync(user);
-        await signInManager.RefreshSignInAsync(user);
 
         if (!result.Succeeded)
         {
+            // Identity's store answers a lost race with ConcurrencyFailure instead of throwing,
+            // so it would otherwise surface as a generic 500. It is the same condition the
+            // If-Match check above reports, just detected one layer down: another writer landed
+            // between our read and our save.
+            if (result.Errors.Any(error => string.Equals(error.Code, errorDescriber.ConcurrencyFailure().Code, StringComparison.Ordinal)))
+            {
+                throw StaleProfileException();
+            }
+
             throw new CustomException("Update profile failed");
         }
+
+        await signInManager.RefreshSignInAsync(user);
     }
+
+    private static void EnsureConcurrencyStampMatches(FshUser user, IReadOnlyList<string>? expectedConcurrencyStamps)
+    {
+        // A null list means the caller sent no If-Match and accepts the stored version as-is.
+        // ponytail: keep the precondition optional for backward compatibility; a future major can
+        // require it and answer 428 Precondition Required when the header is missing.
+        if (expectedConcurrencyStamps is null)
+        {
+            return;
+        }
+
+        var storedStamp = user.ConcurrencyStamp;
+        if (storedStamp is null || !expectedConcurrencyStamps.Contains(storedStamp, StringComparer.Ordinal))
+        {
+            throw StaleProfileException();
+        }
+    }
+
+    private static CustomException StaleProfileException() =>
+        new(
+            "The profile changed since you loaded it. Reload it and apply your changes again.",
+            errors: null,
+            HttpStatusCode.PreconditionFailed);
 
     public async Task SetImageUrlAsync(string userId, string? imageUrl, CancellationToken cancellationToken)
     {

--- a/src/Modules/Identity/Modules.Identity/Services/UserService.cs
+++ b/src/Modules/Identity/Modules.Identity/Services/UserService.cs
@@ -55,8 +55,8 @@ internal sealed class UserService(
     public Task<int> GetCountAsync(CancellationToken cancellationToken)
         => profileService.GetCountAsync(cancellationToken);
 
-    public Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, CancellationToken cancellationToken = default)
-        => profileService.UpdateAsync(userId, firstName, lastName, phoneNumber, image, deleteCurrentImage, cancellationToken);
+    public Task UpdateAsync(string userId, string firstName, string lastName, string phoneNumber, FileUploadRequest image, bool deleteCurrentImage, IReadOnlyList<string>? expectedConcurrencyStamps, CancellationToken cancellationToken = default)
+        => profileService.UpdateAsync(userId, firstName, lastName, phoneNumber, image, deleteCurrentImage, expectedConcurrencyStamps, cancellationToken);
 
     public Task<bool> ExistsWithEmailAsync(string email, string? exceptId = null, CancellationToken cancellationToken = default)
         => profileService.ExistsWithEmailAsync(email, exceptId, cancellationToken);

--- a/src/Tests/Framework.Tests/Web/CorsPolicyTests.cs
+++ b/src/Tests/Framework.Tests/Web/CorsPolicyTests.cs
@@ -1,0 +1,46 @@
+using FSH.Framework.Web.Cors;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using AspNetCorsOptions = Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions;
+
+namespace Framework.Tests.Web;
+
+public sealed class CorsPolicyTests
+{
+    private const string PolicyName = "FSHCorsPolicy";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Policy_Should_ExposeETag_When_Built(bool allowAll)
+    {
+        // Arrange — ETag is not a CORS-safelisted response header, so a front-end can only read the
+        // concurrency validator (and answer with If-Match) if the policy exposes it explicitly.
+        // Both branches are covered: the restricted one builds from configured lists, and neither
+        // AllowAnyHeader nor WithHeaders implies exposure.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CorsOptions:AllowAll"] = allowAll ? "true" : "false",
+                ["CorsOptions:AllowedOrigins:0"] = "https://app.example.com",
+                ["CorsOptions:AllowedHeaders:0"] = "content-type",
+                ["CorsOptions:AllowedMethods:0"] = "GET"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddHeroCors(configuration);
+
+        // Act
+        var policy = services
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<AspNetCorsOptions>>()
+            .Value
+            .GetPolicy(PolicyName);
+
+        // Assert
+        policy.ShouldNotBeNull();
+        policy!.ExposedHeaders.ShouldContain("ETag");
+    }
+}

--- a/src/Tests/Identity.Tests/Handlers/UpdateUserCommandHandlerTests.cs
+++ b/src/Tests/Identity.Tests/Handlers/UpdateUserCommandHandlerTests.cs
@@ -39,7 +39,31 @@ public sealed class UpdateUserCommandHandlerTests
             command.LastName ?? string.Empty,
             command.PhoneNumber ?? string.Empty,
             command.Image!,
-            command.DeleteCurrentImage);
+            command.DeleteCurrentImage,
+            command.ExpectedConcurrencyStamps);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ForwardExpectedConcurrencyStamps_When_CallerSentIfMatch()
+    {
+        // Arrange — the endpoint fills ExpectedConcurrencyStamps from the If-Match header; the
+        // handler has to carry it through or the precondition is silently dropped.
+        var command = _fixture.Create<UpdateUserCommand>();
+        var stamps = new List<string> { "stamp-a", "stamp-b" };
+        command.ExpectedConcurrencyStamps = stamps;
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _userService.Received(1).UpdateAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<FSH.Framework.Shared.Storage.FileUploadRequest>(),
+            Arg.Any<bool>(),
+            Arg.Is<IReadOnlyList<string>?>(actual => actual != null && actual.SequenceEqual(stamps)));
     }
 
     [Fact]
@@ -66,7 +90,8 @@ public sealed class UpdateUserCommandHandlerTests
             string.Empty,
             string.Empty,
             null!,
-            true);
+            true,
+            null);
     }
 
     [Fact]
@@ -83,7 +108,7 @@ public sealed class UpdateUserCommandHandlerTests
         // Arrange
         var command = _fixture.Create<UpdateUserCommand>();
         var expectedExceptionMessage = "Update failed";
-        _userService.UpdateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<FSH.Framework.Shared.Storage.FileUploadRequest>(), Arg.Any<bool>())
+        _userService.UpdateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<FSH.Framework.Shared.Storage.FileUploadRequest>(), Arg.Any<bool>(), Arg.Any<IReadOnlyList<string>?>())
             .Returns(x => throw new InvalidOperationException(expectedExceptionMessage));
 
         // Act & Assert

--- a/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
@@ -306,7 +306,7 @@ public sealed class UserProfileTests
         dto.FirstName.ShouldBe("Concurrent");
     }
 
-    [Fact(Skip = "Blocked on CORS: FSH.Framework.Web.Cors never calls WithExposedHeaders, so a browser hides the ETag from JS on a cross-origin call and the precondition silently degrades to the old lost-update behaviour. Drop the Skip once ETag is exposed.")]
+    [Fact]
     public async Task GetProfile_Should_ExposeETagToCrossOriginCallers_When_ProfileIsRead()
     {
         // Arrange — ETag is not a CORS-safelisted response header, so the contract only reaches a

--- a/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
@@ -274,9 +274,10 @@ public sealed class UserProfileTests
     [Fact]
     public async Task UpdateProfile_Should_KeepAvatar_When_IfMatchIsStaleAndDeleteCurrentImageRequested()
     {
-        // Arrange — the precondition is checked before the storage calls run. Checking it any later
-        // would delete the avatar (and orphan uploads) on a request that then answers 412 and
-        // changes nothing in the database.
+        // Arrange — a rejected delete-my-avatar request must leave the profile exactly as it was.
+        // The precondition runs as the first statement after the user is loaded, ahead of the
+        // storage calls and of SetPhoneNumberAsync (which persists on its own), so a 412 cannot
+        // leave a half-applied update behind.
         using var adminClient = await _auth.CreateRootAdminClientAsync();
         var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-image");
         using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
@@ -302,6 +303,7 @@ public sealed class UserProfileTests
         var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
         var dto = await profile.DeserializeAsync<UserDto>();
         dto.ImageUrl.ShouldBe(imageUrl);
+        dto.FirstName.ShouldBe("Concurrent");
     }
 
     private static async Task<string> ReadProfileETagAsync(HttpClient client)

--- a/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
@@ -306,6 +306,33 @@ public sealed class UserProfileTests
         dto.FirstName.ShouldBe("Concurrent");
     }
 
+    [Fact(Skip = "Blocked on CORS: FSH.Framework.Web.Cors never calls WithExposedHeaders, so a browser hides the ETag from JS on a cross-origin call and the precondition silently degrades to the old lost-update behaviour. Drop the Skip once ETag is exposed.")]
+    public async Task GetProfile_Should_ExposeETagToCrossOriginCallers_When_ProfileIsRead()
+    {
+        // Arrange — ETag is not a CORS-safelisted response header, so the contract only reaches a
+        // front-end if the server also lists it in Access-Control-Expose-Headers. Asserted here
+        // rather than left as a comment: the front-end specs mock the header, so nothing else in
+        // the suite notices when the server stops sending it.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-cors");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{TestConstants.IdentityBasePath}/profile");
+        request.Headers.TryAddWithoutValidation("Origin", "http://localhost:5174");
+
+        // Act
+        var response = await userClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+        response.Headers.TryGetValues("Access-Control-Expose-Headers", out var exposedHeaders).ShouldBeTrue();
+        exposedHeaders!
+            .SelectMany(value => value.Split(','))
+            .Select(value => value.Trim())
+            .ShouldContain(value => string.Equals(value, "ETag", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static async Task<string> ReadProfileETagAsync(HttpClient client)
     {
         var response = await client.GetAsync($"{TestConstants.IdentityBasePath}/profile");

--- a/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
+++ b/src/Tests/Integration.Tests/Tests/Users/UserProfileTests.cs
@@ -113,6 +113,225 @@ public sealed class UserProfileTests
 
     #endregion
 
+    #region Optimistic concurrency (ETag / If-Match)
+
+    [Fact]
+    public async Task GetProfile_Should_ReturnStrongETag_When_ProfileIsRead()
+    {
+        // Arrange
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-read");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        // Act
+        var response = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+
+        // Assert — If-Match mandates strong comparison, so the tag must not be weak.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+        response.Headers.ETag!.IsWeak.ShouldBeFalse();
+        response.Headers.ETag.Tag.ShouldStartWith("\"");
+        response.Headers.ETag.Tag.ShouldEndWith("\"");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_PersistAndRotateETag_When_IfMatchMatches()
+    {
+        // Arrange
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-match");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+        var etag = await ReadProfileETagAsync(userClient);
+
+        // Act
+        var response = await PutProfileAsync(userClient, new { firstName = "Matched" }, etag);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var reread = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await reread.DeserializeAsync<UserDto>();
+        dto.FirstName.ShouldBe("Matched");
+
+        // The token has to move, or a second save built from the same snapshot would be accepted.
+        reread.Headers.ETag!.ToString().ShouldNotBe(etag);
+        var replay = await PutProfileAsync(userClient, new { firstName = "Replayed" }, etag);
+        replay.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_Return412AndKeepConcurrentChange_When_IfMatchIsStale()
+    {
+        // Arrange — the lost update itself: a caller reads, someone else writes, and the caller's
+        // full-representation PUT would otherwise echo every old value back over that write.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-stale");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        var staleETag = await ReadProfileETagAsync(userClient);
+
+        // A concurrent writer lands between that read and the write below.
+        var concurrent = await PutProfileAsync(
+            userClient,
+            new { firstName = "Concurrent", lastName = "Winner", phoneNumber = "5550001111" },
+            ifMatch: null);
+        concurrent.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act — the first caller saves the snapshot it loaded before that write.
+        var response = await PutProfileAsync(
+            userClient,
+            new { firstName = "Stale", lastName = "Loser", phoneNumber = "5559998888" },
+            staleETag);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+
+        var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await profile.DeserializeAsync<UserDto>();
+        dto.FirstName.ShouldBe("Concurrent");
+        dto.LastName.ShouldBe("Winner");
+        dto.PhoneNumber.ShouldBe("5550001111");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_Succeed_When_IfMatchIsAny()
+    {
+        // Arrange — `*` asks only that the resource exist, so it must not block the update.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-any");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        // Act
+        var response = await PutProfileAsync(userClient, new { firstName = "Wildcard" }, "*");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await profile.DeserializeAsync<UserDto>();
+        dto.FirstName.ShouldBe("Wildcard");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_Return412_When_IfMatchIsWeak()
+    {
+        // Arrange — a weak validator can never satisfy the strong comparison If-Match requires,
+        // even when the tag it carries is the current one.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-weak");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+        var etag = await ReadProfileETagAsync(userClient);
+
+        // Act
+        var response = await PutProfileAsync(userClient, new { firstName = "Weak" }, $"W/{etag}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+
+        var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await profile.DeserializeAsync<UserDto>();
+        dto.FirstName.ShouldNotBe("Weak");
+    }
+
+    [Theory]
+    [InlineData("not-an-entity-tag")]
+    [InlineData("\"unterminated")]
+    public async Task UpdateProfile_Should_Return400_When_IfMatchIsMalformed(string ifMatch)
+    {
+        // Arrange — a malformed header is the client's own bug. 412 would send it into a
+        // refetch-and-retry loop it can never win, so the request is rejected as a bad request.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-bad");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        // Act
+        var response = await PutProfileAsync(userClient, new { firstName = "Malformed" }, ifMatch);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_Succeed_When_IfMatchListContainsCurrentETag()
+    {
+        // Arrange — If-Match takes a list; matching any entry is enough.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-list");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+        var etag = await ReadProfileETagAsync(userClient);
+
+        // Act
+        var response = await PutProfileAsync(userClient, new { firstName = "Listed" }, $"\"someone-elses-tag\", {etag}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await profile.DeserializeAsync<UserDto>();
+        dto.FirstName.ShouldBe("Listed");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_Should_KeepAvatar_When_IfMatchIsStaleAndDeleteCurrentImageRequested()
+    {
+        // Arrange — the precondition is checked before the storage calls run. Checking it any later
+        // would delete the avatar (and orphan uploads) on a request that then answers 412 and
+        // changes nothing in the database.
+        using var adminClient = await _auth.CreateRootAdminClientAsync();
+        var user = await IdentityUserSeeder.CreateLoginableUserAsync(_factory, adminClient, "etag-image");
+        using var userClient = await _auth.CreateAuthenticatedClientAsync(user.Email, user.Password);
+
+        const string imageUrl = "https://cdn.example.com/avatars/keep-me.png";
+        var setImage = await userClient.PutAsJsonAsync(
+            $"{TestConstants.IdentityBasePath}/profile/image", new { imageUrl });
+        setImage.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        var staleETag = await ReadProfileETagAsync(userClient);
+        var concurrent = await PutProfileAsync(userClient, new { firstName = "Concurrent" }, ifMatch: null);
+        concurrent.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act
+        var response = await PutProfileAsync(
+            userClient,
+            new { firstName = "Stale", deleteCurrentImage = true },
+            staleETag);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+
+        var profile = await userClient.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        var dto = await profile.DeserializeAsync<UserDto>();
+        dto.ImageUrl.ShouldBe(imageUrl);
+    }
+
+    private static async Task<string> ReadProfileETagAsync(HttpClient client)
+    {
+        var response = await client.GetAsync($"{TestConstants.IdentityBasePath}/profile");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+        return response.Headers.ETag!.ToString();
+    }
+
+    private static async Task<HttpResponseMessage> PutProfileAsync(HttpClient client, object body, string? ifMatch)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"{TestConstants.IdentityBasePath}/profile")
+        {
+            Content = JsonContent.Create(body)
+        };
+
+        if (ifMatch is not null)
+        {
+            // Unvalidated on purpose: the malformed-header cases have to reach the server.
+            request.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        }
+
+        return await client.SendAsync(request);
+    }
+
+    #endregion
+
     #region SetProfileImage (PUT /profile/image)
 
     [Fact]


### PR DESCRIPTION
## What

`PUT /identity/profile` is a full-representation update with no concurrency token, so two
overlapping self-updates silently lose one another's changes (#1359). This adds an optimistic
precondition: `GET /identity/profile` returns a strong `ETag`, `PUT` honours `If-Match`, and a
stale token is answered with `412 Precondition Failed` instead of overwriting the newer write.

Closes #1359.

## The token is already there — no migration

The issue's own suggested fix proposed a new `RowVersion`/`xmin` column. That isn't needed:
`AspNetUsers.ConcurrencyStamp` is already mapped `IsConcurrencyToken()` in the snapshot, and
ASP.NET Identity's `UserStore.UpdateAsync` rotates it on every write. It can serve as the
validator directly, which keeps this change at zero schema impact and avoids carrying two
concurrency tokens on one entity.

The stamp is exposed as the `ETag` and never as a body field (`[JsonIgnore]` on
`UserDto.ConcurrencyStamp`), so it stays out of the OpenAPI contract and cannot be spoofed
through the request body.

## Behaviour

| Request | Result |
|---|---|
| No `If-Match` | Accepted, as before. Backward compatible. |
| `If-Match` matching the stored stamp | Accepted; the stamp rotates. |
| `If-Match: *` | Accepted (RFC 9110: matches any current representation). |
| Stale `If-Match` | `412`, nothing written. |
| Weak validator (`W/"..."`) | `412` — `If-Match` mandates the strong comparison function. |
| Malformed header | `400`, not `412`: a `412` would send a well-behaved client into a refetch-and-retry loop it can never win, since the malformed header is its own bug. |

Two smaller fixes fell out of this:

- `UserManager.UpdateAsync` answers a lost race with `IdentityResult.Failed(ConcurrencyFailure())`
  rather than throwing, so it used to surface as a generic `500`. It now maps to the same `412`.
- `RefreshSignInAsync` ran *before* the success check, refreshing the sign-in even when the update
  had failed. It now runs only on success.

## Ordering matters

The precondition is checked immediately after `FindByIdAsync`, ahead of the storage calls and
ahead of `SetPhoneNumberAsync`. Anywhere later and a `412` would already have orphaned an upload,
or — on the `deleteCurrentImage` path — deleted the avatar with no database change to show for it.
`UpdateProfile_Should_KeepAvatar_When_IfMatchIsStaleAndDeleteCurrentImageRequested` covers exactly
that; I confirmed it goes red if the guard is moved down.

Worth naming for reviewers: `SetPhoneNumberAsync` is a **second** database write and its
`IdentityResult` is discarded (pre-existing, untouched here). The handler is therefore not atomic
across the two writes. A phone-number race is still reported, because the subsequent `UpdateAsync`
also fails and that failure now maps to `412` — but the mechanism is that mapping, not atomicity.

## Client

`clients/dashboard` reads the `ETag` from the profile fetch, echoes it as `If-Match` on save, and
retries **once** on `412` against a fresh read. The retry is deliberate: the stamp also rotates on
writes the user never perceives as a profile edit (a password change, a failed sign-in, a new
avatar), so a single `412` should resolve itself rather than surface as a failed save.

`clients/admin` has no `PUT /identity/profile` caller on `main`, so nothing to change there. (The
issue text claims both apps write the profile — that part of my own report was wrong.)

## The CORS piece — why this PR touches BuildingBlocks

An `ETag`/`If-Match` contract is a no-op in the browser unless CORS cooperates, and it did not:

- **`ETag` is not a CORS-safelisted response header.** `FSH.Framework.Web.Cors` never called
  `WithExposedHeaders`, so a browser hid the tag from JS on every cross-origin call — which is
  every dev run, since both React apps point `apiBase` at the API's own origin. The client then
  read `null`, stopped sending `If-Match`, and the endpoint degraded straight back to the lost
  update it now prevents. One `WithExposedHeaders` call (plus a four-line comment), placed after the
  branch so it covers both policies — neither `AllowAnyHeader` nor `WithHeaders` implies exposure.
- **`if-match` is not a safelisted request header either.** It joins `AllowedHeaders` in both
  shipped `appsettings`, otherwise `AllowAll: false` strips the precondition before the endpoint
  sees it.

I know `src/BuildingBlocks` is protected, so this is deliberately the smallest possible change and
kept in its own commit (`feat(cors): expose ETag and allow If-Match…`) — easy to drop or rework
without touching the rest. Happy to split it into its own PR if you'd rather review it separately.

Both directions are gated rather than described in a comment: `CorsPolicyTests` asserts the exposure
at the policy level for both branches, and
`GetProfile_Should_ExposeETagToCrossOriginCallers_When_ProfileIsRead` asserts it end to end against
a cross-origin request. The front-end specs mock the header, so without a server-side gate nothing
would notice the policy dropping it. Verified by mutation: removing the argument turns all three
red.

Separately and **not fixed here**: the `tenant` header both front-ends send on every request is
also missing from `AllowedHeaders`, so anyone enabling the restricted policy today is already
broken. Filed as #1367 rather than folded into this one.

## Also in this PR

`Directory.Packages.props` pins `SSH.NET` to `2026.0.0` (cherry-picked byte-identical from #1333):
`NU1903` breaks `restore` on `main` too, so nothing builds without it. Drop that commit once #1333
merges.

## Verification

- Integration suite (Testcontainers): 756 passed / 1 skipped (pre-existing) / 0 failed
- All 13 other test projects green, aggregate exit `0` (~1057 tests)
- `clients/dashboard` Playwright: 152 passed; `tsc -b` clean and `eslint .` exit `0` (12 pre-existing
  `react-refresh` warnings, none in touched files)
- Mutation-checked at three points: reverting the precondition guard to a no-op turns 4 tests red;
  moving it below the storage calls turns the avatar test red; dropping the CORS exposure turns
  the three new CORS gates red.

Docs + changelog in `fullstackhero/docs` follow in a companion PR.
