### PR TITLE
fix(deps): bump Testcontainers to 4.14.0 to clear the SSH.NET advisory

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -122,9 +122,10 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Minio" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Minio" Version="4.14.0" />
+
   </ItemGroup>
   <ItemGroup Label="AWS">
     <PackageVersion Include="AWSSDK.S3" Version="4.0.23.4" />


### PR DESCRIPTION
## Problem

`dotnet restore` fails for `Integration.Tests` and `Integration.Middleware.Tests`:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high
severity vulnerability, https://github.com/advisories/GHSA-q939-rpr3-3284
```

`SSH.NET` is not a direct dependency, which is why it does not appear in `Directory.Packages.props`. It arrives transitively:

```
Testcontainers.PostgreSql / .Redis / .Minio (4.11.0)
  └── Testcontainers (4.11.0)
        └── SSH.NET (2025.1.0)
```

GHSA-q939-rpr3-3284 (high) — *ScpClient recursive download allows arbitrary file write via server-controlled SCP filenames*. Affects `<= 2025.1.0`; first patched in `2026.0.0`.

## Fix

Bump the three `Testcontainers.*` packages `4.11.0` → `4.14.0`. Testcontainers 4.14.0 already depends on the patched `SSH.NET` 2026.0.0, so the advisory clears without adding a transitive pin under the "Transitive security pins" group — one less pin to remember to remove later.

## Verification

- `dotnet restore src/FSH.Starter.slnx` — succeeds, all 51 projects, no NU1903.
- `dotnet build` on both integration test projects — 0 warnings / 0 errors under `TreatWarningsAsErrors`.
- Integration tests themselves were **not** run locally (they need Docker). Worth a CI eye, since this crosses three minor Testcontainers releases (4.11 → 4.14).

## Notes

- Test-only dependency change: no runtime, endpoint, or config surface moves, so no docs-repo or changelog entry (golden rule 10 does not apply here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
